### PR TITLE
use tables directory for testing, rather than legacy master tables from bufr.tar archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,8 @@ if(ENABLE_PYTHON)
   add_subdirectory(python)
 endif()
 
+add_subdirectory(tables)
+
 add_subdirectory(test)
 
 # Generate doxygen documentation if desired.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,13 +102,6 @@ install(
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-# Copy the tables directory to the install area if the library builds are successful
-add_custom_command(
-  TARGET ${LIB_TARGETS}
-  POST_BUILD
-  COMMENT "Copying tables directory to install area"
-  COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/tables ${CMAKE_INSTALL_PREFIX}/tables)
-
 # Package config
 include(CMakePackageConfigHelpers)
 set(CONFIG_INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})

--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -1,0 +1,85 @@
+list(APPEND bufr_tables
+  bufrtab.CodeFlag_LOC_0_7_1
+  bufrtab.CodeFlag_STD_0_13
+  bufrtab.CodeFlag_STD_0_14
+  bufrtab.CodeFlag_STD_0_15
+  bufrtab.CodeFlag_STD_0_16
+  bufrtab.CodeFlag_STD_0_17
+  bufrtab.CodeFlag_STD_0_18
+  bufrtab.CodeFlag_STD_0_19
+  bufrtab.CodeFlag_STD_0_20
+  bufrtab.CodeFlag_STD_0_21
+  bufrtab.CodeFlag_STD_0_22
+  bufrtab.CodeFlag_STD_0_23
+  bufrtab.CodeFlag_STD_0_24
+  bufrtab.CodeFlag_STD_0_25
+  bufrtab.CodeFlag_STD_0_26
+  bufrtab.CodeFlag_STD_0_27
+  bufrtab.CodeFlag_STD_0_28
+  bufrtab.CodeFlag_STD_0_29
+  bufrtab.CodeFlag_STD_0_30
+  bufrtab.CodeFlag_STD_0_31
+  bufrtab.CodeFlag_STD_0_32
+  bufrtab.CodeFlag_STD_0_33
+  bufrtab.CodeFlag_STD_0_34
+  bufrtab.CodeFlag_STD_0_35
+  bufrtab.TableB_LOC_0_7_1
+  bufrtab.TableB_STD_0_13
+  bufrtab.TableB_STD_0_14
+  bufrtab.TableB_STD_0_15
+  bufrtab.TableB_STD_0_16
+  bufrtab.TableB_STD_0_17
+  bufrtab.TableB_STD_0_18
+  bufrtab.TableB_STD_0_19
+  bufrtab.TableB_STD_0_20
+  bufrtab.TableB_STD_0_21
+  bufrtab.TableB_STD_0_22
+  bufrtab.TableB_STD_0_23
+  bufrtab.TableB_STD_0_24
+  bufrtab.TableB_STD_0_25
+  bufrtab.TableB_STD_0_26
+  bufrtab.TableB_STD_0_27
+  bufrtab.TableB_STD_0_28
+  bufrtab.TableB_STD_0_29
+  bufrtab.TableB_STD_0_30
+  bufrtab.TableB_STD_0_31
+  bufrtab.TableB_STD_0_32
+  bufrtab.TableB_STD_0_33
+  bufrtab.TableB_STD_0_34
+  bufrtab.TableB_STD_0_35
+  bufrtab.TableD_LOC_0_7_1
+  bufrtab.TableD_STD_0_13
+  bufrtab.TableD_STD_0_14
+  bufrtab.TableD_STD_0_15
+  bufrtab.TableD_STD_0_16
+  bufrtab.TableD_STD_0_17
+  bufrtab.TableD_STD_0_18
+  bufrtab.TableD_STD_0_19
+  bufrtab.TableD_STD_0_20
+  bufrtab.TableD_STD_0_21
+  bufrtab.TableD_STD_0_22
+  bufrtab.TableD_STD_0_23
+  bufrtab.TableD_STD_0_24
+  bufrtab.TableD_STD_0_25
+  bufrtab.TableD_STD_0_26
+  bufrtab.TableD_STD_0_27
+  bufrtab.TableD_STD_0_28
+  bufrtab.TableD_STD_0_29
+  bufrtab.TableD_STD_0_30
+  bufrtab.TableD_STD_0_31
+  bufrtab.TableD_STD_0_32
+  bufrtab.TableD_STD_0_33
+  bufrtab.TableD_STD_0_34
+  bufrtab.TableD_STD_0_35
+)
+
+# Link BUFR tables in the build area
+foreach(FILENAME ${bufr_tables})
+  execute_process( COMMAND ${CMAKE_COMMAND} -E create_symlink
+                   ${CMAKE_CURRENT_SOURCE_DIR}/${FILENAME}
+                   ${CMAKE_CURRENT_BINARY_DIR}/${FILENAME} )
+endforeach(FILENAME)
+
+# Install BUFR tables during installation
+install(FILES ${bufr_tables} DESTINATION ${CMAKE_INSTALL_PREFIX}/tables)
+

--- a/test/test_IN_1.f
+++ b/test/test_IN_1.f
@@ -5,7 +5,7 @@
 
 	PARAMETER	( MXR8PM = 10 )
 	PARAMETER	( MXR8LV = 255 )
-	
+
 	REAL*8		r8arr ( MXR8PM, MXR8LV )
 
 	INTEGER		ibfmg ( MXBFD4 )
@@ -38,7 +38,7 @@ C*	Open the test file.
 
 	print *, '        OPENBF -> OK'
 
-	CALL MTINFO ( '../install/tables', 90, 91 )
+	CALL MTINFO ( '../tables', 90, 91 )
 	print *, '        MTINFO -> OK'
 
 C*	Read the BUFR message from the BUFR file.

--- a/test/test_IN_1.f
+++ b/test/test_IN_1.f
@@ -38,7 +38,7 @@ C*	Open the test file.
 
 	print *, '        OPENBF -> OK'
 
-	CALL MTINFO ( 'testfiles', 90, 91 )
+	CALL MTINFO ( '../install/tables', 90, 91 )
 	print *, '        MTINFO -> OK'
 
 C*	Read the BUFR message from the BUFR file.

--- a/test/test_IN_4.f
+++ b/test/test_IN_4.f
@@ -39,7 +39,7 @@ C*	Open the test file.
 
 	print *, '        OPENBF -> OK'
 
-	CALL MTINFO ( 'testfiles', 90, 91 )
+	CALL MTINFO ( '../install/tables', 90, 91 )
 	print *, '        MTINFO -> OK'
 
 C*	Read the BUFR message from the BUFR file.

--- a/test/test_IN_4.f
+++ b/test/test_IN_4.f
@@ -5,7 +5,7 @@
 
 	PARAMETER	( MXR8PM = 10 )
 	PARAMETER	( MXR8LV = 255 )
-	
+
 	REAL*8		r8arr ( MXR8PM, MXR8LV ),
      +			r8arr2 ( MXR8PM, MXR8LV )
 
@@ -39,7 +39,7 @@ C*	Open the test file.
 
 	print *, '        OPENBF -> OK'
 
-	CALL MTINFO ( '../install/tables', 90, 91 )
+	CALL MTINFO ( '../tables', 90, 91 )
 	print *, '        MTINFO -> OK'
 
 C*	Read the BUFR message from the BUFR file.

--- a/test/test_IN_5.f
+++ b/test/test_IN_5.f
@@ -19,7 +19,7 @@ C*----------------------------------------------------------------------
 
 	print *, '        OPENBF -> OK'
 
-        CALL MTINFO ( '../install/tables', 90, 91 )
+        CALL MTINFO ( '../tables', 90, 91 )
         print *, '        MTINFO -> OK'
 
         CALL CODFLG ( 'Y' )

--- a/test/test_IN_5.f
+++ b/test/test_IN_5.f
@@ -19,7 +19,7 @@ C*----------------------------------------------------------------------
 
 	print *, '        OPENBF -> OK'
 
-        CALL MTINFO ( 'testfiles', 90, 91 )
+        CALL MTINFO ( '../install/tables', 90, 91 )
         print *, '        MTINFO -> OK'
 
         CALL CODFLG ( 'Y' )

--- a/test/test_OUT_4.f
+++ b/test/test_OUT_4.f
@@ -42,7 +42,7 @@ C*	Open the BUFR input and output files.
 	CALL OPENBF ( 13, 'QUIET', -1 )
 	print *, '        OPENBF'
 
-        CALL MTINFO ( 'testfiles', 90, 91 )
+        CALL MTINFO ( '../install/tables', 90, 91 )
 	print *, '        MTINFO'
 
         CALL MAXOUT ( MXBFMG*4 )

--- a/test/test_OUT_4.f
+++ b/test/test_OUT_4.f
@@ -42,7 +42,7 @@ C*	Open the BUFR input and output files.
 	CALL OPENBF ( 13, 'QUIET', -1 )
 	print *, '        OPENBF'
 
-        CALL MTINFO ( '../install/tables', 90, 91 )
+        CALL MTINFO ( '../tables', 90, 91 )
 	print *, '        MTINFO'
 
         CALL MAXOUT ( MXBFMG*4 )
@@ -90,7 +90,7 @@ C*	Process 1 message with 4 subset from infile2.
 C*      Turn off output message standardization.
 
         CALL STDMSG ('N')
-        
+
 C*      Write DX table information for this message into the
 C*      output file.
 
@@ -134,7 +134,7 @@ C*      output file.
             IF ( nsub .eq. 1 ) THEN
               CALL WRITLC ( 13, dummystr, 'DUMMYSTR' )
             END IF
-           
+
           END DO
 
           CALL WRITSA ( -13, MXBFMG, mgbf, lmgbf )
@@ -145,7 +145,7 @@ C*      output file.
           print *, '        WRITSA'
 
         END IF
- 
+
         CALL CLOSBF ( 13 )
         print *, '        CLOSBF'
 


### PR DESCRIPTION
Fixes #97

With this update, 10 legacy master table files have now been removed from the bufr.tar archive on emcrzdm.