### PR TITLE
Fixed missing definitions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ foreach(kind ${kinds})
   set_target_properties(${lib_name}_c PROPERTIES
     COMPILE_OPTIONS "${shared_flags};${c_${kind}_flags}")
   set_target_properties(${lib_name}_c PROPERTIES
-    COMPILE_DEFINITIONS "${c_${kind}_definitions};${allocation_def}")
+    COMPILE_DEFINITIONS "${definitions};${c_${kind}_definitions};${allocation_def}")
 
   set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")


### PR DESCRIPTION
While I was working on updating the GSI to use the public release version of NCEPLIBS, I found that the definitions set at the top of the CMakeLists.txt file are not added during compile. Apparently, this doesn't affect the UFS, but without the underscore (from -DUNDERSCORE), there are undefined symbols in libbufr_*.