### PR TITLE
Do not add '-c' on Apple systems when using llvm-ranlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(ENABLE_PYTHON)
   find_package(Python3 REQUIRED COMPONENTS Interpreter)
 endif()
 
-if(APPLE)
+if(APPLE AND NOT "${CMAKE_RANLIB}" MATCHES "^.*(llvm-ranlib)$")
   # The linker on macOS does not include `common symbols` by default
   # Passing the -c flag includes them and fixes an error with undefined symbols
   set(CMAKE_Fortran_ARCHIVE_FINISH "<CMAKE_RANLIB> -c <TARGET>")


### PR DESCRIPTION
Fixes https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/188.

Tested on macOS with apple-clang + gfortran and with llvm-clang + gfortran:
- the apple-clang + gfortran config has the `-c` flag for the `ranlib` step, all 21 tests pass
- the llvm-clang + gfortran config does not have the `-c` flag for the `ranlib` step, all 21 tests pass