### PR TITLE
automatically configure C bufrlib.h based on parameters defined in Fortran

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,15 +8,28 @@ set(c_8_DA_defs ${c_8_defs})
 # Create the bvers.f file with the version from VERSION file.
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bvers.f.in ${CMAKE_CURRENT_BINARY_DIR}/bvers.f @ONLY)
 
-# Extract BUFRLIB parameters
-file(READ bufrlib.inc _bufrlib_prm_str)
+# Extract BUFRLIB parameters from Fortran source files and propogate them into bufrlib.h for C
+file(READ bufrlib.inc _bufrlib_inc_str)
 foreach(_var IN ITEMS MAXNC MXNAF)
-    if(_bufrlib_prm_str MATCHES "${_var} = ([0-9]+)")
-      list(APPEND c_defs ${_var}=${CMAKE_MATCH_1})
-    else()
-      message(FATAL_ERROR "Unable to parse variable ${_var} value from file: src/bufrlib.inc")
-    endif()
+  if(_bufrlib_inc_str MATCHES "${_var} = ([0-9]+)")
+    set(${_var} ${CMAKE_MATCH_1})
+  else()
+    message(FATAL_ERROR "Unable to parse variable ${_var} value from file: src/bufrlib.inc")
+  endif()
 endforeach()
+set(VAR_REGEX_DYNAMIC "INTEGER ::")
+set(VAR_REGEX_STATIC "PARAMETER ")
+foreach(_var IN ITEMS NFILES MAXCD)
+  foreach(_alloc IN ITEMS DYNAMIC STATIC)
+    file(STRINGS modv_${_var}.F _${_var}_tempstr REGEX ${VAR_REGEX_${_alloc}})
+    if(_${_var}_tempstr MATCHES "${_var} = ([0-9]+)")
+      set(${_var}_${_alloc} ${CMAKE_MATCH_1})
+    else()
+      message(FATAL_ERROR "Unable to parse variable ${_var}_${_alloc} value from file: modv_${_var}.F")
+    endif()
+  endforeach()
+endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bufrlib.h.in ${CMAKE_CURRENT_BINARY_DIR}/bufrlib.h @ONLY)
 
 list(APPEND underscore_def UNDERSCORE)
 
@@ -54,9 +67,9 @@ foreach(kind ${kinds})
   target_compile_definitions(${lib_name}_c PUBLIC "${allocation_def}")
   target_compile_definitions(${lib_name}_c PUBLIC "${underscore_def}")
   target_compile_definitions(${lib_name}_c PRIVATE "${endian_def}")
-  target_compile_definitions(${lib_name}_c PRIVATE "${c_defs}")
   target_compile_definitions(${lib_name}_c PRIVATE "${c_${kind}_defs}")
   target_include_directories(${lib_name}_c PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+  target_include_directories(${lib_name}_c PRIVATE ${CMAKE_CURRENT_BINARY_DIR})  # for bufrlib.h
 
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
 

--- a/src/bufrlib.h.in
+++ b/src/bufrlib.h.in
@@ -4,32 +4,16 @@
 #include <string.h>
 #include <ctype.h>
 
-/*
-** The following value must be identically defined in Fortran source
-** file modv_NFILES.F
-*/
 #ifdef DYNAMIC_ALLOCATION
-#    define NFILES 32
+#    define NFILES @NFILES_DYNAMIC@ 
+#    define MAXCD @MAXCD_DYNAMIC@
 #else
-#    define NFILES 32
+#    define NFILES @NFILES_STATIC@
+#    define MAXCD @MAXCD_STATIC@
 #endif
 
-/*
-** The following value must be identically defined in Fortran source
-** file modv_MAXCD.F
-*/
-#ifdef DYNAMIC_ALLOCATION
-#    define MAXCD 250
-#else
-#    define MAXCD 250
-#endif
-
-/*
-** The following values must be identically defined in source file
-** bufrlib.prm
-*/
-#define MAXNC 600
-#define MXNAF 3
+#define MAXNC @MAXNC@
+#define MXNAF @MXNAF@
 
 /*
 ** On certain operating systems, the FORTRAN compiler appends an underscore

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -332,7 +332,7 @@ set(c_src
   wrdesc.c)
 
 set(c_hdr
-  bufrlib.h
+  ${CMAKE_CURRENT_BINARY_DIR}/bufrlib.h
   cfe.h
   cobfl.h
   cread.h

--- a/src/modv_MAXCD.F
+++ b/src/modv_MAXCD.F
@@ -4,9 +4,6 @@ C	  MAXCD is the maximum number of child descriptors that can
 C	  be included within the sequence definition of a Table D
 C	  descriptor.
 
-C	  This value must be identically defined in the C header
-C	  file bufrlib.h
-
 C	  Note that this value does *not* need to take into account
 C	  the recursive resolution of any child descriptors which may
 C	  themselves be Table D descriptors.

--- a/src/modv_NFILES.F
+++ b/src/modv_NFILES.F
@@ -4,9 +4,6 @@ C	  NFILES is the maximum number of BUFR files that can be
 C	  connected to the BUFRLIB software (for reading or writing)
 C	  at any one time.
 
-C	  This value must be identically defined in the C header
-C	  file bufrlib.h
-
 #ifdef DYNAMIC_ALLOCATION
 
 C	  Set a default value for NFILES.  This value will be used


### PR DESCRIPTION
Fixes #22 