### PR TITLE
Pass `-c` flag to ranlib on macOS so that common symbols are included

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,12 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 option(BUILD_SHARED_LIBS "Enable building shared libraries" OFF)
 
+if(APPLE)
+  # The linker on macOS does not include `common symbols` by default
+  # Passing the -c flag includes them and fixes an error with undefined symbols
+  set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")
+endif()
+
 # Determine the kinds upfront (both src/ and test/ need them).
 # Both GNU and Intel support DYNAMIC_ALLOCATION
 list(APPEND kinds "4_DA" "8_DA" "d_DA")


### PR DESCRIPTION
macOS doesn't include common symbols by default when linking which causes a problem with undefined symbols

Fixes #68 