### PR TITLE
automatically configure bufrlib.inc based on parameters defined in C

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,18 +5,22 @@ endif()
 
 set(c_8_DA_defs ${c_8_defs})
 
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
 # Create the bvers.f file with the version from VERSION file.
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bvers.f.in ${CMAKE_CURRENT_BINARY_DIR}/bvers.f @ONLY)
 
-# Extract BUFRLIB parameters from Fortran source files and propogate them into bufrlib.h for C
-file(READ bufrlib.inc _bufrlib_inc_str)
+# Create the bufrlib.h and bufrlib.inc files
+file(READ bufrlib.h.in _bufrlib_h_in_str)
 foreach(_var IN ITEMS MAXNC MXNAF)
-  if(_bufrlib_inc_str MATCHES "${_var} = ([0-9]+)")
+  if(_bufrlib_h_in_str MATCHES "#define ${_var} ([0-9]+)")
     set(${_var} ${CMAKE_MATCH_1})
   else()
-    message(FATAL_ERROR "Unable to parse variable ${_var} value from file: src/bufrlib.inc")
+    message(FATAL_ERROR "Unable to parse variable ${_var} value from file: src/bufrlib.h.in")
   endif()
 endforeach()
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/bufrlib.inc.in ${CMAKE_CURRENT_BINARY_DIR}/bufrlib.inc @ONLY)
+
 set(VAR_REGEX_DYNAMIC "INTEGER ::")
 set(VAR_REGEX_STATIC "PARAMETER ")
 foreach(_var IN ITEMS NFILES MAXCD)
@@ -68,8 +72,6 @@ foreach(kind ${kinds})
   target_compile_definitions(${lib_name}_c PUBLIC "${underscore_def}")
   target_compile_definitions(${lib_name}_c PRIVATE "${endian_def}")
   target_compile_definitions(${lib_name}_c PRIVATE "${c_${kind}_defs}")
-  target_include_directories(${lib_name}_c PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-  target_include_directories(${lib_name}_c PRIVATE ${CMAKE_CURRENT_BINARY_DIR})  # for bufrlib.h
 
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
 
@@ -90,6 +92,7 @@ foreach(kind ${kinds})
   list(APPEND LIB_TARGETS ${lib_name})
   install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
   install(FILES ${c_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind})
+  install(FILES ${f_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind})
 endforeach()
 
 install(

--- a/src/bufrlib.h.in
+++ b/src/bufrlib.h.in
@@ -12,8 +12,8 @@
 #    define MAXCD @MAXCD_STATIC@
 #endif
 
-#define MAXNC @MAXNC@
-#define MXNAF @MXNAF@
+#define MAXNC 600
+#define MXNAF 3
 
 /*
 ** On certain operating systems, the FORTRAN compiler appends an underscore

--- a/src/bufrlib.inc.in
+++ b/src/bufrlib.inc.in
@@ -2,7 +2,7 @@ C-----------------------------------------------------------------------
 C	Maximum number of Section 3 FXY descriptors that can be
 C	written into a BUFR message by the BUFRLIB software.
 
-	PARAMETER ( MAXNC = 600 )
+	PARAMETER ( MAXNC = @MAXNC@ )
 C-----------------------------------------------------------------------
 C	Maximum number of entries in the internal string cache.
 
@@ -15,7 +15,7 @@ C-----------------------------------------------------------------------
 C	Maximum number of 2-04 associated fields that can be in effect
 C	at the same time for any given Table B descriptor.
 
-	PARAMETER ( MXNAF = 3 )
+	PARAMETER ( MXNAF = @MXNAF@ )
 C-----------------------------------------------------------------------
 C	BUFRLIB "missing" value.  The default value for BMISS is set
 C	within subroutine BFRINI, but it can be modified by the user via

--- a/src/list_of_files.cmake
+++ b/src/list_of_files.cmake
@@ -306,6 +306,9 @@ set(fortran_src
   wrdlen.F
   bufr.interface.f90)
 
+set(f_hdr
+  ${CMAKE_CURRENT_BINARY_DIR}/bufrlib.inc)
+
 set(c_src
   arallocc.c
   ardllocc.c


### PR DESCRIPTION
Fixes #44 

Part of #43 - adds bufrlib.inc into new f_hdr definition in src/list_of_files.cmake