### PR TITLE
Fix Python test by setting PYTHONPATH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,6 +65,8 @@ jobs:
         cd bufr
         mkdir build
         cd build
+        pybufr_dir=`pwd`/install/lib/python3.8/site-packages/py_ncepbufr-11.6.0-py3.8-linux-x86_64.egg
+        export PYTHONPATH="${PYTHONPATH}:${pybufr_dir}"
         cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2
         make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,6 +67,7 @@ jobs:
         cd build
         pybufr_dir=`pwd`/install/lib/python3.8/site-packages/py_ncepbufr-11.6.0-py3.8-linux-x86_64.egg
         export PYTHONPATH="${PYTHONPATH}:${pybufr_dir}"
+        ls `pwd`/install/lib/python3.8/site-packages/
         cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2
         make install


### PR DESCRIPTION
I don't think this fix is very portable because it hardcodes Python3.8 and 11.6.0, but the tests work. 

Going to open this as a draft for now because I think there's a better way of doing this. 

PYTHONPATH is set in CMake:

```
 set_tests_properties(${_test}
    PROPERTIES ENVIRONMENT "PYTHONPATH=${_install_dir}:$ENV{PYTHONPATH}")
```

So, maybe that needs to be adjusted.