### PR TITLE
remove .x extension from debufr and xbfmg utilities

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -185,13 +185,13 @@ foreach(test_src ${test_c_interface_srcs})
   endforeach()
 endforeach()
 
-# Test debufr.x utility
+# Test debufr utility
 set(db_flags_1 "-t ../tables")
 set(db_flags_2 "-t testfiles/data -f bufrtab.031 -c")
 foreach(db_num RANGE 1 2)
   set(db_case debufr_${db_num})
   add_test(NAME test_${db_case} COMMAND ${CMAKE_BINARY_DIR}/bin/test_debufr.sh
-           "${CMAKE_BINARY_DIR}/utils/debufr.x ${db_flags_${db_num}}" "testfiles/data/${db_case}"
+           "${CMAKE_BINARY_DIR}/utils/debufr ${db_flags_${db_num}}" "testfiles/data/${db_case}"
            "testrun/${db_case}.run" "testfiles/testoutput/${db_case}.out")
 endforeach()
 
@@ -202,7 +202,7 @@ add_test(NAME test_gettab
 
 # Test sinv utility
 add_test(NAME test_sinv 
-  COMMAND ${CMAKE_BINARY_DIR}/bin/test_sinv.sh "${CMAKE_BINARY_DIR}/utils/sinv testfiles/data/satwndbufr ${CMAKE_BINARY_DIR}/tables" "testrun/sinv.out"  "testfiles/testoutput/sinv.out"
+  COMMAND ${CMAKE_BINARY_DIR}/bin/test_sinv.sh "${CMAKE_BINARY_DIR}/utils/sinv testfiles/data/satwndbufr ../tables" "testrun/sinv.out"  "testfiles/testoutput/sinv.out"
   )
 
 # Test binv utility
@@ -211,7 +211,7 @@ add_test(NAME test_binv
   )
 
 
-# Test split_by_subset.x utility
+# Test split_by_subset utility
 add_test(NAME test_split_by_subset
   COMMAND ${CMAKE_BINARY_DIR}/bin/test_split_by_subset.sh "${CMAKE_BINARY_DIR}/utils/split_by_subset testfiles/data/satwndbufr" "testfiles/testoutput/satwndbufr_split"
   )
@@ -231,12 +231,12 @@ add_test(NAME test_cmpbqm
   COMMAND ${CMAKE_BINARY_DIR}/bin/test_cmpbqm.sh "${CMAKE_BINARY_DIR}/utils/cmpbqm testfiles/data/prepbufr" "testrun/cmpbqm.out" "testfiles/testoutput/cmpbqm.out"
   )
 
-# Test xbfmg.x utility
+# Test xbfmg utility
 set(xb_flags_1 "-g")
 set(xb_flags_2 "")
 foreach(xb_num RANGE 1 2)
   set(xb_case xbfmg_${xb_num})
   add_test(NAME test_${xb_case} COMMAND ${CMAKE_BINARY_DIR}/bin/test_xbfmg.sh
-           "${CMAKE_BINARY_DIR}/utils/xbfmg.x ${xb_flags_${xb_num}}" "testfiles/data"
+           "${CMAKE_BINARY_DIR}/utils/xbfmg ${xb_flags_${xb_num}}" "testfiles/data"
            "testfiles/testoutput/xbfmg" "${xb_case}")
 endforeach()

--- a/test/test_scripts/test_sinv.sh
+++ b/test/test_scripts/test_sinv.sh
@@ -10,7 +10,7 @@ outfile=$2
 reffile=$3
 
 rc="-1"
-$cmd  > $outfile;   diff -w $outfile $reffile
+$cmd > $outfile && diff -w $outfile $reffile
 rc=${?}
 
 exit $rc

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Create the debufr.c file
+# Create the debufr.c and sinv.f90 files
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/debufr.c.in ${CMAKE_CURRENT_BINARY_DIR}/debufr.c @ONLY)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sinv.f90.in ${CMAKE_CURRENT_BINARY_DIR}/sinv.f90 @ONLY)
 
@@ -13,27 +13,9 @@ list(APPEND _utils_srcs
   xbfmg.c
 )
 
-list(APPEND _no_x 
-  binv
-  sinv
-  readbp
-  readmp
-  cmpbqm
-  gettab
-  split_by_subset
-)
-
 foreach(_src ${_utils_srcs})
-  get_filename_component(_name "${_src}" NAME_WE)
+  get_filename_component(_exec "${_src}" NAME_WE)
   get_filename_component(_ext "${_src}" LAST_EXT)
-
-  set(_exec "${_name}.x")
-
-  foreach(_nox ${_no_x})
-    if(_name MATCHES ${_nox})
-    set(_exec "${_name}")
-    endif()
-  endforeach()
   
   add_executable(${_exec} ${_src})
   add_dependencies(${_exec} bufr::bufr_4)
@@ -47,7 +29,7 @@ foreach(_src ${_utils_srcs})
 endforeach()
 
 # the debufr utility uses the "8" (8-byte integer, 8-byte real) build of the library
-set(_exec debufr.x)
+set(_exec debufr)
 add_executable(${_exec} ${CMAKE_CURRENT_BINARY_DIR}/debufr.c debufr.f)
 add_dependencies(${_exec} bufr::bufr_8)
 set_property(SOURCE ${CMAKE_CURRENT_BINARY_DIR}/debufr.c APPEND_STRING PROPERTY COMPILE_DEFINITIONS

--- a/utils/sinv.f90.in
+++ b/utils/sinv.f90.in
@@ -40,6 +40,7 @@
   
 !  define master table directory
 
+      call openbf(lunbf,'FIRST',lunbf)  ! need to call openbf prior to calling mtinfo
       IF(NARG==2) THEN ! arg 2 would be a user defined table dir
          call getarg(2,tbldir)
          call mtinfo(tbldir,3,4)


### PR DESCRIPTION
Fixes #203 

@jack-woollen I also cleaned up a couple of things with the sinv utility, because it wasn't running cleanly with the Intel compilers on WCOSS2.  Subroutine mtinfo should never be called prior to the first call to openbf, because when that happens then the default master table directory in bfrini will overwrite whatever was passed in previously via mtinfo.  