### PR TITLE
activate testing of static memory builds for all 4-byte builds on all platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,12 +43,8 @@ if(APPLE)
 endif()
 
 # Determine the kinds upfront (both src/ and test/ need them).
-# Both GNU and Intel support DYNAMIC_ALLOCATION
 list(APPEND kinds "4_DA" "8_DA" "d_DA")
-# Only Intel supports STATIC_ALLOCATION
-if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
-  list(APPEND kinds "4" "8" "d")
-endif()
+list(APPEND kinds "4" "8" "d")
 
 # Set common to the package compiler flags
 if(CMAKE_C_COMPILER_ID MATCHES "^(GNU)$")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -104,12 +104,10 @@ function(bufr_add_test_preAPX TESTNAME EXENAME)
            COMMAND ${CMAKE_BINARY_DIR}/bin/test_wrapper.sh ${EXENAME} "Y")
 endfunction()
 
-# Both GNU and Intel support DYNAMIC_ALLOCATION
+# test all "4" (4 byte real, 4 byte int) DYNAMIC_ALLOCATION builds
 list(APPEND test_kinds "4_DA")
-# Only Intel supports STATIC_ALLOCATION
-if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
-  list(APPEND test_kinds "4")
-endif()
+# test all "4" (4 byte real, 4 byte int) STATIC_ALLOCATION builds, except OUT_3 and OUT_4 as noted below
+list(APPEND test_kinds "4")
 
 # IN tests
 foreach(test_src ${test_IN_srcs})


### PR DESCRIPTION
Part of #77 

@edwardhartnett, @aerorahul, @kgerheiser 

As discussed, for now I wanted to re-activate testing for the static memory builds.  I pushed up this branch to test it on gcc-9 and gcc-10, and I was actually expecting the build to fail for gcc-10 b/c it doesn't yet include the src changes from my jba_mstabs branch.  Basically, I wanted to verify that I could reproduce the compile error that Matthew Thompson reported in #81, and then I was going to merge this branch into jba_mstabs and test it together with the src changes in that branch.

So again, I was expecting this particular push to fail, but not in the way that it actually did.  Specifically, it looks like it didn't fail because of the error noted in #81, but rather because it never created test executables for the static memory builds, and therefore it couldn't find those targets in the "build" step.  See https://github.com/NOAA-EMC/NCEPLIBS-bufr/actions/runs/481158783  I'm not sure why this happened or how to fix it (I'm still a bit of a CMake newbie ;-), so I would appreciate any suggestions on how to fix this.

Thanks very much for any help you can provide here.  I seem to recall a discussion in an earlier issue about problems trying to generate static memory builds with non-Intel compilers, so not sure if this is related to that or if that was ever even resolved(?)