### PR TITLE
DA closbuf fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,128 +1,25 @@
 cmake_minimum_required(VERSION 3.15)
-project(bufr VERSION 11.3.0)
-set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION} CACHE INTERNAL "${PROJECT_NAME} version number")
-enable_language (Fortran)
 
-if (NOT CMAKE_BUILD_TYPE)
-  set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
-    "Choose the type of build, options are: PRODUCTION Debug Release."
-    FORCE)
+file(STRINGS "VERSION" pVersion)
+
+project(
+    bufr
+    VERSION ${pVersion}
+    LANGUAGES C Fortran)
+
+if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
+  message(STATUS "Setting build type to 'Release' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "Release"
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
 endif()
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
-  set(IntelComp true )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang*")
-  set(GNUComp true )
-elseif(CMAKE_CXX_COMPILER_ID MATCHES "pgc*")
-  set(PGIComp true )
+if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU|Clang|AppleClang)$")
+  message(WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID}")
 endif()
 
-STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "RelWithDebInfo" BUILD_RELEASE)
-STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "RELEASE" BUILD_RELEASE)
-STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "PRODUCTION" BUILD_PRODUCTION)
-STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "DEBUG" BUILD_DEBUG)
+include(GNUInstallDirs)
 
-option(GSIBUILD "Build only libs for GSI" ON)
-
-set(definitions "UNDERSCORE" "NFILES=32" "MAXCD=250" "MAXNC=600" "MXNAF=3")
-
-if( (BUILD_RELEASE) OR (BUILD_PRODUCTION) )
-  if(IntelComp)
-    #shared with C and Fortran
-    set(shared_flags "-g" "-traceback" "-O3" "-axCORE-AVX2")
-
-    set(c_DA_allocation_def "DYNAMIC_ALLOCATION")
-    set(c_4_DA_flags)    
-    set(c_8_DA_definitions "F77_INTSIZE_8")
-    set(c_d_DA_flags)
-    
-    set(fortran_4_DA_flags)
-    set(fortran_8_DA_flags "-r8" "-i8")
-    set(fortran_d_DA_flags "-r8")
-    
-    set(c_nonDA_allocation_def "STATIC_ALLOCATION")
-    set(c_4_flags)
-    set(c_8_flags)
-    set(c_8_definitions "F77_INTSIZE_8")
-    set(c_d_flags)
-    set(c_SS_flags "-mcmodel=medium" "-shared")
-
-    set(fortran_4_flags)
-    set(fortran_8_flags "-r8" "-i8")
-    set(fortran_d_flags "-r8")
-    set(fortran_SS_flags "-mcmodel=medium" "-shared")
-
-  elseif(GNUComp)
-    set(allocation_def "DYNAMIC_ALLOCATION")
-    set(shared_flags "-O3" "-ggdb" "-Wall")
-
-    set(c_d_flags)
-    set(c_4_flags)
-    set(c_8_flags)
-
-    set(shared_fortran_flags "-funroll-loops")
-    set(fortran_4_flags)
-    set(fortran_d_flags "-fdefault-real-8")
-    set(fortran_8_flags "-fdefault-integer-8" "-fdefault-real-8")
-  else()
-    message("unknown compiler!")
-    exit()
-  endif()
-endif()
-
-
-file(GLOB fortran_src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.f ${CMAKE_CURRENT_SOURCE_DIR}/src/*.F)
-file(GLOB c_src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
-
-if(GSIBUILD)
-  set(kinds "4" "d" "8")
-else()
-  set(kinds "4" "d" "8" "SS" "4_DA" "8_DA" "d_DA")
-endif()
-
-foreach(kind ${kinds})
-  set(lib_name ${PROJECT_NAME}_${kind})
-  set(versioned_lib_name ${PROJECT_NAME}_v${PROJECT_VERSION}_${kind})
-  add_library(${lib_name} STATIC ${fortran_src} ${c_src})
-  set_target_properties(${lib_name} PROPERTIES OUTPUT_NAME "${versioned_lib_name}")
-
-  # different compiler definitions for Intel in DA vs non-DA
-  # -DDYNAMIC_ALLOCATION when compiled with DA and -DSTATIC_ALLOCATION
-  # check current kind and if it has 'DA' in it then set compiler def
- 
-  if(IntelComp)
-    string(FIND ${kind} "DA" isDA)
-    if(isDA GREATER_EQUAL 0)
-      set(allocation_def ${c_DA_allocation_def})
-    else()
-      set(allocation_def ${c_nonDA_allocation_def})
-    endif()
-  endif()
-
-  target_compile_definitions(${lib_name} PRIVATE "${allocation_def}")
-  
-  set_source_files_properties(${c_src} PROPERTIES
-    COMPILE_OPTIONS "${shared_flags};${c_${kind}_flags}")
-  set_source_files_properties(${c_src} PROPERTIES
-    COMPILE_DEFINITIONS "${c_definitions};${c_${kind}_definitions}")
-  
-  set_source_files_properties(${fortran_src} PROPERTIES
-    COMPILE_OPTIONS "${shared_flags};${shared_fortran_flags};${fortran_${kind}_flags}")
-  
-  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
-  set_target_properties(${lib_name} PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
-  
-  target_include_directories(${lib_name} PUBLIC
-    $<BUILD_INTERFACE:${module_dir}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include_${kind}}>)
-
-  install(TARGETS ${lib_name}
-    EXPORT ${PROJECT_NAME}-config
-    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
-    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib) 
-  install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
-endforeach()
-
-install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_PREFIX})
-
+add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.10)
 
 file(STRINGS "VERSION" pVersion)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,128 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.15)
+project(bufr VERSION 11.3.0)
+set(${PROJECT_NAME}_VERSION ${PROJECT_VERSION} CACHE INTERNAL "${PROJECT_NAME} version number")
+enable_language (Fortran)
 
-file(STRINGS "VERSION" pVersion)
-
-project(
-    bufr
-    VERSION ${pVersion}
-    LANGUAGES C Fortran)
-
-if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
-  message(STATUS "Setting build type to 'Release' as none was specified.")
-  set(CMAKE_BUILD_TYPE
-      "Release"
-      CACHE STRING "Choose the type of build." FORCE)
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-                                               "MinSizeRel" "RelWithDebInfo")
+if (NOT CMAKE_BUILD_TYPE)
+  set (CMAKE_BUILD_TYPE RELEASE CACHE STRING
+    "Choose the type of build, options are: PRODUCTION Debug Release."
+    FORCE)
 endif()
 
-if(NOT CMAKE_C_COMPILER_ID MATCHES "^(Intel|GNU|Clang|AppleClang)$")
-  message(WARNING "Compiler not officially supported: ${CMAKE_C_COMPILER_ID}")
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+  set(IntelComp true )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "GNU*" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang*")
+  set(GNUComp true )
+elseif(CMAKE_CXX_COMPILER_ID MATCHES "pgc*")
+  set(PGIComp true )
 endif()
 
-include(GNUInstallDirs)
+STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "RelWithDebInfo" BUILD_RELEASE)
+STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "RELEASE" BUILD_RELEASE)
+STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "PRODUCTION" BUILD_PRODUCTION)
+STRING(COMPARE EQUAL ${CMAKE_BUILD_TYPE} "DEBUG" BUILD_DEBUG)
 
-add_subdirectory(src)
+option(GSIBUILD "Build only libs for GSI" ON)
+
+set(definitions "UNDERSCORE" "NFILES=32" "MAXCD=250" "MAXNC=600" "MXNAF=3")
+
+if( (BUILD_RELEASE) OR (BUILD_PRODUCTION) )
+  if(IntelComp)
+    #shared with C and Fortran
+    set(shared_flags "-g" "-traceback" "-O3" "-axCORE-AVX2")
+
+    set(c_DA_allocation_def "DYNAMIC_ALLOCATION")
+    set(c_4_DA_flags)    
+    set(c_8_DA_definitions "F77_INTSIZE_8")
+    set(c_d_DA_flags)
+    
+    set(fortran_4_DA_flags)
+    set(fortran_8_DA_flags "-r8" "-i8")
+    set(fortran_d_DA_flags "-r8")
+    
+    set(c_nonDA_allocation_def "STATIC_ALLOCATION")
+    set(c_4_flags)
+    set(c_8_flags)
+    set(c_8_definitions "F77_INTSIZE_8")
+    set(c_d_flags)
+    set(c_SS_flags "-mcmodel=medium" "-shared")
+
+    set(fortran_4_flags)
+    set(fortran_8_flags "-r8" "-i8")
+    set(fortran_d_flags "-r8")
+    set(fortran_SS_flags "-mcmodel=medium" "-shared")
+
+  elseif(GNUComp)
+    set(allocation_def "DYNAMIC_ALLOCATION")
+    set(shared_flags "-O3" "-ggdb" "-Wall")
+
+    set(c_d_flags)
+    set(c_4_flags)
+    set(c_8_flags)
+
+    set(shared_fortran_flags "-funroll-loops")
+    set(fortran_4_flags)
+    set(fortran_d_flags "-fdefault-real-8")
+    set(fortran_8_flags "-fdefault-integer-8" "-fdefault-real-8")
+  else()
+    message("unknown compiler!")
+    exit()
+  endif()
+endif()
+
+
+file(GLOB fortran_src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.f ${CMAKE_CURRENT_SOURCE_DIR}/src/*.F)
+file(GLOB c_src ${CMAKE_CURRENT_SOURCE_DIR}/src/*.c)
+
+if(GSIBUILD)
+  set(kinds "4" "d" "8")
+else()
+  set(kinds "4" "d" "8" "SS" "4_DA" "8_DA" "d_DA")
+endif()
+
+foreach(kind ${kinds})
+  set(lib_name ${PROJECT_NAME}_${kind})
+  set(versioned_lib_name ${PROJECT_NAME}_v${PROJECT_VERSION}_${kind})
+  add_library(${lib_name} STATIC ${fortran_src} ${c_src})
+  set_target_properties(${lib_name} PROPERTIES OUTPUT_NAME "${versioned_lib_name}")
+
+  # different compiler definitions for Intel in DA vs non-DA
+  # -DDYNAMIC_ALLOCATION when compiled with DA and -DSTATIC_ALLOCATION
+  # check current kind and if it has 'DA' in it then set compiler def
+ 
+  if(IntelComp)
+    string(FIND ${kind} "DA" isDA)
+    if(isDA GREATER_EQUAL 0)
+      set(allocation_def ${c_DA_allocation_def})
+    else()
+      set(allocation_def ${c_nonDA_allocation_def})
+    endif()
+  endif()
+
+  target_compile_definitions(${lib_name} PRIVATE "${allocation_def}")
+  
+  set_source_files_properties(${c_src} PROPERTIES
+    COMPILE_OPTIONS "${shared_flags};${c_${kind}_flags}")
+  set_source_files_properties(${c_src} PROPERTIES
+    COMPILE_DEFINITIONS "${c_definitions};${c_${kind}_definitions}")
+  
+  set_source_files_properties(${fortran_src} PROPERTIES
+    COMPILE_OPTIONS "${shared_flags};${shared_fortran_flags};${fortran_${kind}_flags}")
+  
+  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
+  set_target_properties(${lib_name} PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
+  
+  target_include_directories(${lib_name} PUBLIC
+    $<BUILD_INTERFACE:${module_dir}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include_${kind}}>)
+
+  install(TARGETS ${lib_name}
+    EXPORT ${PROJECT_NAME}-config
+    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib) 
+  install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
+endforeach()
+
+install(EXPORT ${PROJECT_NAME}-config DESTINATION ${CMAKE_INSTALL_PREFIX})
+

--- a/src/closbf.F
+++ b/src/closbf.F
@@ -54,13 +54,14 @@ C$$$
       USE MODA_NULBFR
 
       INCLUDE 'bufrlib.prm'
+      CHARACTER*128 ERRSTR
 
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
 #ifdef DYNAMIC_ALLOCATION   
       IF ( .NOT. ALLOCATED(NULL) ) THEN
         CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
-        ERRSTR = 'BUFRLIB: CLOSBF WAS CALLED BEFORE CALLING OPENBF' 
+        ERRSTR = 'BUFRLIB: CLOSBF CALLED BEFORE OPENBF'
         CALL ERRWRT(ERRSTR)
         CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
         RETURN

--- a/src/closbf.F
+++ b/src/closbf.F
@@ -58,10 +58,13 @@ C$$$
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
 #ifdef DYNAMIC_ALLOCATION   
-      if(.not. allocated(NULL) ) then
-        write(6,*) 'WARNING calling closbf without having called openbf'
-        return
-      endif
+      IF ( .NOT. ALLOCATED(NULL) ) THEN
+        CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
+        ERRSTR = 'BUFRLIB: CLOSBF WAS CALLED BEFORE CALLING OPENBF' 
+        CALL ERRWRT(ERRSTR)
+        CALL ERRWRT('++++++++++++++++++++WARNING++++++++++++++++++++++')
+        RETURN
+      ENDIF
 #endif
       CALL STATUS(LUNIT,LUN,IL,IM)
       IF(IL.GT.0 .AND. IM.NE.0) CALL CLOSMG(LUNIT)

--- a/src/closbf.F
+++ b/src/closbf.F
@@ -57,7 +57,12 @@ C$$$
 
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
-
+#ifdef DYNAMIC_ALLOCATION   
+      if(.not. allocated(NULL) ) then
+        write(6,*) 'WARNING calling closbf without having called openbf'
+        return
+      endif
+#endif
       CALL STATUS(LUNIT,LUN,IL,IM)
       IF(IL.GT.0 .AND. IM.NE.0) CALL CLOSMG(LUNIT)
       IF(IL.NE.0 .AND. NULL(LUN).EQ.0) CALL CLOSFB(LUN)

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -72,7 +72,6 @@ set(fortran_src
   chrtrn.f
   chrtrna.f
   cktaba.f
-  closbf.F
   closmg.f
   cmpmsg.f
   cmsgini.f
@@ -298,6 +297,7 @@ set(fortran_src
   wtstat.f
   arallocf.F
   ardllocf.F
+  closbf.F
   ireadmt.F
   irev.F
   isetprm.F

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -72,7 +72,7 @@ set(fortran_src
   chrtrn.f
   chrtrna.f
   cktaba.f
-  closbf.f
+  closbf.F
   closmg.f
   cmpmsg.f
   cmsgini.f


### PR DESCRIPTION
The added guard tests to see if arrays have been allocated (which is done during openbf) before continuing with closbf. It is only used in the DYNAMIC_ALLOCATION builds. Addresses https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/9