### PR TITLE
Enable shared libraries and fix installation of non-standard prefix directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ include(GNUInstallDirs)
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+option(BUILD_SHARED_LIBS "Enable building shared libraries" OFF)
+
 # Determine the kinds upfront (both src/ and test/ need them).
 # Both GNU and Intel support DYNAMIC_ALLOCATION
 list(APPEND kinds "4_DA" "8_DA" "d_DA")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -49,7 +49,7 @@ include("list_of_files.cmake")
 
 foreach(kind ${kinds})
   set(lib_name ${PROJECT_NAME}_${kind})
-  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include_${kind}")
+  set(module_dir "${CMAKE_CURRENT_BINARY_DIR}/include/bufr_${kind}")
 
   # determine ALLOCATION based on kind
   if(${kind} MATCHES "^([4|8|d]_DA)$")
@@ -58,14 +58,14 @@ foreach(kind ${kinds})
     set(allocation_def "STATIC_ALLOCATION")
   endif()
 
-  add_library(${lib_name}_f STATIC OBJECT ${fortran_src})
+  add_library(${lib_name}_f OBJECT ${fortran_src})
   set_target_properties(${lib_name}_f PROPERTIES COMPILE_FLAGS
                                                  "${fortran_${kind}_flags}")
   target_compile_definitions(${lib_name}_f PUBLIC "${allocation_def}")
   target_compile_definitions(${lib_name}_f PUBLIC "${underscore_def}")
   target_compile_definitions(${lib_name}_f PRIVATE "${endian_def}")
 
-  add_library(${lib_name}_c STATIC OBJECT ${c_src})
+  add_library(${lib_name}_c OBJECT ${c_src})
   set_target_properties(${lib_name}_c PROPERTIES COMPILE_FLAGS
                                                  "${c_${kind}_flags}")
   target_compile_definitions(${lib_name}_c PUBLIC "${allocation_def}")
@@ -75,8 +75,8 @@ foreach(kind ${kinds})
 
   set_target_properties(${lib_name}_f PROPERTIES Fortran_MODULE_DIRECTORY "${module_dir}")
 
-  add_library(${lib_name} STATIC $<TARGET_OBJECTS:${lib_name}_f>
-                                 $<TARGET_OBJECTS:${lib_name}_c>)
+  add_library(${lib_name} $<TARGET_OBJECTS:${lib_name}_f>
+                          $<TARGET_OBJECTS:${lib_name}_c>)
   add_library(${PROJECT_NAME}::${lib_name} ALIAS ${lib_name})
 
   target_include_directories(${lib_name} PUBLIC
@@ -84,23 +84,23 @@ foreach(kind ${kinds})
 
   target_include_directories(${lib_name} INTERFACE
     $<BUILD_INTERFACE:${module_dir}>
-    $<INSTALL_INTERFACE:include_${kind}>)
+    $<INSTALL_INTERFACE:include/bufr_${kind}>)
 
   target_compile_definitions(${lib_name} PUBLIC "${underscore_def}")
   target_compile_definitions(${lib_name} PUBLIC "${allocation_def}")
 
   list(APPEND LIB_TARGETS ${lib_name})
-  install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX})
-  install(FILES ${c_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind})
-  install(FILES ${f_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include_${kind})
+  install(DIRECTORY ${module_dir} DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
+  install(FILES ${c_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/bufr_${kind})
+  install(FILES ${f_hdr} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/bufr_${kind})
 endforeach()
 
 install(
   TARGETS ${LIB_TARGETS}
   EXPORT ${PROJECT_NAME}Exports
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
 ### Package config
 include(CMakePackageConfigHelpers)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -104,7 +104,7 @@ install(
 
 ### Package config
 include(CMakePackageConfigHelpers)
-set(CONFIG_INSTALL_DESTINATION lib/cmake/${PROJECT_NAME})
+set(CONFIG_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
 export(EXPORT ${PROJECT_NAME}Exports
   NAMESPACE ${PROJECT_NAME}::


### PR DESCRIPTION
Some small changes to the CMake which will improve portability of this library.  The changes should be transparent for downstream dependencies already using the exported CMake targets.

* Allow building either shared or static libraries.  
  * Static libraries are still built by default
  * Shared libraries can be built instead by setting the standard CMake `BUILD_SHARED_LIBS` option to 1.
    * See: [Cmake: BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)
* Conform installation to standard GNU prefix directory structure
  * Installation should respect the platform default installation directories as provided by [`GNUInstallDirs`](https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html)
  * Writing to directories outside of the standard locations is not portable.
  * Move the `include_${kind}` directories to `include/bufr_${kind}`.  This solves the problem of non-standard `include` directories in the prefix.
  * Use `CMAKE_INSTALL_LIBDIR` instead of `lib` as some platforms only have a `lib64` directory.