### PR TITLE
fix failing python tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
         make -j2
         make install
         cd python
-        python setup.py install
+        sudo python3 setup.py install
 
     - name: test
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,8 @@ jobs:
         cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2
         make install
+        cd python
+        python setup.py install
 
     - name: test
       run: |


### PR DESCRIPTION
https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/186

the python module is not being installed by cmake, this is why the python tests fail.  