### PR TITLE
Skip building tests if test data can't be downloaded

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ project(
 option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
 option(ENABLE_PYTHON "Enable building python module 'ncepbufr'" OFF)
 option(BUILD_SHARED_LIBS "Enable building shared libraries" OFF)
+option(BUILD_TESTS "Build tests" ON)
 
 set(MASTER_TABLE_DIR "${CMAKE_INSTALL_PREFIX}/tables" CACHE STRING "Installation location of Master BUFR Tables")
 
@@ -86,7 +87,9 @@ endif()
 
 add_subdirectory(tables)
 
-add_subdirectory(test)
+if(BUILD_TESTS)
+  add_subdirectory(test)
+endif()
 
 # Generate doxygen documentation if desired.
 if(ENABLE_DOCS)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,44 +6,21 @@ else()
   set(BUFR_TAR "bufr.tar")
 endif()
 
-find_program(CURL_pgm curl)
-mark_as_advanced(CURL_pgm)
+if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}")
+  file(DOWNLOAD
+    ${BUFR_URL}/${BUFR_TAR}
+    ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}
+    SHOW_PROGRESS
+    STATUS status
+    )
 
-if(CURL_pgm)
+  list(GET status 0 status_num)
 
-  add_custom_command(
-    OUTPUT ${BUFR_TAR}
-    COMMENT "(curl) downloading ${BUFR_URL}/${BUFR_TAR}"
-    COMMAND ${CURL_pgm}
-            --silent --show-error --fail
-            --retry 0
-            --connect-timeout 30
-            --output ${BUFR_TAR}
-            ${BUFR_URL}/${BUFR_TAR} )
-
-else()
-
-  find_program(WGET_pgm wget)
-  mark_as_advanced(WGET_pgm)
-
-  if(WGET_pgm)
-
-    add_custom_command(
-      OUTPUT ${BUFR_TAR}
-      COMMENT "(wget) downloading ${BUFR_URL}/${BUFR_TAR}"
-      COMMAND ${WGET_pgm}
-              -nv
-              -t 0
-              -T 30
-              -O ${BUFR_TAR}
-              ${BUFR_URL}/${BUFR_TAR} )
-
-  else()
-
-    message(SEND_ERROR "Could not find curl or wget.\nCannot download test data from server.\nPlease obtain the test data by other means and place it in the build directory!")
+  if(NOT status_num EQUAL 0 OR NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR})
+    message(STATUS "Could not download bufr test files, not building tests")
     return()
-
   endif()
+  
 endif()
 
 add_custom_target(get_bufr_test_data ALL DEPENDS ${BUFR_TAR})

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,11 +13,14 @@ if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}")
     ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}
     SHOW_PROGRESS
     STATUS status
+    INACTIVITY_TIMEOUT 30
     )
 
   list(GET status 0 status_num)
 
   if(NOT status_num EQUAL 0 OR NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR})
+    # Remove empty file if download doesn't complete
+    file(REMOVE ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR})
     message(STATUS "Could not download bufr test files, not building tests")
     return()
   endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,7 @@ else()
 endif()
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}")
+  message(STATUS "Downloading bufr test files...")
   file(DOWNLOAD
     ${BUFR_URL}/${BUFR_TAR}
     ${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}


### PR DESCRIPTION
Fix #150 

* Add option to disable building tests. Default is on.
* Use CMake's file(DOWNLOAD ...) to download test data instead of checking for curl/wget
* If test data cannot be downloaded skip building tests