### PR TITLE
updated to use Doxygen to automatically generate cross-references between subprograms

### DIFF
--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -909,13 +909,13 @@ STRIP_CODE_COMMENTS    = YES
 # function all documented functions referencing it will be listed.
 # The default value is: NO.
 
-REFERENCED_BY_RELATION = NO
+REFERENCED_BY_RELATION = YES
 
 # If the REFERENCES_RELATION tag is set to YES then for each documented function
 # all documented entities called/used by that function will be listed.
 # The default value is: NO.
 
-REFERENCES_RELATION    = NO
+REFERENCES_RELATION    = YES
 
 # If the REFERENCES_LINK_SOURCE tag is set to YES and SOURCE_BROWSER tag is set
 # to YES, then the hyperlinks from functions in REFERENCES_RELATION and
@@ -923,7 +923,7 @@ REFERENCES_RELATION    = NO
 # link to the documentation.
 # The default value is: YES.
 
-REFERENCES_LINK_SOURCE = YES
+REFERENCES_LINK_SOURCE = NO
 
 # If SOURCE_TOOLTIPS is enabled (the default) then hovering a hyperlink in the
 # source code will show a tooltip with additional information such as prototype,

--- a/src/adn30.f
+++ b/src/adn30.f
@@ -23,14 +23,6 @@ C>                           routine "BORT"
 C> - 2003-11-04  S. Bender  -- Added remarks and routine interdependencies
 C> - 2003-11-04  D. Keyser  -- Unified/portable for WRF; added
 C>                           history documentation
-C>
-C> <b>This routine calls:</b> bort()
-C>
-C> <b>This routine is called by:</b> cadn30() dxinit() igetrfel() istdesc()
-C> nemtbd() numtab() rdmtbb() rdmtbd() rdmtbf() reads3() seqsdx() sntbde()
-C> sntbfe() ufbqcd() upds3() wrdxtb()
-C> <br>Normally not called by any application programs.
-C>
       
       FUNCTION ADN30(IDN,L30)
 

--- a/src/bfrini.f
+++ b/src/bfrini.f
@@ -52,11 +52,6 @@ C> - 2017-10-13  J. Ator    -- Added initialization of COMMON /TABLEF/
 C> - 2019-05-03  J. Ator    -- Change default location of MTDIR
 C> - 2019-05-09  J. Ator    -- Added dimensions for MSGLEN
 C>
-C> <b>This routine calls:</b> ifxy()  ipkm()
-C>
-C> <b>This routine is called by:</b> openbf()
-C>                <br>Normally not called by any application programs.
-C>
       SUBROUTINE BFRINI
 
       USE MODA_STBFR

--- a/src/bvers.f.in
+++ b/src/bvers.f.in
@@ -29,11 +29,6 @@ C> - 2017-04-03  J. Ator    -- Updated to version 11.3.0
 C> - 2020-10-21  J. Ator    -- Updated to use PROJECT_VERSION
 C>                           macro from CMake
 C>
-C> <b>This routine calls:</b> bort()
-C>
-C> <b>This routine is called by:</b> wrdlen()
-C>      <br>Also called by application programs.
-C>
 	SUBROUTINE BVERS (CVERSTR)
 
 	CHARACTER*(*)	CVERSTR

--- a/src/ccbfl.c
+++ b/src/ccbfl.c
@@ -14,11 +14,6 @@
  *
  *  <b>Program history log:</b>
  *  - 2005-11-29  J. Ator    -- Original author
- *  
- *  <b>This routine calls</b>: None
- *  
- *  <b>This routine is called by:</b> None
- *                   <br>Normally called only by application programs.
  */
 void ccbfl( void )
 {

--- a/src/closbf.F
+++ b/src/closbf.F
@@ -33,12 +33,6 @@ C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C> - 2020-07-16  J. Ator    -- Add sanity check to ensure that openbf()
 C>                             was previously called (needed for GSI)
 C> 
-C> <b>This routine calls:</b>        closfb() closmg() status() wtstat()
-C> 
-C> <b>This routine is called by:</b> copybf() exitbufr() mesgbf() ufbinx()
-C>                            ufbmem() ufbmex()   ufbtab()
-C>                            <br>Also called by application programs.
-C>
       SUBROUTINE CLOSBF(LUNIT)
 
       USE MODA_NULBFR

--- a/src/closmg.f
+++ b/src/closmg.f
@@ -50,13 +50,6 @@ C>                          of all future zero-subset messsages to
 C>                          ABS(LUNIN)
 C> - 2014-12-10  J. Ator  -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> bort()   msgwrt()   status()   wrcmps()
-C>                            wtstat()
-C>
-C> <b>This routine is called by:</b> closbf()   makestab() openmb()
-C>                               openmg() writsa()
-C>                           <br>Also called by application programs.
-C>
       SUBROUTINE CLOSMG(LUNIN)
 
       USE MODA_MSGCWD

--- a/src/cobfl.c
+++ b/src/cobfl.c
@@ -72,11 +72,6 @@
  *  
  *  <b>Program history log:</b>
  *  - 2005-11-29  J. Ator    -- Original author
- * 
- *  <b>This routine calls</b>: bort()   wrdlen()
- * 
- *  <b>This routine is called by:</b> None
- *                  <br>Normally called only by application programs.
  */
 void cobfl( char *bfl, char *io )
 {

--- a/src/codflg.f
+++ b/src/codflg.f
@@ -40,11 +40,6 @@ C>
 C> <b>Program history log:</b>
 C> - 2017-10-13  J. Ator    -- Original author
 C>
-C> <b>This routine calls</b>: bort()   capit()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE CODFLG(CF)
 
       COMMON /TABLEF/ CDMF

--- a/src/crbmg.c
+++ b/src/crbmg.c
@@ -41,12 +41,6 @@
  *
  *  <b>Program history log:</b>
  *  - 2005-11-29  J. Ator    -- Original author
- *  
- *  <b>This routine calls</b>: bort()  gets1loc()  ichkstr()   ipkm() 
- *                           iupbs01()   iupm()    rbytes() 
- *  
- *  <b>This routine is called by:</b> None
- *                   <br>Normally called only by application programs.
  *
  */
 void crbmg( char *bmg, f77int *mxmb, f77int *nmb, f77int *iret )

--- a/src/cwbmg.c
+++ b/src/cwbmg.c
@@ -29,11 +29,6 @@
  *
  *  <b>Program history log:</b>
  *  - 2005-11-29  J. Ator    -- Original author
- *  
- *  <b>This routine calls</b>: bort()
- *  
- *  <b>This routine is called by:</b> None
- *                   <br>Normally called only by application programs.
  */
 void cwbmg( char *bmg, f77int *nmb, f77int *iret )
 {

--- a/src/datelen.f
+++ b/src/datelen.f
@@ -37,11 +37,6 @@ C>                           called), this routine does not require it
 C>                           but it may someday call other routines that
 C>                           do require it
 C>
-C> <b>This routine calls</b>: bort()   wrdlen()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE DATELEN(LEN)
 
       COMMON /DATELN/ LENDAT

--- a/src/drfini.f
+++ b/src/drfini.f
@@ -59,11 +59,6 @@ C> - 2014-09-08  J. Ator    -- Increase NDRF limit from 100 to 200
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C> - 2018-06-07  J. Ator    -- Increase NDRF limit from 200 to 2000
 C>
-C> <b>This routine calls:</b>  bort()     status()   usrtpl()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE DRFINI(LUNIT,MDRF,NDRF,DRFTAG)
 
       USE MODA_USRINT

--- a/src/errwrt.f
+++ b/src/errwrt.f
@@ -36,24 +36,6 @@ C> <b>Program history log:</b>
 C> - 2009-04-21  J. Ator    -- Original author
 C> - 2012-11-15  D. Keyser  -- Use formatted print
 C>
-C> <b>This routine calls:</b> None
-C>
-C> <b>This routine is called by:</b>
-C>                   bort()     bort2()    cktaba()   cpdxmm()
-C>                   cpyupd()   datebf()   dumpbf()   hold4wlc()
-C>                   igetprm()  invcon()   invtag()   invwin()
-C>                   ireadmt()  jstnum()   makestab() maxout()
-C>                   mrginv()   msgupd()   msgwrt()   nvnwin()
-C>                   openbf()   openbt()   pktdd()    rdbfdx()
-C>                   rdmemm()   rdmems()   readdx()   readerme()
-C>                   readlc()   readmg()   reads3()   strnum()
-C>                   strsuc()   ufbevn()   ufbin3()   ufbint()
-C>                   ufbmem()   ufbmex()   ufbovr()   ufbrep()
-C>                   ufbrms()   ufbrw()    ufbseq()   ufbstp()
-C>                   ufbtab()   ufbtam()   usrtpl()   valx()
-C>                   wrdlen()   mtfnam()
-C>              <br>Normally not called by any application programs.
-C>
       SUBROUTINE ERRWRT(STR)
 
       CHARACTER*(*) STR

--- a/src/getbmiss.f
+++ b/src/getbmiss.f
@@ -21,11 +21,6 @@ C>
 C> <b>Program history log:</b>
 C> - 2012-09-15  J. Woollen -- Original author
 C>
-C> <b>This routine calls:</b> openbf()
-C>
-C> <b>This routine is called by:</b>None
-C>                     <br>Normally called only by application programs.
-C>
       REAL*8 FUNCTION GETBMISS()
 
       INCLUDE 'bufrlib.inc'

--- a/src/getcfmng.f
+++ b/src/getcfmng.f
@@ -99,15 +99,9 @@ C> that more information needs to be input to the subroutine in order to
 C> achieve the desired result.
 C>
 C> <b>Program history log:</b>
-C> 2018-01-11  J. Ator    -- Original author
-C> 2018-02-08  J. Ator    -- Add special handling for data types and
+C> - 2018-01-11  J. Ator    -- Original author
+C> - 2018-02-08  J. Ator    -- Add special handling for data types and
 C>                           subtypes in Section 1
-C>
-C> <b>This routine calls</b>: bort()   ifxy()   ireadmt()  nemtab()
-C>                            numtbd() parstr() srchtbf()  status()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
 C>
 	SUBROUTINE GETCFMNG ( LUNIT, NEMOI, IVALI, NEMOD, IVALD,
      .			      CMEANG, LNMNG, IRET )

--- a/src/getntbe.f
+++ b/src/getntbe.f
@@ -20,11 +20,8 @@ C> -  0 = normal return
 C> -  -1 = end-of-file encountered while reading from LUNT
 C> -  -2 = I/O error encountered while reading from LUNT
 C>
-C> <b>This routine calls:</b> bort2() igetntbl() igetfxy() ifxy()
-C>                      parstr()
-C>
-C> <b>This routine is called by:</b> rdmtbb() rdmtbd() rdmtbf()
-C> <br>Normally not called by any application programs.
+C> <b>Program history log:</b>
+C> - 2007-01-19  J. Ator    -- Original author
 C>
 	SUBROUTINE GETNTBE ( LUNT, IFXYN, LINE, IRET )
 

--- a/src/ibfms.f
+++ b/src/ibfms.f
@@ -36,12 +36,6 @@ C> - 2012-10-05  J. Ator    -- Modified to reflect the fact that the
 C>                           "missing" value is now configurable by
 C>                           users (may be something other than 10E10)
 C>
-C> <b>This routine calls:</b> None 
-C>
-C> <b>This routine is called by:</b> invmrg()  strbtm()  ufbdmp() ufbrw()
-C>                                   ufdump()  wrtree()
-C>                     <br>Also called by application programs.
-C>
 	INTEGER FUNCTION IBFMS ( R8VAL )
 
 	INCLUDE	'bufrlib.inc'

--- a/src/icbfms.f
+++ b/src/icbfms.f
@@ -28,12 +28,6 @@ C> - 2015-03-10  J. Woollen -- Improved logic for testing legacy cases
 C>                           prior to BUFRLIB V10.2.0
 C> - 2016-02-12  J. Ator    -- Modified for CRAYFTN compatibility
 C>
-C> <b>This routine calls:</b> iupm()
-C>
-C> <b>This routine is called by:</b>
-C>                            rdcmps()  rdtree()  ufbdmp()  ufdump()
-C>                     <br>Also called by application programs.
-C>
 	INTEGER FUNCTION ICBFMS ( STR, LSTR )
 
 	INCLUDE	'bufrlib.inc'

--- a/src/ireadmg.f
+++ b/src/ireadmg.f
@@ -40,11 +40,6 @@ C> - 2003-11-04  S. Bender  -- Added remarks and routine interdependencies
 C> - 2003-11-04  D. Keyser  -- Unified/portable for WRF; added history
 C>                             documentation
 C>
-C> <b>This routine calls:</b>        readmg()
-C>
-C> <b>This routine is called by:</b> ufbtab()
-C>                            <br>Also called by application programs.
-C>
       FUNCTION IREADMG(LUNIT,SUBSET,IDATE)
 
       CHARACTER*8 SUBSET

--- a/src/ireadns.f
+++ b/src/ireadns.f
@@ -34,11 +34,6 @@ C> - 1994-01-06  J. Woollen -- Original author
 C> - 2002-05-14 J. Woollen -- Changed from an entry point to increase
 C>                           portability to other platforms
 C>
-C> <b>This routine calls:</b> readns()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       FUNCTION IREADNS(LUNIT,SUBSET,IDATE)
 
       CHARACTER*8 SUBSET

--- a/src/ireadsb.f
+++ b/src/ireadsb.f
@@ -27,11 +27,6 @@ C> - 2003-11-04  S. Bender  -- Added remarks and routine interdependencies
 C> - 2003-11-04  D. Keyser  -- Unified/portable for WRF; added history
 C>                           documentation
 C>
-C> <b>This routine calls:</b>  readsb()
-C>
-C> <b>This routine is called by:</b> ufbtab()
-C>                     <br>Also called by application programs.
-C>
       FUNCTION IREADSB(LUNIT)
 
       CALL READSB(LUNIT,IRET)

--- a/src/mtinfo.f
+++ b/src/mtinfo.f
@@ -41,11 +41,6 @@ C>
 C> <b>Program history log:</b>
 C> - 2009-03-23  J. Ator    -- Original author
 C>
-C> <b>This routine calls</b>: bort2()   strsuc()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE MTINFO ( CMTDIR, LUNMT1, LUNMT2 )
 
       COMMON /MSTINF/ LUN1, LUN2, LMTD, MTDIR

--- a/src/openbf.F
+++ b/src/openbf.F
@@ -148,18 +148,6 @@ C>                             setbmiss() and setblock()
 C> - 2014-11-07  J. Ator    -- allow dynamic allocation of certain arrays
 C> - 2015-03-03  J. Ator    -- use MODA_IFOPBF instead of IFIRST
 C>
-C> <b>This routine calls:</b> arallocc() arallocf() bfrini()   bort()
-C>                            dxinit()   errwrt()   posapx()   readdx()
-C>                            status()   wrdlen()   writdx()   wtstat()
-C>                            openrb()   openwb()   openab()
-C>
-C> <b>This routine is called by:</b>
-C>                            copybf()   getbmiss() igetmxby() mesgbc()
-C>                            mesgbf()   pkvs01()   rdmgsb()   ufbinx()
-C>                            ufbmem()   ufbmex()   ufbtab() setbmiss()
-C>                            setblock()
-C>                            <br>Also called by application programs.
-C>
       SUBROUTINE OPENBF(LUNIT,IO,LUNDX)
 
       USE MODA_MSGCWD

--- a/src/openmb.f
+++ b/src/openmb.f
@@ -56,12 +56,6 @@ C>                           diagnostic info when routine terminates
 C>                           abnormally
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls</b>: bort()     closmg()   i4dy()     msgini()
-C>                            nemtba()   status()   usrtpl()   wtstat()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE OPENMB(LUNIT,SUBSET,JDATE)
 
       USE MODA_MSGCWD

--- a/src/openmg.f
+++ b/src/openmg.f
@@ -45,12 +45,6 @@ C>                           diagnostic info when routine terminates
 C>                           abnormally
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls</b>: bort()     closmg()   i4dy()     msgini()
-C>                            nemtba()   status()   usrtpl()   wtstat()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE OPENMG(LUNIT,SUBSET,JDATE)
 
       USE MODA_MSGCWD

--- a/src/readerme.f
+++ b/src/readerme.f
@@ -88,15 +88,6 @@ C> - 2012-06-07  J. Ator    -- Don't respond to DX table messages if
 C>                           Section 3 decoding is being used
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b>
-C>                         bort()     cktaba()   dxinit()   errwrt()
-C>                         ichkstr()  idxmsg()   iupbs3()   lmsg()
-C>                         makestab() reads3()   status()   stbfdx()
-C>                         wtstat()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE READERME(MESG,LUNIT,SUBSET,JDATE,IRET)
 
       USE MODA_SC3BFR

--- a/src/readmg.f
+++ b/src/readmg.f
@@ -95,15 +95,6 @@ C>                           remove code to reread message as bytes;
 C>                           replace Fortran BACKSPACE with C backbufr()
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> backbufr() bort()     cktaba()   errwrt()
-C>                            idxmsg()   rdbfdx()   rdmsgw()   reads3()
-C>                            status()   wtstat()
-C> 
-C> <b>This routine is called by:</b>
-C>                            ireadmg()  readns()   rdmgsb()   rewnbf()
-C>                            ufbinx()   ufbpos()
-C>                            <br>Also called by application programs.
-C>
       SUBROUTINE READMG(LUNXX,SUBSET,JDATE,IRET)
 
       USE MODA_MSGCWD

--- a/src/readns.f
+++ b/src/readns.f
@@ -51,11 +51,6 @@ C>                           increased from 15000 to 16000 (was in
 C>                           verification version)
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> bort()   readmg() readsb() status()
-C>
-C> <b>This routine is called by:</b> ireadns()
-C>                            <br>Also called by application programs.
-C>
       SUBROUTINE READNS(LUNIT,SUBSET,JDATE,IRET)
 
       USE MODA_MSGCWD

--- a/src/readsb.f
+++ b/src/readsb.f
@@ -55,14 +55,6 @@ C> - 2004-08-09  J. Ator    -- Maximum message length increased from
 C>                           20,000 to 50,000 bytes
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b>  bort()   rdcmps() rdtree()  status()
-C>                             upb()
-C>
-C> <b>This routine is called by:</b>
-C>                     copysb()   ireadsb()  rdmems()   readns()
-C>                     ufbinx()   ufbpos()
-C>                     <br>Also called by application programs.
-C>
       SUBROUTINE READSB(LUNIT,IRET)
 
       USE MODA_MSGCWD

--- a/src/setbmiss.f
+++ b/src/setbmiss.f
@@ -33,11 +33,6 @@ C>
 C> <b>Program history log:</b>
 C> - 2012-09-15  J. Woollen -- Original author
 C>
-C> <b>This routine calls:</b> openbf()
-C>
-C> <b>This routine is called by:</b>None
-C>                     <br>Normally called only by application programs.
-C>
       SUBROUTINE SETBMISS(XMISS)
 
       INCLUDE 'bufrlib.inc'

--- a/src/ufbint.f
+++ b/src/ufbint.f
@@ -158,12 +158,6 @@ C> - 2004-08-18  J. Ator    -- Added SAVE for IFIRST1 and IFIRST2 flags
 C> - 2009-04-21  J. Ator    -- Use errwrt()
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> bort()     bort2()    errwrt()  status()
-C>                           string()   trybump()  ufbrw()
-C>
-C> <b>This routine is called by:</b> ufbinx()   ufbrms()
-C>                             <br>Also called by application programs.
-C>
       SUBROUTINE UFBINT(LUNIN,USR,I1,I2,IRET,STR)
 
       USE MODA_USRINT

--- a/src/ufbrep.f
+++ b/src/ufbrep.f
@@ -151,12 +151,6 @@ C> - 2009-03-31  J. Woollen -- Add documentation
 C> - 2009-04-21  J. Ator    -- Use errwrt()
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> bort()     bort2()    errwrt()  status()
-C>                           string()    ufbrp()
-C>
-C> <b>This routine is called by:</b>None
-C>                     <br>Normally called only by application programs.
-C>
       SUBROUTINE UFBREP(LUNIO,USR,I1,I2,IRET,STR)
 
       USE MODA_USRINT

--- a/src/ufbseq.f
+++ b/src/ufbseq.f
@@ -155,12 +155,6 @@ C>                           of available levels is greater than I2;
 C>                           instead just return first I2 levels and
 C>                           print a diagnostic message
 C>
-C> <b>This routine calls:</b> bort()     errwrt()  invtag() invwin()
-C>                            parstr()   status()
-C>
-C> <b>This routine is called by:</b>None
-C>                     <br>Normally called only by application programs.
-C>
       SUBROUTINE UFBSEQ(LUNIN,USR,I1,I2,IRET,STR)
 
       USE MODA_USRINT

--- a/src/ufbstp.f
+++ b/src/ufbstp.f
@@ -125,12 +125,6 @@ C> - 2004-08-18  J. Ator    -- Added SAVE for IFIRST1 and IFIRST2 flags
 C> - 2009-04-21  J. Ator    -- Use errwrt()
 C> - 2014-12-10  J. Ator    -- Use modules instead of COMMON blocks
 C>
-C> <b>This routine calls:</b> bort()     bort2()    errwrt()  status()
-C>                           string()    ufbsp()
-C>
-C> <b>This routine is called by:</b>None
-C>                     <br>Normally called only by application programs.
-C>
       SUBROUTINE UFBSTP(LUNIO,USR,I1,I2,IRET,STR)
 
       USE MODA_USRINT

--- a/src/wrdlen.F
+++ b/src/wrdlen.F
@@ -40,15 +40,6 @@ C>                           within BUFRLIB via conditional compilation
 C>                           directives
 C> - 2009-03-23  J. Ator    -- Call bvers() to get version number
 C>
-C> <b>This routine calls:</b> bort()    bvers()   errwrt()  iupm()
-C>
-C> <b>This routine is called by:</b>
-C>                            cobfl()   copybf()   datebf()  datelen()
-C>                            dumpbf()  iupbs01()  mesgbc()  mesgbf()
-C>                            openbf()  rdmtbb()   rdmtbd()  rdmtbf()
-C>                            upds3()
-C>                <br>Normally not called by any application programs.
-C>
       SUBROUTINE WRDLEN
 
       COMMON /HRDWRD/ NBYTW,NBITW,IORD(8)

--- a/src/writsa.f
+++ b/src/writsa.f
@@ -114,12 +114,6 @@ C>                           messages within MSGT during the same call
 C>                           to this routine, in the rare instances
 C>                           where this can occur
 C>
-C> <b>This routine calls:</b> bort()   closmg() msgupd() status()
-C>                            wrcmps() wrtree()
-C>
-C> <b>This routine is called by:</b> None
-C>                 <br>Normally called only by application programs.
-C>
       SUBROUTINE WRITSA(LUNXX,LMSGT,MSGT,MSGL)
 
       USE MODA_BUFRMG

--- a/src/writsb.f
+++ b/src/writsb.f
@@ -51,12 +51,6 @@ C>                           diagnostic info when routine terminates
 C>                           abnormally
 C> - 2005-03-09  J. Ator -- Added capability for compressed messages
 C>
-C> <b>This routine calls:</b> bort()  msgupd()   status()   wrcmps()
-C>                            wrtree()
-C>
-C> <b>This routine is called by:</b> copysb()   writcp()
-C>                          <br>Also called by application programs.
-C>
       SUBROUTINE WRITSB(LUNIT)
 
       COMMON /MSGCMP/ CCMF


### PR DESCRIPTION
So I came across some Doxygen settings that automatically generate cross-references (i.e. which other subprograms each subprogram calls, and which other subprograms call it) within the output documentation for each subprogram.  I then updated all of the subprograms which have so far been "Doxygenated" to remove the same content which had previously been manually included.  The resulting docblocks are much cleaner and let Doxygen do more of the actual work ;-)

I also added these settings to the [Doxygen notes](https://docs.google.com/document/d/13d1X8GjiFhe72aG6zKoJ5tJfSWeYfQCGVSMNgNpaDvY/edit?usp=sharing) that I previously shared with the rest of the NCEPLIBS team.