### PR TITLE
update tables with version 39 of WMO master table

### DIFF
--- a/tables/CMakeLists.txt
+++ b/tables/CMakeLists.txt
@@ -26,6 +26,7 @@ list(APPEND bufr_tables
   bufrtab.CodeFlag_STD_0_36
   bufrtab.CodeFlag_STD_0_37
   bufrtab.CodeFlag_STD_0_38
+  bufrtab.CodeFlag_STD_0_39
   bufrtab.TableB_LOC_0_7_1
   bufrtab.TableB_STD_0_13
   bufrtab.TableB_STD_0_14
@@ -53,6 +54,7 @@ list(APPEND bufr_tables
   bufrtab.TableB_STD_0_36
   bufrtab.TableB_STD_0_37
   bufrtab.TableB_STD_0_38
+  bufrtab.TableB_STD_0_39
   bufrtab.TableD_LOC_0_7_1
   bufrtab.TableD_STD_0_13
   bufrtab.TableD_STD_0_14
@@ -80,6 +82,7 @@ list(APPEND bufr_tables
   bufrtab.TableD_STD_0_36
   bufrtab.TableD_STD_0_37
   bufrtab.TableD_STD_0_38
+  bufrtab.TableD_STD_0_39
 )
 
 # Link BUFR tables in the build area
@@ -91,4 +94,3 @@ endforeach(FILENAME)
 
 # Install BUFR tables during installation
 install(FILES ${bufr_tables} DESTINATION ${MASTER_TABLE_DIR})
-

--- a/tables/bufrtab.CodeFlag_LOC_0_7_1
+++ b/tables/bufrtab.CodeFlag_LOC_0_7_1
@@ -1,7 +1,7 @@
 Table F LOC |  0 | 7 |  1
 #
 # Local BUFR Table CODE/FLAG, Master Table 0, Originating Center 7, Version 1
-# This file was generated: 2022/05/17 13:29:10
+# This file was generated: 2022/11/08 16:34:18
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC ; CODE               <-- code table definition
@@ -4803,6 +4803,7 @@ Table F LOC |  0 | 7 |  1
               | 80 > | METOP AVHRR winds - infrared (long-wave) (BUFR)
               | 90 > | NPP VIIRS winds - infrared (long-wave) (BUFR)
               | 91 > | NPP VIIRS winds - infrared (long-wave) (BUFR)
+              | 99 > | CIMSS tropical cyclone winds
            | 0-55-020=6
               | 1 > | NeXRaD level 3 radial wind superob
               | 2 > | NeXRaD level 2.5 radial wind superob
@@ -5008,6 +5009,7 @@ Table F LOC |  0 | 7 |  1
               | 5 > | Subsurface float profiles (BUFR)
               | 6 > | XBT/XCTD (TESAC) profiles (BUFR)
               | 7 > | Along track (TRACKOB) observations (BUFR)
+              | 8 > | Marine mammal profiles
               | 11 > | NLSA ERS-2 sea-surface height anomaly (high-resolution regional)
               | 12 > | NLSA TOPEX sea-surface height anomaly (high-resolution regional)
               | 13 > | NLSA TOPEX sea-surface height anomaly (high-resolution regional)
@@ -5048,6 +5050,9 @@ Table F LOC |  0 | 7 |  1
               | 134 > | CNES Sentinel 3A altimeter wind/wave (OGDR)
               | 135 > | CNES Sentinel 3B altimeter wind/wave (OGDR)
               | 136 > | NAVOCEANO CRYOSAT-2 sea-surface height anomaly (high-resolution global) (OGDR)
+              | 137 > | NAVOCEANO Sentinel 6A sea-surface height anomaly (high-resolution global) (NRT)
+              | 138 > | NAVOCEANO Sentinel 6A sea-surface height anomaly (high-resolution global) (STC)
+              | 139 > | NAVOCEANO Sentinel 6A altimeter wind/wave (fast delivery)
            | 0-55-020=255
               | 1 > | Mesonet - Denver Urban Drainage (MADIS)
               | 2 > | Mesonet - RAWS National Interagency Fire Center (MADIS)

--- a/tables/bufrtab.CodeFlag_STD_0_39
+++ b/tables/bufrtab.CodeFlag_STD_0_39
@@ -1,0 +1,8254 @@
+Table F STD |  0 | 39
+#
+# Standard BUFR Table CODE/FLAG, Master Table 0, Version 39
+# This file was generated: 2022/11/08 16:34:16
+#
+#========================================================================================================
+# F-XX-YYY | MNEMONIC ; CODE               <-- code table definition
+#          | F-XX-YYY=VAL                  <-- dependencies, if any (comma-separated if more than one)
+#            | VAL > | MEANING               <-- code figure and meaning (first thru next-to-last)
+#            | VAL   | MEANING               <-- code figure and meaning (last)
+#========================================================================================================
+# F-XX-YYY | MNEMONIC ; FLAG               <-- flag table definition
+#          | F-XX-YYY=BIT                  <-- dependencies, if any (comma-separated if more than one)
+#            | BIT > | MEANING               <-- bit number and meaning (first thru next-to-last)
+#            | BIT   | MEANING               <-- bit number and meaning (last)
+#========================================================================================================
+
+  0-01-003 | WMOR ; CODE
+              | 0 > | Antarctica
+              | 1 > | Region I
+              | 2 > | Region II
+              | 3 > | Region III
+              | 4 > | Region IV
+              | 5 > | Region V
+              | 6   | Region VI
+
+  0-01-007 | SAID ; CODE
+              | 1 > | ERS 1
+              | 2 > | ERS 2
+              | 3 > | METOP-1 (Metop-B)
+              | 4 > | METOP-2 (Metop-A)
+              | 5 > | METOP-3 (Metop-C)
+              | 20 > | SPOT1
+              | 21 > | SPOT2
+              | 22 > | SPOT3
+              | 23 > | SPOT4
+              | 24 > | Metop-D
+              | 25 > | Metop-E
+              | 26 > | Metop-F
+              | 27 > | Metop-G
+              | 28 > | Metop-H
+              | 29 > | Metop-I
+              | 40 > | OERSTED
+              | 41 > | CHAMP
+              | 42 > | TerraSAR-X
+              | 43 > | TanDEM-X
+              | 44 > | PAZ
+              | 45 > | ALTIUS
+              | 46 > | SMOS
+              | 47 > | CryoSat-2
+              | 48 > | AEOLUS
+              | 49 > | EarthCARE
+              | 50 > | METEOSAT 3
+              | 51 > | METEOSAT 4
+              | 52 > | METEOSAT 5
+              | 53 > | METEOSAT 6
+              | 54 > | METEOSAT 7
+              | 55 > | METEOSAT 8
+              | 56 > | METEOSAT 9
+              | 57 > | METEOSAT 10
+              | 58 > | METEOSAT 1
+              | 59 > | METEOSAT 2
+              | 60 > | ENVISAT
+              | 61 > | Sentinel 3A
+              | 62 > | Sentinel 1A
+              | 63 > | Sentinel 1B
+              | 64 > | Sentinel 5P
+              | 65 > | Sentinel 3B
+              | 66 > | Sentinel 6A
+              | 67 > | Sentinel 6B
+              | 70 > | METEOSAT 11
+              | 71 > | METEOSAT 12
+              | 72 > | METEOSAT 13
+              | 73 > | METEOSAT 14
+              | 74 > | METEOSAT 15
+              | 75 > | METEOSAT 16
+              | 76 > | METEOSAT 17
+              | 120 > | ADEOS
+              | 121 > | ADEOS II
+              | 122 > | GCOM-W1
+              | 140 > | GOSAT
+              | 150 > | GMS 3
+              | 151 > | GMS 4
+              | 152 > | GMS 5
+              | 153 > | GMS
+              | 154 > | GMS-2
+              | 171 > | MTSAT-1R
+              | 172 > | MTSAT-2
+              | 173 > | Himawari-8
+              | 174 > | Himawari-9
+              | 200 > | NOAA 8
+              | 201 > | NOAA 9
+              | 202 > | NOAA 10
+              | 203 > | NOAA 11
+              | 204 > | NOAA 12
+              | 205 > | NOAA 14
+              | 206 > | NOAA 15
+              | 207 > | NOAA 16
+              | 208 > | NOAA 17
+              | 209 > | NOAA 18
+              | 220 > | LANDSAT 5
+              | 221 > | LANDSAT 4
+              | 222 > | LANDSAT 7
+              | 223 > | NOAA 19
+              | 224 > | NPP
+              | 225 > | NOAA 20
+              | 226 > | NOAA 21
+              | 227 > | TROPICS-02
+              | 228 > | TROPICS-03
+              | 229 > | TROPICS-04
+              | 240 > | DMSP 7
+              | 241 > | DMSP 8
+              | 242 > | DMSP 9
+              | 243 > | DMSP 10
+              | 244 > | DMSP 11
+              | 245 > | DMSP 12
+              | 246 > | DMSP 13
+              | 247 > | DMSP 14
+              | 248 > | DMSP 15
+              | 249 > | DMSP 16
+              | 250 > | GOES 6
+              | 251 > | GOES 7
+              | 252 > | GOES 8
+              | 253 > | GOES 9
+              | 254 > | GOES 10
+              | 255 > | GOES 11
+              | 256 > | GOES 12
+              | 257 > | GOES 13
+              | 258 > | GOES 14
+              | 259 > | GOES 15
+              | 260 > | JASON 1
+              | 261 > | JASON 2
+              | 262 > | JASON 3
+              | 263 > | TROPICS-05
+              | 264 > | TROPICS-06
+              | 265 > | GeoOptics CICERO OP1
+              | 266 > | GeoOptics CICERO OP2
+              | 267 > | PlanetiQ GNOMES-A
+              | 268 > | PlanetiQ GNOMES-B
+              | 269 > | Spire Lemur 3U Cubesat
+              | 270 > | GOES 16
+              | 271 > | GOES 17
+              | 272 > | GOES 18
+              | 273 > | GOES 19
+              | 281 > | QUIKSCAT
+              | 282 > | TRMM
+              | 283 > | CORIOLIS
+              | 284 > | TROPICS-07
+              | 285 > | DMSP17
+              | 286 > | DMSP18
+              | 287 > | DMSP-19
+              | 288 > | GPM-core
+              | 289 > | Orbiting Carbon Observatory - 2 (OCO-2, NASA)
+              | 310 > | GOMS 1
+              | 311 > | GOMS 2
+              | 320 > | METEOR 2-21
+              | 321 > | METEOR 3-5
+              | 322 > | METEOR 3M-1
+              | 323 > | METEOR 3M-2
+              | 324 > | METEOR-M N2
+              | 325 > | METEOR-M N2 2
+              | 341 > | RESURS 01-4
+              | 410 > | KALPANA-1
+              | 421 > | Oceansat-2
+              | 422 > | ScatSat-1
+              | 423 > | Oceansat-3
+              | 430 > | INSAT 1B
+              | 431 > | INSAT 1C
+              | 432 > | INSAT 1D
+              | 440 > | Megha-Tropiques
+              | 441 > | SARAL
+              | 450 > | INSAT 2A
+              | 451 > | INSAT 2B
+              | 452 > | INSAT 2E
+              | 470 > | INSAT 3A
+              | 471 > | INSAT 3D
+              | 472 > | INSAT 3E
+              | 473 > | INSAT 3DR
+              | 474 > | INSAT 3DS
+              | 500 > | FY-1C
+              | 501 > | FY-1D
+              | 502 > | Hai Yang 2A (HY-2A, SOA/NSOAS China)
+              | 503 > | Hai Yang 2B (HY-2B, SOA/NSOAS China)
+              | 504 > | Hai Yang 2C (HY-2C, SOA/NSOAS China)
+              | 505 > | Hai Yang 2D (HY-2D, SOA/NSOAS China)
+              | 510 > | FY-2
+              | 512 > | FY-2B
+              | 513 > | FY-2C
+              | 514 > | FY-2D
+              | 515 > | FY-2E
+              | 516 > | FY-2F
+              | 517 > | FY-2G
+              | 518 > | FY-2H
+              | 520 > | FY-3A
+              | 521 > | FY-3B
+              | 522 > | FY-3C
+              | 523 > | FY-3D
+              | 524 > | FY-3E
+              | 530 > | FY-4A
+              | 531 > | FY-4B
+              | 700 > | TIROS M (ITOS 1)
+              | 701 > | NOAA 1
+              | 702 > | NOAA 2
+              | 703 > | NOAA 3
+              | 704 > | NOAA 4
+              | 705 > | NOAA 5
+              | 706 > | NOAA 6
+              | 707 > | NOAA 7
+              | 708 > | TIROS-N
+              | 709 > | TROPICS-01 (Pathfinder)
+              | 710 > | GOES (SMS 1)
+              | 711 > | GOES (SMS 2)
+              | 720 > | TOPEX
+              | 721 > | GFO
+              | 722 > | GRACE A
+              | 723 > | GRACE B
+              | 724 > | COSMIC-2 P1
+              | 725 > | COSMIC-2 P2
+              | 726 > | COSMIC-2 P3
+              | 727 > | COSMIC-2 P4
+              | 728 > | COSMIC-2 P5
+              | 729 > | COSMIC-2 P6
+              | 731 > | GOES 1
+              | 732 > | GOES 2
+              | 733 > | GOES 3
+              | 734 > | GOES 4
+              | 735 > | GOES 5
+              | 740 > | COSMIC-1
+              | 741 > | COSMIC-2
+              | 742 > | COSMIC-3
+              | 743 > | COSMIC-4
+              | 744 > | COSMIC-5
+              | 745 > | COSMIC-6
+              | 750 > | COSMIC-2 E1
+              | 751 > | COSMIC-2 E2
+              | 752 > | COSMIC-2 E3
+              | 753 > | COSMIC-2 E4
+              | 754 > | COSMIC-2 E5
+              | 755 > | COSMIC-2 E6
+              | 761 > | NIMBUS 1
+              | 762 > | NIMBUS 2
+              | 763 > | NIMBUS 3
+              | 764 > | NIMBUS 4
+              | 765 > | NIMBUS 5
+              | 766 > | NIMBUS 6
+              | 767 > | NIMBUS 7
+              | 780 > | ERBS
+              | 781 > | UARS
+              | 782 > | EARTH PROBE
+              | 783 > | TERRA
+              | 784 > | AQUA
+              | 785 > | AURA
+              | 786 > | C/NOFS
+              | 787 > | CALIPSO
+              | 788 > | CloudSat
+              | 789 > | SMAP
+              | 800 > | SUNSAT
+              | 801 > | International Space Station (ISS)
+              | 802 > | CFOSAT
+              | 803 > | GRACE C (GRACE-FO)
+              | 804 > | GRACE D (GRACE-FO)
+              | 810 > | COMS
+              | 811 > | GEO-KOMPSAT-2A
+              | 812 > | SCISAT-1
+              | 813 > | ODIN
+              | 820 > | SAC-C
+              | 821 > | SAC-D
+              | 825 > | KOMPSAT-5
+              | 850 > | Combination of TERRA and AQUA
+              | 851 > | Combination of NOAA 16 to NOAA 19
+              | 852 > | Combination of METOP-1 to METOP-3
+              | 853 > | Combination of METEOSAT and DMSP
+              | 854 > | Non-specific mixture of geostationary and low earth orbiting satellites
+              | 855 > | Combination of INSAT 3D and INSAT 3DR
+              | 856   | Combination of Sentinel-3 satellites
+
+  0-01-024 | WSPDS ; CODE
+              | 0 > | No wind speed data available
+              | 1 > | AMSR-E data
+              | 2 > | TMI data
+              | 3 > | NWP: ECMWF
+              | 4 > | NWP: UK Met Office
+              | 5 > | NWP: NCEP
+              | 6 > | Reference climatology
+              | 7   | ERS_Scatterometer
+
+  0-01-028 | AODS ; CODE
+              | 0 > | No AOD data available
+              | 1 > | NESDIS
+              | 2 > | NAVOCEANO
+              | 3 > | NAAPS
+              | 4 > | MERIS
+              | 5   | AATSR
+
+  0-01-029 | SSIS ; CODE
+              | 0 > | No SSI data available
+              | 1 > | MSG_SEVIRI
+              | 2 > | GOES East
+              | 3 > | GOES West
+              | 4 > | ECMWF
+              | 5 > | NCEP
+              | 6   | UK Met Office
+
+  0-01-031 | GCLONG ; CODE
+              | 0 > | WMO Secretariat
+              | 1 > | Melbourne
+              | 2 > | Melbourne
+              | 3 > | Melbourne
+              | 4 > | Moscow
+              | 5 > | Moscow
+              | 6 > | Moscow
+              | 7 > | U.S. National Weather Service, National Centres for Environmental Prediction (NCEP)
+              | 8 > | U.S. National Weather Service Telecommunications Gateway (NWSTG)
+              | 9 > | U.S. National Weather Service - Other
+              | 10 > | Cairo (RSMC)
+              | 11 > | Cairo (RSMC)
+              | 12 > | Dakar (RSMC)
+              | 13 > | Dakar (RSMC)
+              | 14 > | Nairobi (RSMC)
+              | 15 > | Nairobi (RSMC)
+              | 16 > | Casablanca (RSMC)
+              | 17 > | Tunis (RSMC)
+              | 18 > | Tunis Casablanca (RSMC)
+              | 19 > | Tunis Casablanca (RSMC)
+              | 20 > | Las Palmas
+              | 21 > | Algiers (RSMC)
+              | 22 > | ACMAD
+              | 23 > | Mozambique (NMC)
+              | 24 > | Pretoria (RSMC)
+              | 25 > | La Reunion (RSMC)
+              | 26 > | Khabarovsk (RSMC)
+              | 27 > | Khabarovsk (RSMC)
+              | 28 > | New Delhi (RSMC)
+              | 29 > | New Delhi (RSMC)
+              | 30 > | Novosibirsk (RSMC)
+              | 31 > | Novosibirsk (RSMC)
+              | 32 > | Tashkent (RSMC)
+              | 33 > | Jeddah (RSMC)
+              | 34 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 35 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 36 > | Bangkok
+              | 37 > | Ulaanbaatar
+              | 38 > | Beijing (RSMC)
+              | 39 > | Beijing (RSMC)
+              | 40 > | Seoul
+              | 41 > | Buenos Aires (RSMC)
+              | 42 > | Buenos Aires (RSMC)
+              | 43 > | Brasilia (RSMC)
+              | 44 > | Brasilia (RSMC)
+              | 45 > | Santiago
+              | 46 > | Brazilian Space Agency - INPE
+              | 47 > | Colombia (NMC)
+              | 48 > | Ecuador (NMC)
+              | 49 > | Peru (NMC)
+              | 50 > | Venezuela (NMC)
+              | 51 > | Miami (RSMC)
+              | 52 > | Miami (RSMC), National Hurricane Center
+              | 53 > | MSC Monitoring
+              | 54 > | Montreal (RSMC)
+              | 55 > | San Francisco
+              | 56 > | ARINC Centre
+              | 57 > | U.S. Air Force Global Weather Central
+              | 58 > | Fleet Numerical Meteorology and Oceanography Center, Monterey, CA, USA
+              | 59 > | NOAA Forecast Systems Laboratory, Boulder, CO, USA
+              | 60 > | United States National Centre for Atmospheric Research (NCAR)
+              | 61 > | Service ARGOS - Landover
+              | 62 > | U.S. Naval Oceanographic Office
+              | 63 > | International Research Institute for Climate and Society (IRI)
+              | 64 > | Honolulu (RSMC)
+              | 65 > | Darwin (RSMC)
+              | 66 > | Darwin (RSMC)
+              | 67 > | Melbourne (RSMC)
+              | 69 > | Wellington (RSMC)
+              | 70 > | Wellington (RSMC)
+              | 71 > | Nadi (RSMC)
+              | 72 > | Singapore
+              | 73 > | Malaysia (NMC)
+              | 74 > | UK Meteorological Office, Exeter (RSMC)
+              | 75 > | UK Meteorological Office, Exeter (RSMC)
+              | 76 > | Moscow (RSMC)
+              | 78 > | Offenbach (RSMC)
+              | 79 > | Offenbach (RSMC)
+              | 80 > | Rome (RSMC)
+              | 81 > | Rome (RSMC)
+              | 82 > | Norrkoping
+              | 83 > | Norrkoping
+              | 84 > | Toulouse (RSMC)
+              | 85 > | Toulouse (RSMC)
+              | 86 > | Helsinki
+              | 87 > | Belgrade
+              | 88 > | Oslo
+              | 89 > | Prague
+              | 90 > | Episkopi
+              | 91 > | Ankara
+              | 92 > | Frankfurt/Main
+              | 93 > | London (WAFC)
+              | 94 > | Copenhagen
+              | 95 > | Rota
+              | 96 > | Athens
+              | 97 > | European Space Agency (ESA)
+              | 98 > | European Centre for Medium-Range Weather Forecasts (ECMWF)
+              | 99 > | De Bilt
+              | 100 > | Brazzaville
+              | 101 > | Abidjan
+              | 102 > | Libya (NMC)
+              | 103 > | Madagascar (NMC)
+              | 104 > | Mauritius (NMC)
+              | 105 > | Niger (NMC)
+              | 106 > | Seychelles (NMC)
+              | 107 > | Uganda (NMC)
+              | 108 > | Tanzania (NMC)
+              | 109 > | Zimbabwe (NMC)
+              | 110 > | Hong-Kong, China
+              | 111 > | Afghanistan (NMC)
+              | 112 > | Bahrain (NMC)
+              | 113 > | Bangladesh (NMC)
+              | 114 > | Bhutan (NMC)
+              | 115 > | Cambodia (NMC)
+              | 116 > | Democratic People's Republic of Korea (NMC)
+              | 117 > | Islamic Republic of Iran (NMC)
+              | 118 > | Iraq (NMC)
+              | 119 > | Kazakhstan (NMC)
+              | 120 > | Kuwait (NMC)
+              | 121 > | Kyrgyzstan (NMC)
+              | 122 > | Lao People's Democratic Republic (NMC)
+              | 123 > | Macao, China
+              | 124 > | Maldives (NMC)
+              | 125 > | Myanmar (NMC)
+              | 126 > | Nepal (NMC)
+              | 127 > | Oman (NMC)
+              | 128 > | Pakistan (NMC)
+              | 129 > | Qatar (NMC)
+              | 130 > | Republic of Yemen (NMC)
+              | 131 > | Sri Lanka (NMC)
+              | 132 > | Tajikistan (NMC)
+              | 133 > | Turkmenistan (NMC)
+              | 134 > | United Arab Emirates (NMC)
+              | 135 > | Uzbekistan (NMC)
+              | 136 > | Viet Nam (NMC)
+              | 140 > | Bolivia (NMC)
+              | 141 > | Guyana (NMC)
+              | 142 > | Paraguay (NMC)
+              | 143 > | Suriname (NMC)
+              | 144 > | Uruguay (NMC)
+              | 145 > | French Guyana
+              | 146 > | Brazilian Navy Hydrographic Centre
+              | 147 > | COmision Nacional de Actividades Espaciales (CONAE) - Argentina
+              | 148 > | Brazilian Department of Airspace Control - DECEA
+              | 150 > | Antigua and Barbuda (NMC)
+              | 151 > | Bahamas (NMC)
+              | 152 > | Barbados (NMC)
+              | 153 > | Belize (NMC)
+              | 154 > | British Caribbean Territories Centre
+              | 155 > | San Jose
+              | 156 > | Cuba (NMC)
+              | 157 > | Dominica (NMC)
+              | 158 > | Dominican Republic (NMC)
+              | 159 > | El Salvador (NMC)
+              | 160 > | U.S. NOAA/NESDIS
+              | 161 > | U.S. NOAA Office of Oceanic and Atmospheric Research
+              | 162 > | Guatemala (NMC)
+              | 163 > | Haiti (NMC)
+              | 164 > | Honduras (NMC)
+              | 165 > | Jamaica (NMC)
+              | 166 > | Mexico
+              | 167 > | Curacao and Sint Maarten (NMC)
+              | 168 > | Nicaragua (NMC)
+              | 169 > | Panama (NMC)
+              | 170 > | Saint Lucia (NMC)
+              | 171 > | Trinidad and Tobago (NMC)
+              | 172 > | French Departments in RA IV
+              | 173 > | U.S. National Aeronautics and Space Administration (NASA)
+              | 174 > | Integrated System Data Management/Marine Environmental Data Service (ISDM/MEDS - Canada)
+              | 175 > | University Corporation for Atmospheric Research (UCAR) - United States
+              | 176 > | U.S. Cooperative Institute for Meteorological Satellite Studies (CIMSS)
+              | 177 > | U.S. NOAA National Ocean Service
+              | 178 > | Spire Global, Inc.
+              | 179 > | GeoOptics, Inc.
+              | 180 > | PlanetiQ
+              | 190 > | Cook Islands (NMC)
+              | 191 > | French Polynesia (NMC)
+              | 192 > | Tonga (NMC)
+              | 193 > | Vanuatu (NMC)
+              | 194 > | Brunei Darussalam (NMC)
+              | 195 > | Indonesia (NMC)
+              | 196 > | Kiribati (NMC)
+              | 197 > | Federated States of Micronesia (NMC)
+              | 198 > | New Caledonia (NMC)
+              | 199 > | Niue
+              | 200 > | Papua New Guinea (NMC)
+              | 201 > | Philippines (NMC)
+              | 202 > | Samoa (NMC)
+              | 203 > | Solomon Islands (NMC)
+              | 204 > | National Institute of Water and Atmospheric Research  (NIWA - New Zealand)
+              | 210 > | Frascati (ESA/ESRIN)
+              | 211 > | Lannion
+              | 212 > | Lisboa
+              | 213 > | Reykiavik
+              | 214 > | Madrid
+              | 215 > | Zurich
+              | 216 > | Service ARGOS Toulouse
+              | 217 > | Bratislava
+              | 218 > | Budapest
+              | 219 > | Ljubljana
+              | 220 > | Warsaw
+              | 221 > | Zagreb
+              | 222 > | Albania (NMC)
+              | 223 > | Armenia (NMC)
+              | 224 > | Austria (NMC)
+              | 225 > | Azerbaijan (NMC)
+              | 226 > | Belarus (NMC)
+              | 227 > | Belgium (NMC)
+              | 228 > | Bosnia and Herzegovina (NMC)
+              | 229 > | Bulgaria (NMC)
+              | 230 > | Cyprus (NMC)
+              | 231 > | Estonia (NMC)
+              | 232 > | Georgia (NMC)
+              | 233 > | Dublin
+              | 234 > | Israel (NMC)
+              | 235 > | Jordan (NMC)
+              | 236 > | Latvia (NMC)
+              | 237 > | Lebanon (NMC)
+              | 238 > | Lithuania (NMC)
+              | 239 > | Luxembourg
+              | 240 > | Malta (NMC)
+              | 241 > | Monaco
+              | 242 > | Romania (NMC)
+              | 243 > | Syrian Arab Republic (NMC)
+              | 244 > | The former Yugoslav Republic of Macedonia (NMC)
+              | 245 > | Ukraine (NMC)
+              | 246 > | Republic of Moldova (NMC)
+              | 247 > | Operational Programme for the Exchange of weather RAdar information (OPERA) - EUMETNET
+              | 248 > | Montenegro (NMC)
+              | 249 > | Barcelona Dust Forecast Center
+              | 250 > | COnsortium for Small scale MOdelling  (COSMO)
+              | 251 > | Meteorological Cooperation on Operational NWP (MetCoOp)
+              | 252 > | Max Planck Institute for Meteorology (MPI-M)
+              | 254 > | EUMETSAT Operation Centre
+              | 256 > | Angola (NMC)
+              | 257 > | Benin (NMC)
+              | 258 > | Botswana (NMC)
+              | 259 > | Burkina Faso (NMC)
+              | 260 > | Burundi (NMC)
+              | 261 > | Cameroon (NMC)
+              | 262 > | Cape Verde (NMC)
+              | 263 > | Central African Republic (NMC)
+              | 264 > | Chad (NMC)
+              | 265 > | Comoros (NMC)
+              | 266 > | Democratic Republic of the Congo (NMC)
+              | 267 > | Djibouti (NMC)
+              | 268 > | Eritrea (NMC)
+              | 269 > | Ethiopia (NMC)
+              | 270 > | Gabon (NMC)
+              | 271 > | Gambia (NMC)
+              | 272 > | Ghana (NMC)
+              | 273 > | Guinea (NMC)
+              | 274 > | Guinea Bissau (NMC)
+              | 275 > | Lesotho (NMC)
+              | 276 > | Liberia (NMC)
+              | 277 > | Malawi (NMC)
+              | 278 > | Mali (NMC)
+              | 279 > | Mauritania (NMC)
+              | 280 > | Namibia (NMC)
+              | 281 > | Nigeria (NMC)
+              | 282 > | Rwanda (NMC)
+              | 283 > | Sao Tome and Principe (NMC)
+              | 284 > | Sierra Leone (NMC)
+              | 285 > | Somalia (NMC)
+              | 286 > | Sudan (NMC)
+              | 287 > | Swaziland (NMC)
+              | 288 > | Togo (NMC)
+              | 289 > | Zambia (NMC)
+              | 290 > | EUMETNET E-Profile
+              | 291   | The Institute of Atmospheric Physics (IAP) of Chinese Academy of Sciences (CAS)
+
+  0-01-032 | GNAP ; CODE
+           | 0-01-031,0-01-033,0-01-035=34
+              | 101 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+              | 102 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+              | 103 > | Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+           | 0-01-031,0-01-033,0-01-035=98
+              | 61 > | 3DVAR analysis
+              | 65 > | 4DVAR analysis
+           | 0-01-031,0-01-033,0-01-035=254
+              | 1 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+              | 2 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+              | 3 > | Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+           | 0-01-031,0-01-033,0-01-035=176
+              | 1 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test
+              | 2 > | Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+              | 3 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+           | 0-01-031,0-01-033,0-01-035=7
+              | 2 > | Ultra Violet Index Model
+              | 3 > | NCEP/ARL Transport and Dispersion Model
+              | 4 > | NCEP/ARL Smoke Model
+              | 5 > | Satellite-derived precipitation and temperature from IR
+              | 6 > | NCEP/ARL Dust Model
+              | 10 > | Global Wind-Wave Forecast Model
+              | 11 > | Global Multi-Grid Wave Model (Static Grids)
+              | 12 > | Probabilistic Storm Surge
+              | 13 > | Hurricane Multi-Grid Wave Model
+              | 14 > | Extratropical Storm Surge Model
+              | 19 > | Limited-area Fine Mesh (LFM) analysis
+              | 25 > | Snow Cover Analysis
+              | 30 > | Forecaster generated field
+              | 31 > | Value added post processed field
+              | 39 > | Nested Grid Forecast Model (NGM)
+              | 42 > | Global Optimum Interpolation Analysis (GOI) from GFS model
+              | 43 > | Global Optimum Interpolation Analysis (GOI) from "Final" run
+              | 44 > | Sea Surface Temperature Analysis
+              | 45 > | Coastal Ocean Circulation Model
+              | 46 > | HYCOM - Global
+              | 47 > | HYCOM - North Pacific basin
+              | 48 > | HYCOM - North Atlantic basin
+              | 49 > | Ozone Analysis from TIROS Observations
+              | 52 > | Ozone Analysis from Nimbus 7 Observations
+              | 53 > | LFM-Fourth Order Forecast Model
+              | 64 > | Regional Optimum Interpolation Analysis (ROI)
+              | 68 > | 80 wave triangular, 18-layer Spectral model from GFS model
+              | 69 > | 80 wave triangular, 18 layer Spectral model from "Medium Range Forecast
+              | 70 > | Quasi-Lagrangian Hurricane Model (QLM)
+              | 71 > | Hurricane Weather Research and Forecasting (HWRF) Model
+              | 72 > | Hurricane Non-Hydrostatic Multiscale Model on the B Grid (HNMMB)
+              | 73 > | Fog Forecast model - Ocean Products Center
+              | 74 > | Gulf of Mexico Wind/Wave
+              | 75 > | Gulf of Alaska Wind/Wave
+              | 76 > | Bias-corrected Medium Range Forecast
+              | 77 > | 126 wave triangular, 28 layer Spectral model from GFS model
+              | 78 > | 126 wave triangular, 28 layer Spectral model from "Medium Range Forecast" run
+              | 79 > | Backup from the previous run
+              | 80 > | 62 wave triangular, 28 layer Spectral model from "Medium Range Forecast" run
+              | 81 > | Analysis from GFS (Global Forecast System)
+              | 82 > | Analysis from GDAS (Global Data Assimilation System)
+              | 84 > | MESO NAM Model (currently 12 km)
+              | 85 > | Real Time Ocean Forecast System (RTOFS)
+              | 86 > | RUC Model, from Forecast Systems Lab (isentropic; scale: 60km at 40N)
+              | 87 > | CAC Ensemble Forecasts from Spectral (ENSMB)
+              | 88 > | NOAA Wave Watch III (NWW3) Ocean Wave Model
+              | 89 > | Non-hydrostatic Meso Model (NMM) (Currently 8 km)
+              | 90 > | 62 wave triangular, 28 layer spectral model extension of the "Medium Range Forecast" run
+              | 91 > | 62 wave triangular, 28 layer spectral model extension of the GFS model
+              | 92 > | 62 wave triangular, 28 layer spectral model run from the "Medium Range Forecast" final analysis
+              | 93 > | 62 wave triangular, 28 layer spectral model run from the T62 GDAS analysis of the "Medium Range Forecast" run
+              | 94 > | T170/L42 Global Spectral Model from MRF run
+              | 95 > | T126/L42 Global Spectral Model from MRF run
+              | 96 > | Global Forecast System Model (T574 - forecast hours 000-192, T190 - forecast hours 204-384)
+              | 98 > | Climate Forecast System Model -- Atmospheric model (GFS) coupled to a multi-level ocean model (currently GFS spectral model at T62, 64 levels coupled to 40 level MOM3 ocean model)
+              | 99 > | Miscellaneous Test ID
+              | 100 > | RUC Surface Analysis (scale: 60km at 40N)
+              | 101 > | RUC Surface Analysis (scale: 40km at 40N)
+              | 105 > | RUC Model from FSL (isentropic; scale: 20km at 40N)
+              | 107 > | Global Ensemble Forecast System (GEFS)
+              | 108 > | LAMP
+              | 109 > | RTMA (Real Time Mesoscale Analysis)
+              | 110 > | NAM Model - 15km version
+              | 111 > | NAM model, generic resolution (used in SREF processing)
+              | 112 > | WRF-NMM model, generic resolution (used in various runs) NMM=Nondydrostatic Mesoscale Model (NCEP)
+              | 113 > | Products from NCEP SREF processing
+              | 114 > | NAEFS Products from joined NCEP, CMC global ensembles
+              | 115 > | Downscaled GFS from NAM eXtension
+              | 116 > | WRF-EM model, generic resolution (used in various runs) EM - Eulerian Mass-core (NCAR - aka Advanced Research WRF)
+              | 117 > | NEMS GFS Aerosol Component
+              | 118 > | URMA (UnRestricted Mesoscale Analysis)
+              | 120 > | Ice Concentration Analysis
+              | 121 > | Western North Atlantic Regional Wave Model
+              | 122 > | Alaska Waters Regional Wave Model
+              | 123 > | North Atlantic Hurricane Wave Model
+              | 124 > | Eastern North Pacific Regional Wave Model
+              | 125 > | North Pacific Hurricane Wave Model
+              | 126 > | Sea Ice Forecast Model
+              | 127 > | Lake Ice Forecast Model
+              | 128 > | Global Ocean Forecast Model
+              | 129 > | Global Ocean Data Analysis System (GODAS)
+              | 130 > | Merge of fields from the RUC, NAM, and Spectral Model
+              | 131 > | Great Lakes Wave Model
+              | 140 > | North American Regional Reanalysis (NARR)
+              | 141 > | Land Data Assimilation and Forecast System
+              | 150 > | NWS River Forecast System (NWSRFS)
+              | 151 > | NWS Flash Flood Guidance System (NWSFFGS)
+              | 152 > | WSR-88D Stage II Precipitation Analysis
+              | 153 > | WSR-88D Stage III Precipitation Analysis
+              | 180 > | Quantitative Precipitation Forecast generated by NCEP
+              | 181 > | River Forecast Center Quantitative Precipitation Forecast mosaic generated by NCEP
+              | 182 > | River Forecast Center Quantitative Precipitation Estimate mosaic generated by NCEP
+              | 183 > | NDFD product generated by NCEP/HPC
+              | 184 > | Climatological Calibrated Precipitation Analysis - CCPA
+              | 190 > | National Convective Weather Diagnostic generated by NCEP/AWC
+              | 191 > | Current Icing Potential automated product genterated by NCEP/AWC
+              | 192 > | Analysis product from NCEP/AWC
+              | 193 > | Forecast product from NCEP/AWC
+              | 195 > | Climate Data Assimilation System 2 (CDAS2)
+              | 196 > | Climate Data Assimilation System 2 (CDAS2) - used for regeneration runs
+              | 197 > | Climate Data Assimilation System (CDAS)
+              | 198 > | Climate Data Assimilation System (CDAS) - used for regeneration runs
+              | 199 > | Climate Forecast System Reanalysis (CFSR) -- Atmospheric model (GFS) coupled to a multi-level ocean, land and seaice model (currently GFS spectral model at T382, 64 levels coupled to 40 level MOM4 ocean model)
+              | 200 > | CPC Manual Forecast Product
+              | 201 > | CPC Automated Product
+              | 210 > | EPA Air Quality Forecast - Currently Northeast U.S. Domain
+              | 211 > | EPA Air Quality Forecast - Currently Eastern U.S. Domain
+              | 215 > | SPC Manual Forecast Product
+              | 220 > | NCEP/OPC automated product
+           | 0-01-031,0-01-033,0-01-035=160
+              | 0 > | First guess
+              | 1 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test, but with slight differences between the different satellite operators
+              | 2 > | Quality values derived from the NESDIS RFF (Recursive Filter Function) method
+              | 3 > | Quality values derived from the EUMETSAT QI (Quality Indicator) method, with the forecast consistency test
+              | 4 > | Quality values derived from the NESDIS EE (Expected Error) method
+              | 5   | Quality values derived from the EUMETSAT QI (Quality Indicator) method, excluding the forecast consistency test, and common to all satellite operators (computed exactly the same way)
+
+  0-01-033 | OGCE ; CODE
+              | 0 > | WMO Secretariat
+              | 1 > | Melbourne
+              | 2 > | Melbourne
+              | 3 > | Melbourne
+              | 4 > | Moscow
+              | 5 > | Moscow
+              | 6 > | Moscow
+              | 7 > | U.S. National Weather Service, National Centres for Environmental Prediction (NCEP)
+              | 8 > | U.S. National Weather Service Telecommunications Gateway (NWSTG)
+              | 9 > | U.S. National Weather Service - Other
+              | 10 > | Cairo (RSMC)
+              | 11 > | Cairo (RSMC)
+              | 12 > | Dakar (RSMC)
+              | 13 > | Dakar (RSMC)
+              | 14 > | Nairobi (RSMC)
+              | 15 > | Nairobi (RSMC)
+              | 16 > | Casablanca (RSMC)
+              | 17 > | Tunis (RSMC)
+              | 18 > | Tunis Casablanca (RSMC)
+              | 19 > | Tunis Casablanca (RSMC)
+              | 20 > | Las Palmas
+              | 21 > | Algiers (RSMC)
+              | 22 > | ACMAD
+              | 23 > | Mozambique (NMC)
+              | 24 > | Pretoria (RSMC)
+              | 25 > | La Reunion (RSMC)
+              | 26 > | Khabarovsk (RSMC)
+              | 27 > | Khabarovsk (RSMC)
+              | 28 > | New Delhi (RSMC)
+              | 29 > | New Delhi (RSMC)
+              | 30 > | Novosibirsk (RSMC)
+              | 31 > | Novosibirsk (RSMC)
+              | 32 > | Tashkent (RSMC)
+              | 33 > | Jeddah (RSMC)
+              | 34 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 35 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 36 > | Bangkok
+              | 37 > | Ulaanbaatar
+              | 38 > | Beijing (RSMC)
+              | 39 > | Beijing (RSMC)
+              | 40 > | Seoul
+              | 41 > | Buenos Aires (RSMC)
+              | 42 > | Buenos Aires (RSMC)
+              | 43 > | Brasilia (RSMC)
+              | 44 > | Brasilia (RSMC)
+              | 45 > | Santiago
+              | 46 > | Brazilian Space Agency - INPE
+              | 47 > | Colombia (NMC)
+              | 48 > | Ecuador (NMC)
+              | 49 > | Peru (NMC)
+              | 50 > | Venezuela (NMC)
+              | 51 > | Miami (RSMC)
+              | 52 > | Miami (RSMC), National Hurricane Center
+              | 53 > | MSC Monitoring
+              | 54 > | Montreal (RSMC)
+              | 55 > | San Francisco
+              | 56 > | ARINC Centre
+              | 57 > | U.S. Air Force Global Weather Central
+              | 58 > | Fleet Numerical Meteorology and Oceanography Center, Monterey, CA, USA
+              | 59 > | NOAA Forecast Systems Laboratory, Boulder, CO, USA
+              | 60 > | United States National Centre for Atmospheric Research (NCAR)
+              | 61 > | Service ARGOS - Landover
+              | 62 > | U.S. Naval Oceanographic Office
+              | 63 > | International Research Institute for Climate and Society (IRI)
+              | 64 > | Honolulu (RSMC)
+              | 65 > | Darwin (RSMC)
+              | 66 > | Darwin (RSMC)
+              | 67 > | Melbourne (RSMC)
+              | 69 > | Wellington (RSMC)
+              | 70 > | Wellington (RSMC)
+              | 71 > | Nadi (RSMC)
+              | 72 > | Singapore
+              | 73 > | Malaysia (NMC)
+              | 74 > | UK Meteorological Office, Exeter (RSMC)
+              | 75 > | UK Meteorological Office, Exeter (RSMC)
+              | 76 > | Moscow (RSMC)
+              | 78 > | Offenbach (RSMC)
+              | 79 > | Offenbach (RSMC)
+              | 80 > | Rome (RSMC)
+              | 81 > | Rome (RSMC)
+              | 82 > | Norrkoping
+              | 83 > | Norrkoping
+              | 84 > | Toulouse (RSMC)
+              | 85 > | Toulouse (RSMC)
+              | 86 > | Helsinki
+              | 87 > | Belgrade
+              | 88 > | Oslo
+              | 89 > | Prague
+              | 90 > | Episkopi
+              | 91 > | Ankara
+              | 92 > | Frankfurt/Main
+              | 93 > | London (WAFC)
+              | 94 > | Copenhagen
+              | 95 > | Rota
+              | 96 > | Athens
+              | 97 > | European Space Agency (ESA)
+              | 98 > | European Centre for Medium-Range Weather Forecasts (ECMWF)
+              | 99 > | De Bilt
+              | 100 > | Brazzaville
+              | 101 > | Abidjan
+              | 102 > | Libya (NMC)
+              | 103 > | Madagascar (NMC)
+              | 104 > | Mauritius (NMC)
+              | 105 > | Niger (NMC)
+              | 106 > | Seychelles (NMC)
+              | 107 > | Uganda (NMC)
+              | 108 > | Tanzania (NMC)
+              | 109 > | Zimbabwe (NMC)
+              | 110 > | Hong-Kong, China
+              | 111 > | Afghanistan (NMC)
+              | 112 > | Bahrain (NMC)
+              | 113 > | Bangladesh (NMC)
+              | 114 > | Bhutan (NMC)
+              | 115 > | Cambodia (NMC)
+              | 116 > | Democratic People's Republic of Korea (NMC)
+              | 117 > | Islamic Republic of Iran (NMC)
+              | 118 > | Iraq (NMC)
+              | 119 > | Kazakhstan (NMC)
+              | 120 > | Kuwait (NMC)
+              | 121 > | Kyrgyzstan (NMC)
+              | 122 > | Lao People's Democratic Republic (NMC)
+              | 123 > | Macao, China
+              | 124 > | Maldives (NMC)
+              | 125 > | Myanmar (NMC)
+              | 126 > | Nepal (NMC)
+              | 127 > | Oman (NMC)
+              | 128 > | Pakistan (NMC)
+              | 129 > | Qatar (NMC)
+              | 130 > | Republic of Yemen (NMC)
+              | 131 > | Sri Lanka (NMC)
+              | 132 > | Tajikistan (NMC)
+              | 133 > | Turkmenistan (NMC)
+              | 134 > | United Arab Emirates (NMC)
+              | 135 > | Uzbekistan (NMC)
+              | 136 > | Viet Nam (NMC)
+              | 140 > | Bolivia (NMC)
+              | 141 > | Guyana (NMC)
+              | 142 > | Paraguay (NMC)
+              | 143 > | Suriname (NMC)
+              | 144 > | Uruguay (NMC)
+              | 145 > | French Guyana
+              | 146 > | Brazilian Navy Hydrographic Centre
+              | 147 > | COmision Nacional de Actividades Espaciales (CONAE) - Argentina
+              | 148 > | Brazilian Department of Airspace Control - DECEA
+              | 150 > | Antigua and Barbuda (NMC)
+              | 151 > | Bahamas (NMC)
+              | 152 > | Barbados (NMC)
+              | 153 > | Belize (NMC)
+              | 154 > | British Caribbean Territories Centre
+              | 155 > | San Jose
+              | 156 > | Cuba (NMC)
+              | 157 > | Dominica (NMC)
+              | 158 > | Dominican Republic (NMC)
+              | 159 > | El Salvador (NMC)
+              | 160 > | U.S. NOAA/NESDIS
+              | 161 > | U.S. NOAA Office of Oceanic and Atmospheric Research
+              | 162 > | Guatemala (NMC)
+              | 163 > | Haiti (NMC)
+              | 164 > | Honduras (NMC)
+              | 165 > | Jamaica (NMC)
+              | 166 > | Mexico
+              | 167 > | Curacao and Sint Maarten (NMC)
+              | 168 > | Nicaragua (NMC)
+              | 169 > | Panama (NMC)
+              | 170 > | Saint Lucia (NMC)
+              | 171 > | Trinidad and Tobago (NMC)
+              | 172 > | French Departments in RA IV
+              | 173 > | U.S. National Aeronautics and Space Administration (NASA)
+              | 174 > | Integrated System Data Management/Marine Environmental Data Service (ISDM/MEDS - Canada)
+              | 175 > | University Corporation for Atmospheric Research (UCAR) - United States
+              | 176 > | U.S. Cooperative Institute for Meteorological Satellite Studies (CIMSS)
+              | 177 > | U.S. NOAA National Ocean Service
+              | 178 > | Spire Global, Inc.
+              | 179 > | GeoOptics, Inc.
+              | 180 > | PlanetiQ
+              | 190 > | Cook Islands (NMC)
+              | 191 > | French Polynesia (NMC)
+              | 192 > | Tonga (NMC)
+              | 193 > | Vanuatu (NMC)
+              | 194 > | Brunei Darussalam (NMC)
+              | 195 > | Indonesia (NMC)
+              | 196 > | Kiribati (NMC)
+              | 197 > | Federated States of Micronesia (NMC)
+              | 198 > | New Caledonia (NMC)
+              | 199 > | Niue
+              | 200 > | Papua New Guinea (NMC)
+              | 201 > | Philippines (NMC)
+              | 202 > | Samoa (NMC)
+              | 203 > | Solomon Islands (NMC)
+              | 204 > | National Institute of Water and Atmospheric Research  (NIWA - New Zealand)
+              | 210 > | Frascati (ESA/ESRIN)
+              | 211 > | Lannion
+              | 212 > | Lisboa
+              | 213 > | Reykiavik
+              | 214 > | Madrid
+              | 215 > | Zurich
+              | 216 > | Service ARGOS Toulouse
+              | 217 > | Bratislava
+              | 218 > | Budapest
+              | 219 > | Ljubljana
+              | 220 > | Warsaw
+              | 221 > | Zagreb
+              | 222 > | Albania (NMC)
+              | 223 > | Armenia (NMC)
+              | 224 > | Austria (NMC)
+              | 225 > | Azerbaijan (NMC)
+              | 226 > | Belarus (NMC)
+              | 227 > | Belgium (NMC)
+              | 228 > | Bosnia and Herzegovina (NMC)
+              | 229 > | Bulgaria (NMC)
+              | 230 > | Cyprus (NMC)
+              | 231 > | Estonia (NMC)
+              | 232 > | Georgia (NMC)
+              | 233 > | Dublin
+              | 234 > | Israel (NMC)
+              | 235 > | Jordan (NMC)
+              | 236 > | Latvia (NMC)
+              | 237 > | Lebanon (NMC)
+              | 238 > | Lithuania (NMC)
+              | 239 > | Luxembourg
+              | 240 > | Malta (NMC)
+              | 241 > | Monaco
+              | 242 > | Romania (NMC)
+              | 243 > | Syrian Arab Republic (NMC)
+              | 244 > | The former Yugoslav Republic of Macedonia (NMC)
+              | 245 > | Ukraine (NMC)
+              | 246 > | Republic of Moldova (NMC)
+              | 247 > | Operational Programme for the Exchange of weather RAdar information (OPERA) - EUMETNET
+              | 248 > | Montenegro (NMC)
+              | 249 > | Barcelona Dust Forecast Center
+              | 250 > | COnsortium for Small scale MOdelling  (COSMO)
+              | 251 > | Meteorological Cooperation on Operational NWP (MetCoOp)
+              | 252 > | Max Planck Institute for Meteorology (MPI-M)
+              | 254   | EUMETSAT Operation Centre
+
+  0-01-034 | GSES ; CODE
+           | 0-01-031,0-01-033,0-01-035=34
+              | 0 > | No sub-centre
+              | 207 > | Syowa
+              | 240 > | Kiyose
+              | 241 > | Reanalysis project
+           | 0-01-031,0-01-033,0-01-035=46
+              | 0 > | No sub-centre
+              | 10 > | Cachoeira Paulista (INPE)
+              | 11 > | Cuiaba (INPE)
+              | 12 > | Brasilia (SEPIS-INMET)
+              | 13 > | Fortaleza (FUNCEME)
+              | 14 > | Natal (Navy Hygrog. Centre)
+              | 15 > | Manaus (SIVAM)
+              | 16 > | Natal (INPE)
+              | 17 > | Boa Vista
+              | 18 > | SIPAM-Porto Velho-RO
+              | 19 > | SIPAM-Belem-PA
+              | 25 > | Sao Paulo University - USP
+           | 0-01-031,0-01-033,0-01-035=147
+              | 0 > | No sub-centre
+              | 10 > | Cordoba
+              | 15 > | Ushuaia
+              | 20 > | Marambio
+              | 30 > | Santiago de Chile
+              | 40 > | Punta Arenas
+              | 50 > | Base Presidente Frei
+              | 60 > | Cotopaxi
+           | 0-01-031,0-01-033,0-01-035=72
+              | 0 > | No sub-centre
+              | 249 > | Singapore
+           | 0-01-031,0-01-033,0-01-035=227
+              | 0 > | No sub-centre
+              | 1 > | Luxembourg (NMC)
+           | 0-01-031,0-01-033,0-01-035=254
+              | 0 > | No sub-centre
+              | 10 > | Tromso (Norway)
+              | 20 > | Maspalomas (Spain)
+              | 30 > | Kangerlussuaq (Greenland)
+              | 40 > | Edmonton (Canada)
+              | 50 > | Bedford (Canada)
+              | 60 > | Gander (Canada)
+              | 70 > | Monterey (USA)
+              | 80 > | Wallops Island (USA)
+              | 90 > | Gilmor Creek (USA)
+              | 100 > | Athens (Greece)
+              | 120 > | Ewa Beach, Hawaii
+              | 125 > | Ford Island, Hawaii
+              | 130 > | Miami, Florida
+              | 140 > | Lannion (France)
+              | 150 > | Svalbard (Norway)
+              | 170 > | St Denis (La Reunion)
+              | 180 > | Moscow
+              | 190 > | Muscat
+              | 200 > | Khabarovsk
+              | 210 > | Novosibirsk
+           | 0-01-031,0-01-033,0-01-035=80
+              | 0 > | No sub-centre
+              | 101 > | Albania (NMC)
+              | 102 > | National Research Council/Institute of Atmospheric Sciences and Climate (CNR-ISAC)
+           | 0-01-031,0-01-033,0-01-035=40
+              | 0 > | No sub-centre
+              | 243 > | Seoul
+              | 245 > | Jincheon
+           | 0-01-031,0-01-033,0-01-035=96
+              | 0 > | No sub-centre
+              | 1 > | Cyprus (NMC)
+           | 0-01-031,0-01-033,0-01-035=2
+              | 0 > | No sub-centre
+              | 201 > | Casey
+              | 203 > | Davis
+              | 210 > | Alice Springs
+              | 211 > | Melbourne Crib Point 1
+              | 214 > | Darwin
+              | 217 > | Perth
+              | 219 > | Townsville
+              | 232 > | Fiji
+              | 235 > | Noumea
+              | 237 > | Papeete
+              | 250 > | Vladivostock
+              | 251 > | Guam
+              | 252 > | Honolulu
+           | 0-01-031,0-01-033,0-01-035=176
+              | 0 > | No sub-centre
+              | 10 > | Tromso (Norway)
+              | 11 > | McMurdo (Antarctica)
+              | 12 > | Sodankyla (Finland)
+              | 13 > | Fairbanks (USA)
+              | 14 > | Barrow (USA)
+              | 15 > | Rothera (Antarctica)
+              | 20 > | Honolulu (United States)
+              | 21 > | Gilmore Creek (United States)
+              | 22 > | Madison (United States)
+              | 23 > | Miami (United States)
+              | 24 > | Mayaguez (Puerto Rico)
+              | 25 > | Monterey (United States)
+              | 26 > | Guam
+              | 27 > | Corvallis (United States)
+              | 28 > | Hampton (United States)
+              | 29 > | New York City (United States)
+           | 0-01-031,0-01-033,0-01-035=161
+              | 0 > | No sub-centre
+              | 1 > | Great Lakes Environmental Research Laboratory
+              | 2 > | Earth System Research Laboratory
+              | 3 > | Atlantic Oceanographic and Meteorological Laboratory
+              | 4 > | Pacific Marine Environmental Laboratory
+              | 5 > | Air Resources Laboratory
+              | 6 > | Geophysical Fluid Dynamics Laboratory
+              | 7 > | National Severe Storms Laboratory
+           | 0-01-031,0-01-033,0-01-035=74
+              | 0 > | No sub-centre
+              | 1 > | Shanwick Oceanic Area Control Centre
+              | 2 > | Fucino
+              | 3 > | Gatineau
+              | 4 > | Maspalomas
+              | 5 > | ESA ERS Central Facility
+              | 6 > | Prince Albert
+              | 7 > | West Freugh
+              | 13 > | Tromso
+              | 21 > | Agenzia Spaziale Italiana (Italy)
+              | 22 > | Centre National de la Recherche Scientifique (France)
+              | 23 > | GeoForschungs Zentrum (Germany)
+              | 24 > | Geodetic Observatory Pecny (Czech Republic)
+              | 25 > | Institut d'Estudis Espacials de Catalunya (Spain)
+              | 26 > | Federal Office of Topography (Switzerland)
+              | 27 > | Nordic Commission of Geodesy (Norway)
+              | 28 > | Nordic Commission of Geodesy (Sweden)
+              | 29 > | Institute Geographique National (France) - Service de geodesie
+              | 30 > | Bundesamt fur Kartographie und Geodasie (Germany)
+              | 31 > | Institute of Engineering Satellite Surveying and Geodesy (U.K.)
+              | 32 > | Joint Operational Meteorology and Oceanography Centre (JOMOC)
+              | 33 > | Koninklijk Nederlands Meteorologisch Institut (Netherlands)
+              | 34 > | Nordic GPS Atmospheric Analysis centre (Sweden)
+              | 35 > | Instituto Geografico Nacional de Espana (Spain)
+              | 36 > | Met Eireann (Ireland)
+              | 37 > | Royal Observatory of Belgium (Belgium)
+           | 0-01-031,0-01-033,0-01-035=250
+              | 0 > | No sub-centre
+              | 76 > | RHM (Russia)
+              | 78 > | DWD (Germany)
+              | 80 > | USAM (Italy)
+              | 96 > | HNMS (Greece)
+              | 215 > | MCH (Switzerland)
+              | 220 > | IMGW (Poland)
+              | 242 > | NMA (Romania)
+           | 0-01-031,0-01-033,0-01-035=39
+              | 0 > | No sub-centre
+              | 225 > | Beijing
+              | 226 > | Guangzhou
+              | 228 > | Urumuqi
+           | 0-01-031,0-01-033,0-01-035=145
+              | 1 > | DBNet station of Cayenne (French Guyana)
+           | 0-01-031,0-01-033,0-01-035=89
+              | 0 > | No sub-centre
+              | 1 > | Solar and Ozone Observatory Hradec Kralove
+           | 0-01-031,0-01-033,0-01-035=78
+              | 0 > | No sub-centre
+              | 10 > | POLARA (Polarimetric Radar Algorithms instance)
+              | 64 > | Bundeswehr Geoinformation Office (BGIO)
+              | 110 > | NowCast mobile (Lightning data)
+              | 221 > | Schleswig-Holstein, Traffic Operations Computing Center (TOCC) Kiel/Neumunster
+              | 222 > | Hamburg, TOCC Hamburg
+              | 223 > | Niedersachsen, TOCC Hannover
+              | 224 > | Austria (NMC)
+              | 225 > | Nordrhein-Westfalen, TOCC Kamen
+              | 226 > | Hessen, TOCC Russelsheim
+              | 227 > | Rheinland-Pfalz, TOCC Koblenz
+              | 228 > | Baden-Wurttemberg, TOCC Ludwigsburg
+              | 229 > | Bayern, TOCC Freimann
+              | 230 > | Saarland, TOCC Rohrbach
+              | 231 > | Bayern, Autobahn directorate Nordbayern
+              | 232 > | Brandenburg, TOCC Stolpe
+              | 233 > | Mecklenburg-Vorpommern, TOCC Malchow
+              | 234 > | Sachsen, TOCC Dresden
+              | 235 > | Sachsen-Anhalt, TOCC Halle
+              | 236 > | Thuringen, TOCC Erfurt
+              | 237 > | EasyWay - Meteotrans
+              | 254 > | EUMETSAT
+           | 0-01-031,0-01-033,0-01-035=85
+              | 0 > | No sub-centre
+              | 200 > | Institut National de l'Environnement Industriel et des Risques (France)
+              | 201 > | Rheinisches Institut fur Umweltforschung an der Universitat zu Koln E.V. (Germany)
+              | 202 > | Institut Francais de Recherche pour l'Exploitation de la Mer
+              | 203 > | Aarhus University (Denmark)
+              | 204 > | Institute of Environmental Protection - National Research Institute (Poland)
+           | 0-01-031,0-01-033,0-01-035=177
+              | 0 > | No sub-centre
+              | 1 > | Center for Operational Oceanographic Products and Services
+              | 2 > | Coastal Survey Development Laboratory
+           | 0-01-031,0-01-033,0-01-035=173
+              | 0 > | No sub-centre
+              | 1 > | Ames Research Center
+              | 2 > | Dryden Flight Research Center
+              | 3 > | Glenn Research Center
+              | 4 > | Goddard Space Flight Center
+              | 5 > | Jet Propulsion Laboratory
+              | 6 > | Johnson Space Center
+              | 7 > | Kennedy Space Center
+              | 8 > | Langley Research Center
+              | 9 > | Marshall Space Flight Center
+              | 10 > | Stennis Space Center
+              | 11 > | Goddard Institute for Space Studies
+              | 12 > | Independent Verification and Validation Facility
+              | 13 > | NASA Shared Service Center
+              | 14 > | Wallops Flight Facility
+           | 0-01-031,0-01-033,0-01-035=110
+              | 0 > | No sub-centre
+              | 229 > | Hong-Kong
+           | 0-01-031,0-01-033,0-01-035=7
+              | 0 > | No sub-centre
+              | 1 > | NCEP Reanalysis Project
+              | 2 > | NCEP Ensemble Products
+              | 3 > | NCEP Central Operations
+              | 4 > | Environmental Modeling Center
+              | 5 > | Weather Prediction Center
+              | 6 > | Ocean Prediction Center
+              | 7 > | Climate Prediction Center
+              | 8 > | Aviation Weather Center
+              | 9 > | Storm Prediction Center
+              | 10 > | National Hurricane Center
+              | 11 > | NWS Techniques Development Laboratory
+              | 12 > | NESDIS Office of Research and Applications
+              | 13 > | Federal Aviation Administration
+              | 14 > | NWS Meteorological Development Laboratory
+              | 15 > | North American Regional Reanalysis Project
+              | 16 > | Space Weather Prediction Center
+              | 17 > | ESRL Global Systems Division
+           | 0-01-031,0-01-033,0-01-035=204
+              | 0 > | No sub-centre
+              | 101 > | Maupuia
+              | 102 > | Lauder
+           | 0-01-031,0-01-033,0-01-035=191
+              | 0 > | No sub-centre
+              | 1 > | RARS station of Tahiti (French Polynesia)
+           | 0-01-031,0-01-033,0-01-035=69
+              | 0 > | No sub-centre
+              | 204 > | National Institute of Water and Atmospheric Research (NIWA - New Zealand)
+              | 205 > | Niue
+              | 206 > | Raotonga (Cook Islands)
+              | 207 > | Apia (Samoa)
+              | 208 > | Tonga
+              | 209 > | Tuvalu
+              | 210 > | Kiribati
+              | 211 > | Tokelau
+              | 243 > | Kelburn
+           | 0-01-031,0-01-033,0-01-035=160
+              | 0 > | No sub-centre
+              | 1 > | National Climatic Data Center
+              | 2 > | National Geophysical Data Center
+              | 3 > | National Oceanographic Data Center
+              | 4 > | Center for Satellite Applications and Research (STAR)
+              | 5 > | Joint Polar Satellite System
+              | 10 > | Tromso (Norway)
+              | 11 > | McMurdo (Antarctica)
+           | 0-01-031,0-01-033,0-01-035=148
+              | 1   | Integrated Centre of Aeronautical Meteorology - CIMAER
+
+  0-01-035 | ORIGC ; CODE
+              | 0 > | WMO Secretariat
+              | 1 > | Melbourne
+              | 2 > | Melbourne
+              | 3 > | Melbourne
+              | 4 > | Moscow
+              | 5 > | Moscow
+              | 6 > | Moscow
+              | 7 > | U.S. National Weather Service, National Centres for Environmental Prediction (NCEP)
+              | 8 > | U.S. National Weather Service Telecommunications Gateway (NWSTG)
+              | 9 > | U.S. National Weather Service - Other
+              | 10 > | Cairo (RSMC)
+              | 11 > | Cairo (RSMC)
+              | 12 > | Dakar (RSMC)
+              | 13 > | Dakar (RSMC)
+              | 14 > | Nairobi (RSMC)
+              | 15 > | Nairobi (RSMC)
+              | 16 > | Casablanca (RSMC)
+              | 17 > | Tunis (RSMC)
+              | 18 > | Tunis Casablanca (RSMC)
+              | 19 > | Tunis Casablanca (RSMC)
+              | 20 > | Las Palmas
+              | 21 > | Algiers (RSMC)
+              | 22 > | ACMAD
+              | 23 > | Mozambique (NMC)
+              | 24 > | Pretoria (RSMC)
+              | 25 > | La Reunion (RSMC)
+              | 26 > | Khabarovsk (RSMC)
+              | 27 > | Khabarovsk (RSMC)
+              | 28 > | New Delhi (RSMC)
+              | 29 > | New Delhi (RSMC)
+              | 30 > | Novosibirsk (RSMC)
+              | 31 > | Novosibirsk (RSMC)
+              | 32 > | Tashkent (RSMC)
+              | 33 > | Jeddah (RSMC)
+              | 34 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 35 > | Tokyo (RSMC), Japan Meteorological Agency
+              | 36 > | Bangkok
+              | 37 > | Ulaanbaatar
+              | 38 > | Beijing (RSMC)
+              | 39 > | Beijing (RSMC)
+              | 40 > | Seoul
+              | 41 > | Buenos Aires (RSMC)
+              | 42 > | Buenos Aires (RSMC)
+              | 43 > | Brasilia (RSMC)
+              | 44 > | Brasilia (RSMC)
+              | 45 > | Santiago
+              | 46 > | Brazilian Space Agency - INPE
+              | 47 > | Colombia (NMC)
+              | 48 > | Ecuador (NMC)
+              | 49 > | Peru (NMC)
+              | 50 > | Venezuela (NMC)
+              | 51 > | Miami (RSMC)
+              | 52 > | Miami (RSMC), National Hurricane Center
+              | 53 > | MSC Monitoring
+              | 54 > | Montreal (RSMC)
+              | 55 > | San Francisco
+              | 56 > | ARINC Centre
+              | 57 > | U.S. Air Force Global Weather Central
+              | 58 > | Fleet Numerical Meteorology and Oceanography Center, Monterey, CA, USA
+              | 59 > | NOAA Forecast Systems Laboratory, Boulder, CO, USA
+              | 60 > | United States National Centre for Atmospheric Research (NCAR)
+              | 61 > | Service ARGOS - Landover
+              | 62 > | U.S. Naval Oceanographic Office
+              | 63 > | International Research Institute for Climate and Society (IRI)
+              | 64 > | Honolulu (RSMC)
+              | 65 > | Darwin (RSMC)
+              | 66 > | Darwin (RSMC)
+              | 67 > | Melbourne (RSMC)
+              | 69 > | Wellington (RSMC)
+              | 70 > | Wellington (RSMC)
+              | 71 > | Nadi (RSMC)
+              | 72 > | Singapore
+              | 73 > | Malaysia (NMC)
+              | 74 > | UK Meteorological Office, Exeter (RSMC)
+              | 75 > | UK Meteorological Office, Exeter (RSMC)
+              | 76 > | Moscow (RSMC)
+              | 78 > | Offenbach (RSMC)
+              | 79 > | Offenbach (RSMC)
+              | 80 > | Rome (RSMC)
+              | 81 > | Rome (RSMC)
+              | 82 > | Norrkoping
+              | 83 > | Norrkoping
+              | 84 > | Toulouse (RSMC)
+              | 85 > | Toulouse (RSMC)
+              | 86 > | Helsinki
+              | 87 > | Belgrade
+              | 88 > | Oslo
+              | 89 > | Prague
+              | 90 > | Episkopi
+              | 91 > | Ankara
+              | 92 > | Frankfurt/Main
+              | 93 > | London (WAFC)
+              | 94 > | Copenhagen
+              | 95 > | Rota
+              | 96 > | Athens
+              | 97 > | European Space Agency (ESA)
+              | 98 > | European Centre for Medium-Range Weather Forecasts (ECMWF)
+              | 99 > | De Bilt
+              | 100 > | Brazzaville
+              | 101 > | Abidjan
+              | 102 > | Libya (NMC)
+              | 103 > | Madagascar (NMC)
+              | 104 > | Mauritius (NMC)
+              | 105 > | Niger (NMC)
+              | 106 > | Seychelles (NMC)
+              | 107 > | Uganda (NMC)
+              | 108 > | Tanzania (NMC)
+              | 109 > | Zimbabwe (NMC)
+              | 110 > | Hong-Kong, China
+              | 111 > | Afghanistan (NMC)
+              | 112 > | Bahrain (NMC)
+              | 113 > | Bangladesh (NMC)
+              | 114 > | Bhutan (NMC)
+              | 115 > | Cambodia (NMC)
+              | 116 > | Democratic People's Republic of Korea (NMC)
+              | 117 > | Islamic Republic of Iran (NMC)
+              | 118 > | Iraq (NMC)
+              | 119 > | Kazakhstan (NMC)
+              | 120 > | Kuwait (NMC)
+              | 121 > | Kyrgyzstan (NMC)
+              | 122 > | Lao People's Democratic Republic (NMC)
+              | 123 > | Macao, China
+              | 124 > | Maldives (NMC)
+              | 125 > | Myanmar (NMC)
+              | 126 > | Nepal (NMC)
+              | 127 > | Oman (NMC)
+              | 128 > | Pakistan (NMC)
+              | 129 > | Qatar (NMC)
+              | 130 > | Republic of Yemen (NMC)
+              | 131 > | Sri Lanka (NMC)
+              | 132 > | Tajikistan (NMC)
+              | 133 > | Turkmenistan (NMC)
+              | 134 > | United Arab Emirates (NMC)
+              | 135 > | Uzbekistan (NMC)
+              | 136 > | Viet Nam (NMC)
+              | 140 > | Bolivia (NMC)
+              | 141 > | Guyana (NMC)
+              | 142 > | Paraguay (NMC)
+              | 143 > | Suriname (NMC)
+              | 144 > | Uruguay (NMC)
+              | 145 > | French Guyana
+              | 146 > | Brazilian Navy Hydrographic Centre
+              | 147 > | COmision Nacional de Actividades Espaciales (CONAE) - Argentina
+              | 148 > | Brazilian Department of Airspace Control - DECEA
+              | 150 > | Antigua and Barbuda (NMC)
+              | 151 > | Bahamas (NMC)
+              | 152 > | Barbados (NMC)
+              | 153 > | Belize (NMC)
+              | 154 > | British Caribbean Territories Centre
+              | 155 > | San Jose
+              | 156 > | Cuba (NMC)
+              | 157 > | Dominica (NMC)
+              | 158 > | Dominican Republic (NMC)
+              | 159 > | El Salvador (NMC)
+              | 160 > | U.S. NOAA/NESDIS
+              | 161 > | U.S. NOAA Office of Oceanic and Atmospheric Research
+              | 162 > | Guatemala (NMC)
+              | 163 > | Haiti (NMC)
+              | 164 > | Honduras (NMC)
+              | 165 > | Jamaica (NMC)
+              | 166 > | Mexico
+              | 167 > | Curacao and Sint Maarten (NMC)
+              | 168 > | Nicaragua (NMC)
+              | 169 > | Panama (NMC)
+              | 170 > | Saint Lucia (NMC)
+              | 171 > | Trinidad and Tobago (NMC)
+              | 172 > | French Departments in RA IV
+              | 173 > | U.S. National Aeronautics and Space Administration (NASA)
+              | 174 > | Integrated System Data Management/Marine Environmental Data Service (ISDM/MEDS - Canada)
+              | 175 > | University Corporation for Atmospheric Research (UCAR) - United States
+              | 176 > | U.S. Cooperative Institute for Meteorological Satellite Studies (CIMSS)
+              | 177 > | U.S. NOAA National Ocean Service
+              | 178 > | Spire Global, Inc.
+              | 179 > | GeoOptics, Inc.
+              | 180 > | PlanetiQ
+              | 190 > | Cook Islands (NMC)
+              | 191 > | French Polynesia (NMC)
+              | 192 > | Tonga (NMC)
+              | 193 > | Vanuatu (NMC)
+              | 194 > | Brunei Darussalam (NMC)
+              | 195 > | Indonesia (NMC)
+              | 196 > | Kiribati (NMC)
+              | 197 > | Federated States of Micronesia (NMC)
+              | 198 > | New Caledonia (NMC)
+              | 199 > | Niue
+              | 200 > | Papua New Guinea (NMC)
+              | 201 > | Philippines (NMC)
+              | 202 > | Samoa (NMC)
+              | 203 > | Solomon Islands (NMC)
+              | 204 > | National Institute of Water and Atmospheric Research  (NIWA - New Zealand)
+              | 210 > | Frascati (ESA/ESRIN)
+              | 211 > | Lannion
+              | 212 > | Lisboa
+              | 213 > | Reykiavik
+              | 214 > | Madrid
+              | 215 > | Zurich
+              | 216 > | Service ARGOS Toulouse
+              | 217 > | Bratislava
+              | 218 > | Budapest
+              | 219 > | Ljubljana
+              | 220 > | Warsaw
+              | 221 > | Zagreb
+              | 222 > | Albania (NMC)
+              | 223 > | Armenia (NMC)
+              | 224 > | Austria (NMC)
+              | 225 > | Azerbaijan (NMC)
+              | 226 > | Belarus (NMC)
+              | 227 > | Belgium (NMC)
+              | 228 > | Bosnia and Herzegovina (NMC)
+              | 229 > | Bulgaria (NMC)
+              | 230 > | Cyprus (NMC)
+              | 231 > | Estonia (NMC)
+              | 232 > | Georgia (NMC)
+              | 233 > | Dublin
+              | 234 > | Israel (NMC)
+              | 235 > | Jordan (NMC)
+              | 236 > | Latvia (NMC)
+              | 237 > | Lebanon (NMC)
+              | 238 > | Lithuania (NMC)
+              | 239 > | Luxembourg
+              | 240 > | Malta (NMC)
+              | 241 > | Monaco
+              | 242 > | Romania (NMC)
+              | 243 > | Syrian Arab Republic (NMC)
+              | 244 > | The former Yugoslav Republic of Macedonia (NMC)
+              | 245 > | Ukraine (NMC)
+              | 246 > | Republic of Moldova (NMC)
+              | 247 > | Operational Programme for the Exchange of weather RAdar information (OPERA) - EUMETNET
+              | 248 > | Montenegro (NMC)
+              | 249 > | Barcelona Dust Forecast Center
+              | 250 > | COnsortium for Small scale MOdelling  (COSMO)
+              | 251 > | Meteorological Cooperation on Operational NWP (MetCoOp)
+              | 252 > | Max Planck Institute for Meteorology (MPI-M)
+              | 254 > | EUMETSAT Operation Centre
+              | 256 > | Angola (NMC)
+              | 257 > | Benin (NMC)
+              | 258 > | Botswana (NMC)
+              | 259 > | Burkina Faso (NMC)
+              | 260 > | Burundi (NMC)
+              | 261 > | Cameroon (NMC)
+              | 262 > | Cape Verde (NMC)
+              | 263 > | Central African Republic (NMC)
+              | 264 > | Chad (NMC)
+              | 265 > | Comoros (NMC)
+              | 266 > | Democratic Republic of the Congo (NMC)
+              | 267 > | Djibouti (NMC)
+              | 268 > | Eritrea (NMC)
+              | 269 > | Ethiopia (NMC)
+              | 270 > | Gabon (NMC)
+              | 271 > | Gambia (NMC)
+              | 272 > | Ghana (NMC)
+              | 273 > | Guinea (NMC)
+              | 274 > | Guinea Bissau (NMC)
+              | 275 > | Lesotho (NMC)
+              | 276 > | Liberia (NMC)
+              | 277 > | Malawi (NMC)
+              | 278 > | Mali (NMC)
+              | 279 > | Mauritania (NMC)
+              | 280 > | Namibia (NMC)
+              | 281 > | Nigeria (NMC)
+              | 282 > | Rwanda (NMC)
+              | 283 > | Sao Tome and Principe (NMC)
+              | 284 > | Sierra Leone (NMC)
+              | 285 > | Somalia (NMC)
+              | 286 > | Sudan (NMC)
+              | 287 > | Swaziland (NMC)
+              | 288 > | Togo (NMC)
+              | 289 > | Zambia (NMC)
+              | 290 > | EUMETNET E-Profile
+              | 291 > | The Institute of Atmospheric Physics (IAP) of Chinese Academy of Sciences (CAS)
+              | 292   | Helmholtz Centre for Environmental Research (UFZ)
+
+  0-01-036 | AOOP ; CODE
+              | 36001 > | Australia, Bureau of Meteorology (BOM)
+              | 36002 > | Australia, Joint Australian Facility for Ocean Observing Systems (JAFOOS)
+              | 36003 > | Australia, the Commonwealth Scientific and Industrial Research Organisation (CSIRO)
+              | 124001 > | Canada, Marine Environmental Data Service (MEDS)
+              | 124002 > | Canada, Institute of Ocean Sciences (IOS)
+              | 124173 > | Canada, Environment Canada
+              | 124174 > | Canada, Department of National Defense
+              | 124175 > | Canada, Nav Canada
+              | 156001 > | China, The State Oceanic Administration
+              | 156002 > | China, Second Institute of Oceanography State Oceanic Administration
+              | 156003 > | China, Institute of Ocean Technology
+              | 250001 > | France, Institut de Recherche pour le Developpement (IRD)
+              | 250002 > | France, Institut Francais de Recherche pour l'Exploitation de la mer (IFREMER)
+              | 276001 > | Germany, Bundesamt fuer Seeschiffahrt und Hydrographie (BSH)
+              | 276002 > | Germany, Institut fuer Meereskunde, Kiel
+              | 356001 > | India, National Institute of Oceanography (NIO)
+              | 356002 > | India, National Institute for Ocean Technology (NIOT)
+              | 356003 > | India, National Centre for Ocean Information Service
+              | 392001 > | Japan, Japan Meteorological Agency (JMA)
+              | 392002 > | Japan, Frontier Observational Research System for Global Change
+              | 392003 > | Japan, Japan Marine Science and Technology Centre (JAMSTEC)
+              | 410001 > | Republic of Korea, Seoul National University
+              | 410002 > | Republic of Korea, Korea Ocean Research and Development Institute  (KORDI)
+              | 410003 > | Republic of Korea, Meteorological Research Institute
+              | 540001 > | New Caledonia, Institut de Recherche pour le Developpement (IRD)
+              | 554001 > | New Zealand, National Institute of Water and Atmospheric Research (NIWA)
+              | 643001 > | Russia, State Oceanographic Institute of Roshydromet
+              | 643002 > | Russia, Federal Service for Hydrometeorology and Environmental Monitoring
+              | 724001 > | Spain, Instituto Espanol de Oceanografia
+              | 826001 > | United Kingdom, Hydrographic Office
+              | 826002 > | United Kingdom, Southampton Oceanography Centre (SOC)
+              | 826003 > | United Kingdom, Centre for Environment, Fisheries and Aquaculture (Cefas)
+              | 826004 > | United Kingdom, Marine Scotland (MS)
+              | 826005 > | United Kingdom, Plymouth Marine Laboratory (PML)
+              | 826006 > | United Kingdom, British Antarctic Survey (BAS)
+              | 840001 > | USA, NOAA Atlantic Oceanographic and Meteorological Laboratories (AOML)
+              | 840002 > | USA, NOAA Pacific Marine Environmental Laboratories (PMEL)
+              | 840003 > | USA, Scripps Institution of Oceanography (SIO)
+              | 840004 > | USA, Woods Hole Oceanographic Institution (WHOI)
+              | 840005 > | USA, University of Washington
+              | 840006   | USA, Naval Oceanographic Office
+
+  0-01-038 | SSIF ; CODE
+              | 0 > | No sea ice set
+              | 1 > | NSIDC SSM/I Cavalieri et al (1992)
+              | 2 > | AMSR-E
+              | 3 > | ECMWF
+              | 4 > | CMS (France) cloud mask used by Medspiration
+              | 5   | EUMETSAT OSI-SAF
+
+  0-01-044 | GNAPS ; CODE
+              | 1 > | Full weighted mixture of individual quality tests
+              | 2 > | Weighted mixture of individual tests, but excluding forecast comparison
+              | 3 > | Recursive filter function
+              | 4 > | Common quality index (QI) without forecast
+              | 5 > | QI without forecast
+              | 6 > | QI with forecast
+              | 7   | Estimated Error (EE) in m/s converted to a percent confidence
+
+  0-01-052 | PTIDT ; CODE
+              | 0 > | Primary
+              | 1   | Secondary
+
+  0-01-090 | TMIP ; CODE
+              | 0 > | Lagged-Average Forecasting (LAF)
+              | 1 > | Breeding
+              | 2 > | Singular vectors
+              | 3   | Multiple analysis cycles
+
+  0-01-092 | TOEF ; CODE
+              | 0 > | Unperturbed high-resolution control forecast
+              | 1 > | Unperturbed low-resolution control forecast
+              | 2 > | Negatively perturbed forecast
+              | 3 > | Positively perturbed forecast
+              | 4   | Perturbed forecast
+
+  0-01-101 | STID ; CODE
+              | 100 > | Algeria
+              | 101 > | Angola
+              | 102 > | Benin
+              | 103 > | Botswana
+              | 104 > | Burkina Faso
+              | 105 > | Burundi
+              | 106 > | Cameroon
+              | 107 > | Cape Verde
+              | 108 > | Central African Republic
+              | 109 > | Chad
+              | 110 > | Comoros
+              | 111 > | Congo
+              | 112 > | Cote d'Ivoire
+              | 113 > | Democratic Republic of the Congo
+              | 114 > | Djibouti
+              | 115 > | Egypt
+              | 116 > | Eritrea
+              | 117 > | Ethiopia
+              | 118 > | France (RA I)
+              | 119 > | Gabon
+              | 120 > | Gambia
+              | 121 > | Ghana
+              | 122 > | Guinea
+              | 123 > | Guinea-Bissau
+              | 124 > | Kenya
+              | 125 > | Lesotho
+              | 126 > | Liberia
+              | 127 > | Libya
+              | 128 > | Madagascar
+              | 129 > | Malawi
+              | 130 > | Mali
+              | 131 > | Mauritania
+              | 132 > | Mauritius
+              | 133 > | Morocco
+              | 134 > | Mozambique
+              | 135 > | Namibia
+              | 136 > | Niger
+              | 137 > | Nigeria
+              | 138 > | Portugal (RA I)
+              | 139 > | Rwanda
+              | 140 > | Sao Tom and Prince
+              | 141 > | Senegal
+              | 142 > | Seychelles
+              | 143 > | Sierra Leone
+              | 144 > | Somalia
+              | 145 > | South Africa
+              | 146 > | Spain
+              | 147 > | Sudan
+              | 148 > | Swaziland
+              | 149 > | Togo
+              | 150 > | Tunisia
+              | 151 > | Uganda
+              | 152 > | United Kingdom of Great Britain and Northern Ireland (RA I)
+              | 153 > | United Republic of Tanzania
+              | 154 > | Zambia
+              | 155 > | Zimbabwe
+              | 200 > | Afghanistan
+              | 201 > | Bahrain
+              | 202 > | Bangladesh
+              | 203 > | Bhutan
+              | 204 > | Cambodia
+              | 205 > | China
+              | 206 > | Democratic People's Republic of Korea
+              | 207 > | Hong Kong, China
+              | 208 > | India
+              | 209 > | Iran, Islamic Republic of
+              | 210 > | Iraq
+              | 211 > | Japan
+              | 212 > | Kazakhstan
+              | 213 > | Kuwait
+              | 214 > | Kyrgyzstan
+              | 215 > | Lao People's Democratic Republic
+              | 216 > | Macao, China
+              | 217 > | Maldives
+              | 218 > | Mongolia
+              | 219 > | Myanmar
+              | 220 > | Nepal
+              | 221 > | Oman
+              | 222 > | Pakistan
+              | 223 > | Qatar
+              | 224 > | Republic of Korea
+              | 225 > | Republic of Yemen
+              | 226 > | Russian Federation (RA II)
+              | 227 > | Saudi Arabia
+              | 228 > | Sri Lanka
+              | 229 > | Tajikistan
+              | 230 > | Thailand
+              | 231 > | Turkmenistan
+              | 232 > | United Arab Emirates
+              | 233 > | Uzbekistan
+              | 234 > | Viet Nam
+              | 300 > | Argentina
+              | 301 > | Bolivia
+              | 302 > | Brazil
+              | 303 > | Chile
+              | 304 > | Colombia
+              | 305 > | Ecuador
+              | 306 > | France
+              | 307 > | Guyana
+              | 308 > | Paraguay
+              | 309 > | Peru
+              | 310 > | Suriname
+              | 311 > | Uruguay
+              | 312 > | Venezuela
+              | 400 > | Antigua and Barbuda
+              | 401 > | Bahamas
+              | 402 > | Barbados
+              | 403 > | Belize
+              | 404 > | British Caribbean Territories
+              | 405 > | Canada
+              | 406 > | Colombia
+              | 407 > | Costa Rica
+              | 408 > | Cuba
+              | 409 > | Dominica
+              | 410 > | Dominican Republic
+              | 411 > | El Salvador
+              | 412 > | France (RA IV)
+              | 413 > | Guatemala
+              | 414 > | Haiti
+              | 415 > | Honduras
+              | 416 > | Jamaica
+              | 417 > | Mexico
+              | 418 > | Curacao and Sint Maarten
+              | 419 > | Nicaragua
+              | 420 > | Panama
+              | 421 > | Saint Lucia
+              | 422 > | Trinidad and Tobago
+              | 423 > | United Kingdom of Great Britain and Northern Ireland (RA IV)
+              | 424 > | United States of America (RA IV)
+              | 425 > | Venezuela
+              | 500 > | Australia
+              | 501 > | Brunei Darussalam
+              | 502 > | Cook Islands
+              | 503 > | Fiji
+              | 504 > | French Polynesia
+              | 505 > | Indonesia
+              | 506 > | Kiribati
+              | 507 > | Malaysia
+              | 508 > | Micronesia, Federated States of
+              | 509 > | New Caledonia
+              | 510 > | New Zealand
+              | 511 > | Niue
+              | 512 > | Papua New Guinea
+              | 513 > | Philippines
+              | 514 > | Samoa
+              | 515 > | Singapore
+              | 516 > | Solomon Islands
+              | 517 > | Tonga
+              | 518 > | United Kingdom of Great Britain and Northern Ireland (RA V)
+              | 519 > | United States of America (RA V)
+              | 520 > | Vanuatu
+              | 600 > | Albania
+              | 601 > | Armenia
+              | 602 > | Austria
+              | 603 > | Azerbaijan
+              | 604 > | Belarus
+              | 605 > | Belgium
+              | 606 > | Bosnia and Herzegovina
+              | 607 > | Bulgaria
+              | 608 > | Croatia
+              | 609 > | Cyprus
+              | 610 > | Czech Republic
+              | 611 > | Denmark
+              | 612 > | Estonia
+              | 613 > | Finland
+              | 614 > | France (RA VI)
+              | 615 > | Georgia
+              | 616 > | Germany
+              | 617 > | Greece
+              | 618 > | Hungary
+              | 619 > | Iceland
+              | 620 > | Ireland
+              | 621 > | Israel
+              | 622 > | Italy
+              | 623 > | Jordan
+              | 624 > | Kazakhstan
+              | 625 > | Latvia
+              | 626 > | Lebanon
+              | 627 > | Lithuania
+              | 628 > | Luxembourg
+              | 629 > | Malta
+              | 630 > | Monaco
+              | 631 > | Montenegro
+              | 632 > | Netherlands
+              | 633 > | Norway
+              | 634 > | Poland
+              | 635 > | Portugal (RA VI)
+              | 636 > | Republic of Moldova
+              | 637 > | Romania
+              | 638 > | Russian Federation (RA VI)
+              | 639 > | Serbia
+              | 640 > | Slovakia
+              | 641 > | Slovenia
+              | 642 > | Spain
+              | 643 > | Sweden
+              | 644 > | Switzerland
+              | 645 > | Syrian Arab Republic
+              | 646 > | The Former Yugoslav Republic of Macedonia
+              | 647 > | Turkey
+              | 648 > | Ukraine
+              | 649   | United Kingdom of Great Britain and Northern Ireland (RA VI)
+
+  0-01-150 | CRFS ; CODE
+              | 0 > | WGS84, as used by ICAO since 1998
+              | 1 > | ETRS89, as defined by EPSG::4258
+              | 2 > | NAD83, as defined by EPSG::4269
+              | 3 > | DHDN, as defined by EPSG::4314
+              | 4 > | Ellipsoidal datum using the International Reference Meridian and the International Reference Pole as the prime meridian and prime pole, respectively, and the origin of the International Terrestrial Reference System (ITRS).  International Reference Meridian, International Reference Pole and ITRS are maintained by the International Earth Rotation and Reference Systems Service (IERS).
+              | 5   | Earth-centered, earth-fixed (ECEF) coordinate system or Earth-centred rotational (ECR) system. This is a right-handed Cartesian coordinate system (X, Y, Z) rotating with the Earth. The origin is defined by the centre of mass of the Earth.
+
+  0-01-151 | FMSLRD ; CODE
+              | 0 > | Earth Gravitational Model 1996
+              | 1   | Baltic height system 1977
+
+  0-01-155 | RTRID ; CODE
+              | 0 > | Standard Correct Algorithm (SCA)
+              | 1 > | Standard Correct Algorithm mid-bin (SCA mid-bin)
+              | 2 > | Maximum Likelihood Estimation (MLE)
+              | 3 > | Optimal Estimation Profile (OE-PRO)
+              | 4 > | Group
+              | 5   | Group mid-bin
+
+  0-02-001 | TOST ; CODE
+              | 0 > | Automatic
+              | 1 > | Manned
+              | 2   | Hybrid: both manned and automatic
+
+  0-02-002 | TIWM ; FLAG
+              | 1 > | Certified Instruments
+              | 2 > | Originally measured in knots
+              | 3   | Originally measured in km h**-1
+
+  0-02-003 | A4ME ; CODE
+              | 0 > | Pressure Instrument associated with wind measuring equipment
+              | 1 > | Optical theodolite
+              | 2 > | Radio theodolite
+              | 3 > | Radar
+              | 4 > | VLF-Omega
+              | 5 > | Loran C
+              | 6 > | Wind profiler
+              | 7 > | Satellite navigation
+              | 8 > | Radio-acoustic Sounding System (RASS)
+              | 9 > | Sodar
+              | 10 > | LIDAR
+              | 14   | Pressure instrument associated with wind measuring equipment but pressure element failed during ascent
+
+  0-02-004 | TIEM ; CODE
+              | 0 > | USA open pan evaporimeter (without cover)
+              | 1 > | USA open pan evaporimeter (mesh covered)
+              | 2 > | GGI 3000 evaporimeter (sunken)
+              | 3 > | 20 m**2 tank
+              | 4 > | Others
+              | 5 > | Rice
+              | 6 > | Wheat
+              | 7 > | Maize
+              | 8 > | Sorghum
+              | 9   | Other crops
+
+  0-02-006 | UARSI ; CODE
+              | 1 > | Elastic backscatter lidar
+              | 2 > | Raman backscatter lidar
+              | 3 > | Radar wind profiler
+              | 4 > | Lidar wind profiler
+              | 5 > | Sodar wind profiler
+              | 6 > | Wind profiler
+              | 7   | Lidar
+
+  0-02-007 | TGIT ; CODE
+              | 1 > | Shaft encoder float system
+              | 2 > | Ultrasonic
+              | 3 > | Radar
+              | 4 > | Pressure (single transducer)
+              | 5 > | Pressure (multiple transducer)
+              | 6 > | Pressure (in stilling well)
+              | 7 > | Bubbler pressure
+              | 8 > | Acoustic (with sounding tube)
+              | 9   | Acoustic (in open air)
+
+  0-02-008 | TOFSP ; CODE
+              | 0 > | Fixed platform
+              | 1 > | Mobile offshore drill ship
+              | 2 > | Jack-up rig
+              | 3 > | Semi-submersible platform
+              | 4 > | FPSO (floating production storage and offloading unit)
+              | 5   | Light vessel
+
+  0-02-011 | RATP ; CODE
+              | 1 > | iMet-1-BB (USA)
+              | 2 > | No radiosonde - passive target (e.g. reflector)
+              | 3 > | No radiosonde - active target (e.g. transponder)
+              | 4 > | No radiosonde - passive temperature-humidity profiler
+              | 5 > | No radiosonde - active temperature-humidity profiler
+              | 6 > | No radiosonde - radio acoustic sounder
+              | 7 > | iMet-1-AB (USA)
+              | 8 > | No radiosonde - reserved
+              | 9 > | No radiosonde - system unknown or not specified
+              | 10 > | VIZ type A pressure-commutated (USA)
+              | 11 > | VIZ type B time-commutated (USA)
+              | 12 > | RS SDC (Space Data Corporation - USA)
+              | 13 > | Astor (no longer made - Australia)
+              | 14 > | VIZ MARK I MICROSONDE (USA)
+              | 15 > | EEC Company type 23 (USA)
+              | 16 > | Elin (Austria)
+              | 17 > | Graw G. (Germany)
+              | 18 > | Graw DFM-06 (Germany)
+              | 19 > | Graw M60 (Germany)
+              | 20 > | Indian Meteorological Service MK3 (India)
+              | 21 > | VIZ/Jin Yang MARK I MICROSONDE (Republic of Korea)
+              | 22 > | Meisei RS2-80 (Japan)
+              | 23 > | Mesural FMO 1950A (France)
+              | 24 > | Mesural FMO 1945A (France)
+              | 25 > | Mesural MH73A (France)
+              | 26 > | Meteolabor Basora (Switzerland)
+              | 27 > | AVK MRZ (Russian Federation)
+              | 28 > | Meteorit MARZ2-1 (Russian Federation)
+              | 29 > | Meteorit MARZ2-2 (Russian Federation)
+              | 30 > | Oki RS2-80 (Japan)
+              | 31 > | VIZ/Valcom type A pressure-commutated (Canada)
+              | 32 > | Shanghai Radio (China)
+              | 33 > | UK Met Office MK3 (UK)
+              | 34 > | Vinohrady (Czech Republic)
+              | 35 > | Vaisala RS18 (Finland)
+              | 36 > | Vaisala RS21 (Finland)
+              | 37 > | Vaisala RS80 (Finland)
+              | 38 > | VIZ LOCATE Loran-C (USA)
+              | 39 > | Sprenger E076 (Germany)
+              | 40 > | Sprenger E084 (Germany)
+              | 41 > | Sprenger E085 (Germany
+              | 42 > | Sprenger E086 (Germany)
+              | 43 > | AIR IS - 4A - 1680 (USA)
+              | 44 > | AIR IS - 4A - 1680 X (USA)
+              | 45 > | RS MSS (USA)
+              | 46 > | Air IS - 4A - 403 (USA)
+              | 47 > | Meisei RS2-91 (Japan)
+              | 48 > | VALCOM (Canada)
+              | 49 > | VIZ MARK II (USA)
+              | 50 > | Graw DFM-90 (Germany)
+              | 51 > | VIZ-B2 (USA)
+              | 52 > | Vaisala RS80-57H
+              | 53 > | AVK-RF95 (Russian Federation)
+              | 54 > | Graw DFM-97 (Germany)
+              | 55 > | Meisei RS-016 (Japan)
+              | 56 > | M2K2 (France)
+              | 57 > | Modem M2K2-DC (France)
+              | 58 > | AVK BAR (Russian Federation)
+              | 59 > | Modem M2K2 R 1680 MHz RDF radiosonde with pressure sensor chip (France)
+              | 60 > | Vaisala RS80/MicroCora (Finland)
+              | 61 > | Vaisala RS80/Loran/Digicora I,II or Marwin (Finland)
+              | 62 > | Vaisala RS80/PCCora (Finland)
+              | 63 > | Vaisala RS80/Star (Finland)
+              | 64 > | Orbital Sciences Corporation, Space Data Division, transponder radiosonde, type 909 11-XX, where XX corresponds to the model of the instrument (USA)
+              | 65 > | VIZ transponder radiosonde, model number 1499-520 (USA)
+              | 66 > | Vaisala RS80 /Autosonde (Finland)
+              | 67 > | Vaisala RS80/Digicora III (Finland)
+              | 68 > | AVK RZM-2 (Russian Federation)
+              | 69 > | MARL-A or Vektor-M-RZM-2 (Russian Federation)
+              | 70 > | Vaisala RS92/Star (Finland)
+              | 71 > | Vaisala RS90/Loran/Digicora I,II or Marwin (Finland)
+              | 72 > | Vaisala RS90/PC-Cora (Finland)
+              | 73 > | Vaisala RS90/Autosonde (Finland)
+              | 74 > | Vaisala RS90/Star (Finland)
+              | 75 > | AVK-MRZ-ARMA (Russian Federation)
+              | 76 > | AVK-RF95-ARMA (Russian Federation)
+              | 77 > | GEOLINK GPSonde GL98 (France)
+              | 78 > | Vaisala RS90/Digicora III (Finland)
+              | 79 > | Vaisala RS92/Digicora I,II or Marwin (Finland)
+              | 80 > | Vaisala RS92/Digicora III (Finland)
+              | 81 > | Vaisala RS92/Autosonde (Finland)
+              | 82 > | Sippican MK2 GPS/STAR (USA) with rod thermistor, carbon element and derived pressure
+              | 83 > | Sippican MK2 GPS/W9000 (USA) with rod thermistor, carbon element and derived pressure
+              | 84 > | Sippican MARK II with chip thermistor, carbon element and derived pressure from GPS height
+              | 85 > | Sippican MARK IIA with chip thermistor, carbon element and derived pressure from GPS height
+              | 86 > | Sippican MARK II with chip thermistor, pressure and carbon element
+              | 87 > | Sippican MARK IIA with chip thermistor, pressure and carbon element
+              | 88 > | MARL-A or Vektor-M-MRZ (Russian Federation)
+              | 89 > | MARL-A or Vektor-M-BAR (Russian Federation)
+              | 90 > | Radiosonde not specified or unknown
+              | 91 > | Pressure only radiosonde
+              | 92 > | Pressure only radiosonde plus transponder
+              | 93 > | Pressure only radiosonde plus radar reflector
+              | 94 > | No pressure radiosonde plus transponder
+              | 95 > | No pressure radiosonde plus radar reflector
+              | 96 > | Descending radiosonde
+              | 97 > | iMet-2/iMet-1500 RDF radiosonde with pressure sensor chip (South Africa)
+              | 98 > | iMet-2/iMet-1500 GPS radiosonde with derived pressure from GPS height (South Africa)
+              | 99 > | iMet-2/iMet-3200 GPS radiosonde with derived pressure from GPS height (South Africa)
+              | 110 > | Sippican LMS5 w/Chip Thermistor, duct mounted capacitance relative humidity sensor and derived pressure from GPS height
+              | 111 > | Sippican LMS6 w/Chip Thermistor, external boom mounted capacitance relative humidity sensor, and derived pressure from GPS height
+              | 112 > | Jin Yang RSG-20A with derived pressure from GPS height GL-5000P (Republic of Korea)
+              | 113 > | Vaisala RS92/MARWIN MW32 (Finland)
+              | 114 > | Vaisala RS92/DigiCORA MW41 (Finland)
+              | 115 > | PAZA-12M/Radiotheodolite-UL (Ukraine)
+              | 116 > | PAZA-22/AVK-1 (Ukraine)
+              | 117 > | Graw DFM-09 (Germany)
+              | 119 > | Polus-MRZ-N1 (Russian Federation)
+              | 121 > | Jin Yang 1524LA LORAN-C/GL5000 (Republic of Korea)
+              | 122 > | Meisei RS-11G GPS radiosonde with thermistor, capacitance relative humidity sensor, and derived pressure from GPS height (Japan)
+              | 123 > | Vaisala RS41/DigiCORA MW41 (Finland)
+              | 124 > | Vaisala RS41/AUTOSONDE (Finland)
+              | 125 > | Vaisala RS41/MARWIN MW32 (Finland)
+              | 126 > | Meteolabor SRS-C34/Argus 37 (Switzerland)
+              | 128 > | AVK - AK2-02 (Russian Federation)
+              | 129 > | MARL-A or Vektor-M - AK2-02 (Russian Federation)
+              | 130 > | Meisei RS06G (Japan)
+              | 131 > | Taiyuan GTS1-1/GFE(L) (China)
+              | 132 > | Shanghai GTS1/GFE(L) (China)
+              | 133 > | Nanjing GTS1-2/GFE(L) (China)
+              | 134 > | iMet-4 GPS radiosonde (USA)
+              | 135 > | Meisei iMS-100 GPS radiosonde w/thermistor sensor, capacitance relative humidity sensor, and derived pressure from GPS height (Japan)
+              | 136 > | Meisei iMDS-17 GPS dropsonde w/thermistor sensor, capacitance relative humidity sensor, and capacitance pressure sensor (Japan)
+              | 138 > | WEATHEX WxR-301D with derived pressure from GPS (Republic of Korea)
+              | 141 > | Vaisala RS41 with pressure derived from GPS height/ DigiCORA MW41 (Finland)
+              | 142 > | Vaisala RS41 with pressure derived from GPS height/ AUTOSONDE (Finland)
+              | 143 > | NanJing Daqiao XGP-3G (China)
+              | 144 > | TianJin HuaYunTianYi GTS(U)1 (China)
+              | 145 > | Beijing Changfeng CF-06 (China)
+              | 146 > | Shanghai Changwang GTS3 (China)
+              | 148 > | PAZA-22M/MARL-A
+              | 150 > | Meteolabor SRS-C50/Argus (Switzerland)
+              | 152 > | Vaisala RS92-NGP/Intermet IMS-2000 (USA)
+              | 153 > | AVK - I-2012 (Russian Federation)
+              | 154 > | Graw DFM-17 (Germany)
+              | 160 > | MARL-A or Vektor-M - I-2012 (Russian Federation)
+              | 162 > | MARL-A or Vektor-M - MRZ-3MK (Russian Federation)
+              | 163 > | Modem M20 radiosonde w/thermistor sensor, capacitance relative humidity sensor, and derived pressure from GPS height (France)
+              | 164 > | Modem PilotSonde GPS radiosonde (France)
+              | 165 > | Meteosis MTS-01 (Turkey)
+              | 173 > | MARL-A (Russian Federation) - ASPAN-15 (Kazakhstan)
+              | 177 > | Modem GPSonde M10 (France)
+              | 182 > | Lockheed Martin LMS-6 w/chip thermistor, external boom mounted polymer capacitive relative humidity sensor, capacitive pressure sensor and GPS wind
+              | 183 > | Vaisala RS92-D/Intermet IMS 1500 w/silicon capacitive pressure sensor, capacitive wire temperature sensor, twin thin-film heated polymer capacitive relative humidity sensor and RDF wind
+              | 184 > | iMet-54/iMet-3200/3400 GPS radiosonde with derived pressure from GPS height (South Africa)
+              | 190 > | NCAR research dropsonde NRD94 with GPS and Vaisala RS92-based sensor module (United States)
+              | 191 > | NCAR research dropsonde NRD41 with GPS and Vaisala RS41-based sensor module (United States)
+              | 192 > | Vaisala/NCAR dropsonde RD94 with GPS and Vaisala RS92-based sensor module (Finland/USA)
+              | 193 > | Vaisala/NCAR dropsonde RD41 with GPS and Vaisala RS41-based sensor module (Finland/USA)
+              | 200 > | Nanjing GTS11 (China)
+              | 201 > | Shanghai GTS12 (China)
+              | 202 > | Taiyuan GTS13 (China)
+              | 203   | Shanghai GTS14 (China)
+
+  0-02-013 | SIRC ; CODE
+              | 0 > | No correction
+              | 1 > | CIMO solar corrected and CIMO infrared corrected
+              | 2 > | CIMO solar corrected and infrared corrected
+              | 3 > | CIMO solar corrected only
+              | 4 > | Solar and infrared corrected automatically by radiosonde system
+              | 5 > | Solar corrected automatically by radiosonde system
+              | 6 > | Solar and infrared corrected as specified by country
+              | 7 > | Solar corrected as specified by country
+              | 8 > | Solar and infrared corrected as specified by GRUAN
+              | 9   | Solar corrected as specified by GRUAN
+
+  0-02-014 | TTSS ; CODE
+              | 0 > | No wind finding
+              | 1 > | Automatic with auxiliary optical direction finding
+              | 2 > | Automatic with auxiliary radio direction finding
+              | 3 > | Automatic with auxiliary ranging
+              | 5 > | Automatic with multiple VLF-Omega signals
+              | 6 > | Automatic cross chain Loran-C
+              | 7 > | Automatic with auxiliary wind profiler
+              | 8 > | Automatic satellite navigation
+              | 19 > | Tracking technique not specified
+              | 20 > | Vessel stopped
+              | 21 > | Vessel diverted from original destination
+              | 22 > | Vessel's arrival delayed
+              | 23 > | Container damaged
+              | 24 > | Power failure to container
+              | 29 > | Other problems
+              | 30 > | Major power problems
+              | 31 > | UPS inoperative
+              | 32 > | Receiver hardware problems
+              | 33 > | Receiver software problems
+              | 34 > | Processor hardware problems
+              | 35 > | Processor software problems
+              | 36 > | NAVAID system damaged
+              | 37 > | Shortage of lifting gas
+              | 39 > | Other problems
+              | 40 > | Mechanical defect
+              | 41 > | Material defect (hand launcher)
+              | 42 > | Power failure
+              | 43 > | Control failure
+              | 44 > | Pneumatic/hydraulic failure
+              | 45 > | Other problems
+              | 46 > | Compressor problems
+              | 47 > | Balloon problems
+              | 48 > | Balloon release problems
+              | 49 > | Launcher damaged
+              | 50 > | R/S receiver antenna defect
+              | 51 > | NAVAID antenna defect
+              | 52 > | R/S receiver cabling (antenna) defect
+              | 53 > | NAVAID antenna cabling defect
+              | 59 > | Other problems
+              | 60 > | ASAP communications defect
+              | 61 > | Communications facility rejected data
+              | 62 > | No power at transmitting antenna
+              | 63 > | Antenna cable broken
+              | 64 > | Antenna cable defect
+              | 65 > | Message transmitted power below normal
+              | 69 > | Other problems
+              | 70 > | All systems in normal operation
+              | 99   | Status of system and its components not specified
+
+  0-02-015 | RACP ; CODE
+              | 1 > | Pressure only radiosonde
+              | 2 > | Pressure only radiosonde plus transponder
+              | 3 > | Pressure only radiosonde plus radar reflector
+              | 4 > | No-pressure radiosonde plus transponder
+              | 5   | No-pressure radiosonde plus radar reflector
+
+  0-02-016 | RCONF ; FLAG
+              | 1 > | Train regulator
+              | 2 > | Light unit
+              | 3 > | Parachute
+              | 4   | Rooftop release
+
+  0-02-017 | CAHM ; CODE
+              | 0 > | No corrections
+              | 1 > | Time lag correction provided by the manufacturer
+              | 2 > | Solar radiation correction provided by the manufacturer
+              | 3 > | Solar radiation and time lag correction provided by the manufacturer
+              | 7   | GRUAN solar radiation and time lag correction
+
+  0-02-019 | SIID ; CODE
+              | 8 > | DoD Radiometer SSM/T (Special Sensor Microwave-Temperature)
+              | 9 > | DoD Radiometer SSM/T2 (Special Sensor Microwave-Humidity)
+              | 10 > | BNSC Radiometer AATSR (Advanced along track scanning radiometer)
+              | 11 > | BNSC Radiometer ATSR (Along track scanning radiometer)
+              | 12 > | BNSC Radiometer ATSR-2 (Along track scanning radiometer - 2)
+              | 13 > | BNSC Radiometer MWR (Microwave radiometer)
+              | 14 > | UKSA Radiometer PMR (Pressure modulator radiometer)
+              | 15 > | UKSA Radiometer SCR (Selective Chopper Radiometer)
+              | 30 > | CNES Communications ARGOS
+              | 40 > | CNES Lidar Laser reflectors
+              | 41 > | CNES Lidar DORIS (Doppler orbitography and radio-positioning integrated by satellite)
+              | 42 > | CNES Lidar DORIS-NG (Doppler orbitography and radio-positioning integrated by satellite-NG)
+              | 47 > | CNES Radar altimeter POSEIDON-1 (SSALT1) (Positioning ocean solid Earth ice dynamics orbiting navigator (single frequency solid state radar altimeter))
+              | 48 > | CNES Radar altimeter POSEIDON-2 (SSALT2) (Positioning ocean solid Earth ice dynamics orbiting navigator (double frequency solid state radar altimeter))
+              | 49 > | CNES Radar altimeter POSEIDON-3 (SSALT3) (Advanced microwave radiometer)
+              | 50 > | CNES Imager radiometer ATSR/M (ATSR/M)
+              | 51 > | CNES High resolution optical imager HRG
+              | 52 > | CNES Radiometer HRV (High-resolution visible)
+              | 53 > | CNES Radiometer HRVIR (High-resolution visible and infrared)
+              | 54 > | CNES Radiometer ScaRaB/MV2 (Scanner for Earth's radiation budget)
+              | 55 > | CNES Radiometer POLDER (POLDER)
+              | 56 > | CNES Imaging multi-spectral radiometer IIR (Imaging Infrared Radiometer)
+              | 57 > | ESA/EUMETSAT Radar altimeter POSEIDON-4 (High precision altimetry, dual frequency (C and Ku band) pulse-width limited radar altimeter, synthetic-aperture processing, interleaved Low Rate and High Rate)
+              | 60 > | CNES Spectrometer VEGETATION (VEGETATION)
+              | 61 > | CNES Spectrometer WINDII (WINDII)
+              | 62 > | CNES Altimeter AltiKa (Ka band Radar Altimeter)
+              | 63 > | CNES Rotating multi-beam altimeter SWIM (Surface Waves Investigation and Monitoring)
+              | 80 > | CSA Communications RADARSAT DTT
+              | 81 > | CSA Communications RADARSAT TTC
+              | 85 > | CSA Radar SAR (CSA) (Synthetic aperture radar (CSA))
+              | 90 > | CSA Radiometer MOPITT (Measurements of pollution in the troposphere)
+              | 91 > | CSA Atmospheric chemistry instrument OSIRIS (Optical spectrograph and Infrared imaging system)
+              | 92 > | CSA Limb-scanning sounder ACE-FTS (Atmospheric Chemistry Experiment - Fourier Transform Spectrometer)
+              | 97 > | CSIRO Radiometer Panchromatic imager
+              | 98 > | CRCSS Atmospheric temperature and humidity sounder GPS receiver
+              | 102 > | DLR Radiometer CHAMP GPS sounder (GPS turborogue space receiver (TRSR))
+              | 103 > | DLR Radiometer IGOR (Integrated GPS and Occultation Receiver)
+              | 104 > | NASA GNSS occultation sounder Tri-G (Triple-G (GPS, Galileo, GLONASS))
+              | 116 > | DLR Magnetometer CHAMP gravity package (Accelerometer+GPS) (STAR accelerometer)
+              | 117 > | DLR Magnetometer CHAMP magnetometry package (1 scalar+2 vector magnetometer) (Overhauser magnetometer (OVM) and fluxgate magnetometer (FGM))
+              | 120 > | ESA Communications ENVISAT Comms (Communications package on ENVISAT)
+              | 121 > | ESA Communications ERS Comms (Communication package for ERS)
+              | 130 > | ESA Lidar ALADIN (Atmospheric laser doppler instrument)
+              | 131 > | ESA Lidar ATLID (Atmospheric lidar)
+              | 140 > | ESA Radar AMI/SAR/Image (Active microwave instrumentation image mode)
+              | 141 > | ESA Radar AMI/SAR/wave (Active microwave instrumentation wave mode)
+              | 142 > | ESA Radar AMI/scatterometer (Active microwave instrumentation wind mode)
+              | 143 > | ESA Radar ASAR (ASAR)
+              | 144 > | ESA Imaging microwave ASAR (Advanced synthetic aperture radar (image mode))
+              | 145 > | ESA Imaging microwave ASAR (Advanced synthetic aperture radar (wave mode))
+              | 146 > | ESA Cloud profile and rain radar CPR (Cloud radar)
+              | 147 > | ESA Radar RA-2/MWR (Radar altimeter - 2)
+              | 148 > | ESA Radar RA/MWR (Radar altimeter)
+              | 150 > | ESA Scatterometer SCATTEROMETER (Scatterometer)
+              | 151 > | ESA Imaging radar SAR-C (Synthetic Aperture Radar (C-band))
+              | 152 > | Cross-nadir scanning SW (Sounder TROPOMI Tropospheric Monitoring Instrument)
+              | 161 > | ESA Radiometer MIPAS (Michelson interferometric passive atmosphere sounder)
+              | 162 > | ESA Imaging multi-spectral radiometer (passive microwave) MWR-2 (Microwave radiometer-2)
+              | 163 > | ESA Atmospheric chemistry instrument SOPRANO (Sub-milimetre observation of processes in the absorption noteworthy for ozone)
+              | 170 > | ESA Atmospheric chemistry instrument GOME (Global ozone monitoring experiment)
+              | 172 > | ESA Spectrometer GOMOS (Global ozone monitoring by occultation of stars)
+              | 173 > | ESA Spectrometer ALTIUS (Atmospheric Limb Tracker for Investigation of the Upcoming Stratosphere)
+              | 174 > | ESA Spectrometer MERIS (Medium resolution imaging spectrometer)
+              | 175 > | ESA Spectrometer SCIAMACHY (Scanning imaging absorption spectrometer for atmospheric cartography)
+              | 176 > | ESA Radiometer MIRAS (Microwave Imaging Radiometer Using Aperture Synthesis)
+              | 177 > | ESA Radar Altimeter SIRAL (SAR/Interferometric Radar Altimeter)
+              | 178 > | ESA Radar Altimeter SRAL (Synthetic aperture radar altimeter)
+              | 179 > | Moderate resolution optical imager OLCI (Ocean and land colour imager)
+              | 180 > | Moderate resolution optical imager SLSTR (Sea and land surface temperature radiometer)
+              | 181 > | EUMETSAT Communications METEOSAT Comms (Communications package for METEOSAT)
+              | 182 > | EUMETSAT Communications MSG Comms (Communications package for MSG)
+              | 190 > | ESA/EUMETSAT Scatterometer ASCAT (Advanced scatterometer)
+              | 200 > | EUMETSAT Radiometer GERB (Geostationary Earth radiation budget)
+              | 202 > | ESA/EUMETSAT Radiometer GRAS (GNSS receiver for atmospheric sounding)
+              | 203 > | EUMETSAT Radiometer MHS (Microwave humidity sounder)
+              | 205 > | EUMETSAT Radiometer MVIRI (METEOSAT visible and infrared imager)
+              | 207 > | EUMETSAT Radiometer SEVIRI (Spinning enhanced visible and infrared imager)
+              | 208 > | EUMETSAT Imaging multi-spectral radiometer (vis/IR) VIRI (VIRI)
+              | 210 > | ESA/EUMETSAT/Thales Alenia Space Imager FCI (Flexible Combined Imager)
+              | 211 > | ESA/EUMETSAT/Leonardo Imager LI (Lightning Imager)
+              | 212 > | EUMETSAT/OHB Interferometer IRS (Infrared Sounder)
+              | 213 > | ESA/EUMETSAT/Copernicus - Airbus Spectrometer S4 (Ultraviolet and Near-Infrared Multispectral Spectrometer (S4 UVN))
+              | 220 > | ESA/EUMETSAT Spectrometer GOME-2 (Global ozone monitoring experiment - 2)
+              | 221 > | CNES/EUMETSAT Atmospheric temperature and humidity sounder IASI (Infrared atmospheric sounding interferometer)
+              | 230 > | ESA/EUMETSAT Radiometer 3MI (Multi-viewing Multi-channel Multi-polarisation Imaging)
+              | 231 > | CNES/EUMETSAT Sounder-Interferometer IASI-NG (Infrared Atmospheric Sounding Interferometer - New Generation)
+              | 232 > | DLR/EUMETSAT Radiometer METimage (Meteorological Imager)
+              | 233 > | ESA/EUMETSAT Radiometer MWS (Microwave Sounder)
+              | 234 > | ESA/EUMETSAT Radio Occultation RO (Radio Occultation)
+              | 235 > | ESA/EUMETSAT Spectrometer S5/UVNS (Copernicus Sentinel-5 Ultraviolet Visible Near-infrared and Shortwave-infrared Spectrometer)
+              | 236 > | ESA/EUMETSAT Radiometer ICI (Ice Cloud Imager)
+              | 237 > | ESA/EUMETSAT Radiometer MWI (Microwave Imager)
+              | 238 > | ESA/EUMETSAT Radar SCA (Scatterometer)
+              | 240 > | CAST Communications DCP (Data-collection platform transponder)
+              | 245 > | CAST Radiometer CCD (High-resolution CCD camera)
+              | 246 > | INPE Atmospheric temperature and humidity sounder HSB (Humidity sounder/Brazil)
+              | 248 > | INPE Imaging multi-spectral radiometer (vis/IR) OBA (Observador Brasileiro da Amazonia)
+              | 250 > | CAST Radiometer WFI (Wide field imager)
+              | 255 > | CAST Spectrometer IRMSS (Infrared multispectral scanner)
+              | 260 > | ISRO Precision orbit BSS & FSS transponders
+              | 261 > | ISRO Precision orbit DRT-S&R
+              | 262 > | ISRO Communications INSAT Comms (Communications package for INSAT)
+              | 268 > | ISRO High resolution optical imager HR-PAN (High-resolution panchromatic camera)
+              | 269 > | ISRO Imaging multi-spectral radiometer (passive microwave) MSMR (Multifrequency scanning microwave radiometer)
+              | 270 > | ISRO Imaging multi-spectral radiometer (vis/IR) VHRR (Very high resolution radiometer)
+              | 271 > | ISRO Imaging multi-spectral radiometer (vis/IR) WiFS (Wide field sensor)
+              | 275 > | ISRO High-resolution optical imager AWiFS (Advanced wide field sensor)
+              | 276 > | ISRO High-resolution optical imager LISS-I (Linear imaging self scanner - I)
+              | 277 > | ISRO High-resolution optical imager LISS-II (Linear imaging self scanner - II)
+              | 278 > | ISRO High-resolution optical imager LISS-III (Linear imaging self scanner - III)
+              | 279 > | ISRO High-resolution optical imager LISS-IV (Linear imaging self scanner - IV)
+              | 284 > | ISRO High-resolution optical imager PAN (Panchromatic sensor)
+              | 285 > | ISRO Imaging multi-spectral radiometer (vis/IR) MOS (Modular opto-electronic scanner)
+              | 286 > | ISRO Ocean colour instrument OCM (Ocean colour monitor)
+              | 287 > | ASI ROSA (Radio Occultation Sounder of the Atmosphere)
+              | 288 > | ISRO Scatterometer SCAT (Scatterometer)
+              | 289 > | ISRO Optical imager IMG (Imager)
+              | 290 > | JMA Communications MTSAT Comms (Communications package for MTSAT)
+              | 291 > | JMA Communications Himawari Comms (Communications package for Himawari)
+              | 294 > | JMA Imaging multi-spectral radiometer IMAGER/MTSAT-2 (Imager/MTSAT-2)
+              | 295 > | JMA Imaging multi-spectral radiometer JAMI (Japanese Advanced Meteorological Imager)
+              | 296 > | JMA Imaging multi-spectral radiometer VISSR (Visible and infrared spin scan radiometer)
+              | 297 > | JMA Imaging multi-spectral radiometer AHI (Advanced Himawari Imager)
+              | 300 > | NASA Lidar GLAS (Geoscience laser altimeter system)
+              | 301 > | NASA Precision orbit LRA (Laser retroreflector array)
+              | 302 > | NASA Lidar MBLA (Multi beam laser altimeter)
+              | 303 > | NASA Lidar CALIOP (Cloud-aerosol lidar with orthogonal polarization)
+              | 309 > | NASA Cloud profile and rain radar CPR (Cloudsat) (Cloud profiling radar)
+              | 312 > | NASA Radar NSCAT (NASA scatterometer)
+              | 313 > | NASA Radar SeaWinds (ADEOS II - NASA scatterometer)
+              | 314 > | NASA Radar RapidScat (RapidScat scatterometer)
+              | 330 > | NASA Earth radiation budget radiometer ACRIM (Active cavity radiometer irradiance monitor)
+              | 334 > | NASA Total and profile ozone BUV (Backscatter ultraviolet instrument)
+              | 336 > | NASA High-resolution optical imager ALI (Advanced land imager)
+              | 347 > | NASA High-resolution optical imager ASTER (Advanced spaceborne thermal emission and reflection radiometer)
+              | 348 > | NASA Earth radiation budget radiometer CERES-2 (Cloud and the Earth's radiant energy system)
+              | 351 > | NASA Atmospheric temperature and humidity sounder GPSDR (GPS demonstration receiver)
+              | 353 > | NASA Total and profile ozone HiRDLS (High-resolution dynamics limb sounder)
+              | 354 > | NASA Total and profile ozone HRDI (High-resolution Doppler imager)
+              | 356 > | NASA Radiometer LIS (Lightning imaging sensor)
+              | 358 > | NASA Magnetic field, Auroal imagery Scintillation boundary PEM (Particle environment monitor)
+              | 359 > | NASA Ocean colour instrument SeaWiFS (Sea-viewing wide field-of-view sensor)
+              | 360 > | NASA Earth radiation budget radiometer SUSIM (UARS) (Solar ultraviolet irradiance monitor)
+              | 363 > | NASA Total and profile ozone SBUV/1 (Solar backscatter ultraviolet 1 instrument)
+              | 365 > | NASA Imaging multi-spectral radiometer (passive microwave) TMI (TRMM microwave imager)
+              | 366 > | NASA Imaging multi-spectral radiometer (passive microwave) JMR (JASON-1 microwave radiometer)
+              | 367 > | NASA Imaging multi-spectral radiometer AMR (Positioning ocean solid Earth ice dynamics orbiting navigator (double frequency solid state radar altimeter))
+              | 369 > | NASA Total and profile ozone LIMS (Limb infrared monitor of the stratosphere)
+              | 370 > | NASA Total and profile ozone LRIR (Limb radiance inversion radiometer instrument)
+              | 371 > | NASA Total and profile ozone EPIC (Earth polychromatic imaging camera)
+              | 372 > | NASA Earth radiation budget radiometer NISTAR (NIST advanced radiometer)
+              | 373 > | NASA Magnetic field, auroal imagery scintillation boundary Plasma-Mag
+              | 374 > | NASA Other XPS (XUV photometer system)
+              | 375 > | NASA Imaging multi-spectral radiometer (vis/IR) VIRS (Visible infrared scanner)
+              | 376 > | CNES Multiple direction/polarisation radiometer POLDER II (Polarization and directionality of the Earth's reflectance - II)
+              | 377 > | NASA Earth radiation budget radiometer TIM (Total irradiance monitor)
+              | 379 > | NASA Imaging multi-spectral radiometer (vis/IR) WFC (Wide field camera)
+              | 382 > | NASA Spectro-radiometer CLAES (Cryogenic limb array etalon spectrometer)
+              | 383 > | NASA Spectro-radiometer HALOE (Halogen occultation experiment)
+              | 384 > | NASA Spectro-radiometer ISAMS (Improved stratospheric and mesospheric sounder)
+              | 385 > | NASA Spectro-radiometer MISR (Multi-angle imaging spectroradiometer)
+              | 386 > | NASA Spectro-radiometer MLS (Microwave limb sounder)
+              | 387 > | NASA Spectro-radiometer MLS (EOS-Aura) (Microwave limb sounder (EOS-Aura))
+              | 389 > | NASA Spectro-radiometer MODIS (Moderate-resolution imaging spectroradiometer)
+              | 393 > | NASA Gravity HAIRS (High accuracy inter-satellite ranging system)
+              | 394 > | NASA Total and profile ozone OMI (Ozone measuring instrument)
+              | 395 > | NASA Radiometer Atmospheric corrector (Atmospheric corrector)
+              | 396 > | NASA Radiometer Hyperion (Hyperspectral imager)
+              | 397 > | NASA Radiometer HRIR (High-resolution infrared radiometer)
+              | 398 > | NASA Radiometer MRIR (Single-channel infrared radiometer)
+              | 399 > | NASA Spectro-radiometer SAGE I (Stratospheric aerosol and gas experiment-I)
+              | 400 > | NASA Spectro-radiometer SAGE II (Stratospheric aerosol and gas experiment-II)
+              | 401 > | NASA Spectro-radiometer SAGE III (Stratospheric aerosol and gas experiment-III)
+              | 402 > | NASA Spectro-radiometer SAMS (Stratospheric and mesospheric sounder)
+              | 403 > | NASA Spectro-radiometer SAM-II (Stratospheric aerosol measurement - II)
+              | 404 > | NASA Spectro-radiometer IRIS (Infrared interferometer spectrometer)
+              | 405 > | NASA Atmospheric temperature and humidity sounder GIFTS (Geosynchronous imaging fourier transform spectrometer)
+              | 420 > | NASA Spectrometer AIRS (Atmospheric Infrared sounder)
+              | 421 > | NASA Spectrometer SIRS-A (Satellite infrared spectrometer-A)
+              | 422 > | NASA Spectrometer SIRS-B (Satellite infrared spectrometer-B)
+              | 426 > | NASA Spectrometer SOLSTICE (Solar stellar irradiance comparison experiment)
+              | 430 > | NASA Spectrometer TES (Troposhperic emission spectrometer)
+              | 431 > | NASA Spectrometer TOMS (Total ozone mapping spectrometer)
+              | 432 > | NASA Spectrometer OCO (Orbiting Carbon Observatory)
+              | 433 > | NASA Spectrometer TMS (TROPICS Millimeter-wave Sounder)
+              | 434 > | NASA MW radiometer SMAP (Soil Moisture Active-Passive)
+              | 450 > | JAXA Communications ADEOS Comms (Communications package for ADEOS)
+              | 451 > | JAXA Communications DCS (JAXA) (Data collection system (JAXA))
+              | 453 > | NASDA Communications GMS Comms (Communications package on GMS)
+              | 454 > | NASDA Communications JERS-1 Comms (Communications package for JERS-1)
+              | 460 > | NASDA Lidar RIS (Retroreflector in space)
+              | 461 > | NASDA Radar PR (Precipitation radar)
+              | 462 > | NASDA Imaging microwave radar SAR (Synthetic aperture radar)
+              | 470 > | JAXA Imaging microwave radar PALSAR (Phased array type L-band synthetic aperture radar)
+              | 478 > | JAXA Imaging multi-spectral radiometer (passive microwave) AMSR2 (Advanced microwave scanning radiometer 2)
+              | 479 > | JAXA Imaging multi-spectral radiometer (passive microwave) AMSR-E (Advanced microwave scanning radiometer-EOS)
+              | 480 > | JAXA High resolution optical imager PRISM (ALOS) (Panchromatic remote-sensing Instrument for stereo mapping)
+              | 481 > | JAXA Radiometer AMSR (Advanced microwave scanning Radiometer)
+              | 482 > | NASDA High-resolution optical imager AVNIR (Advanced visible and near infrared radiometer)
+              | 483 > | JAXA High-resolution optical imager AVNIR-2 (Advanced visible and near infra-red radiometer type 2)
+              | 484 > | JAXA Imager GLI (Global imager)
+              | 485 > | NASDA Radiometer MESSR (Multispectral electronic self scanning radiometer)
+              | 486 > | NASDA Radiometer MSR (Microwave scanning radiometer)
+              | 487 > | NASDA Radiometer OCTS (Ocean color and temperature scanner)
+              | 488 > | NASDA Radiometer OPS (Optical sensor)
+              | 489 > | NASDA Radiometer VISSR (GMS-5) (Visible and infrared spin scan radiometer (GMS-5))
+              | 490 > | NASDA Radiometer VTIR (Visible and thermal infrared radiometer)
+              | 510 > | NASDA Spectrometer ILAS-I (Imoroved limb atmosphiric spectrometer)
+              | 511 > | NASDA Spectrometer ILAS-II (Improved limb atmosphiric spectrometer)
+              | 512 > | NASDA Spectrometer IMG (Inferometric monitor of greenhouse gases)
+              | 514 > | NASDA Space environment SEM (Space environment monitor (NASDA))
+              | 515 > | JAXA Total and profile ozone SOFIS (Solar occultation Fourier transform spectrometer for Inclined orbit Satellite)
+              | 516 > | JAXA Spectrometer TANSO-FTS (Thermal and Near infrared Sensor for carbon Observations ( TANSO) Fourier Transform Spectrometer (FTS))
+              | 517 > | JAXA Imager TANSO-CAI (Thermal and Near infrared Sensor for carbon Observations ( TANSO) Cloud and Aerosol Imager (CAI))
+              | 518 > | JAXA Cloud and precipitation radar DPR (Dual-frequency precipitation radar)
+              | 519 > | JAXA MW imaging/sounding radiometer, conical scanning GMI (GPM microwave imager)
+              | 520 > | NASA Imaging radiometer SMMR (Scanning Multichannel Microwave Radiometer)
+              | 526 > | GeoOptics GNSS occultation sounder Cion-A (GeoOptics Cion GNSS occultation receiver A)
+              | 527 > | GeoOptics GNSS occultation sounder Cion-B (GeoOptics Cion GNSS occultation receiver B)
+              | 528 > | GeoOptics GNSS occultation sounder Cion-C (GeoOptics Cion GNSS occultation receiver C)
+              | 529 > | GeoOptics GNSS occultation sounder Cion-D (GeoOptics Cion GNSS occultation receiver D)
+              | 530 > | Spire GNSS occultation sounder SGNOS-A (Spire global navigation satellite system occultation sounder A)
+              | 531 > | Spire GNSS occultation sounder SGNOS-B (Spire global navigation satellite system occultation sounder B)
+              | 532 > | Spire GNSS occultation sounder SGNOS-C (Spire global navigation satellite system occultation sounder C)
+              | 533 > | Spire GNSS occultation sounder SGNOS-D (Spire global navigation satellite system occultation sounder D)
+              | 534 > | PlanetiQ GNSS occultationsounder Pyxis-A (PlanetiQ Pyxis GNSS occultation receiver A)
+              | 535 > | PlanetiQ GNSS occultationsounder Pyxis-B (PlanetiQ Pyxis GNSS occultation receiver B)
+              | 540 > | NOAA Communications DCS (NOAA) (Data-collection system (NOAA))
+              | 541 > | NOAA Communications GOES Comms (Communications package on GOES)
+              | 542 > | NOAA Communications LANDSAT Comms (Communications package for LANDSAT)
+              | 543 > | NOAA Communications NOAA Comms (Communications package for NOAA)
+              | 544 > | NOAA Communications S&R (GOES) (Search and rescue)
+              | 545 > | NOAA Communications S&R (NOAA) (Search and rescue)
+              | 546 > | NOAA Communications WEFAX (Weather facsimile)
+              | 547 > | NOAA Spectrometer SEM(GOES) (Space environment monitor)
+              | 550 > | NOAA Magnetic field SSM (Special sensor magnetometer)
+              | 551 > | NOAA Magnetic field SSJ/4 (Special sensor precipitating plasma monitor)
+              | 552 > | NOAA Space environment SSIES-2 (Special sensor ionospheric plasma drift/scintillation meter)
+              | 553 > | NOAA Space environment SSB/X-2 (Special sensor gamma ray particle dectector)
+              | 570 > | NOAA Radiometer AMSU-A (Advanced microwave sounding unit-A)
+              | 574 > | NOAA Radiometer AMSU-B (Advanced microwave sounding unit-B)
+              | 580 > | NOAA Radiometer ATOVS (HIRS/3 + AMSU + AVHRR/3) (Advanced TIROS operational vertical sounder)
+              | 590 > | NOAA Radiometer AVHRR/2 (Advanced very high-resolution radiometer/2)
+              | 591 > | NOAA Radiometer AVHRR/3 (Advanced very high-resolution radiometer/3)
+              | 592 > | NOAA Radiometer AVHRR/4 (Advanced very high-resolution radiometer/4)
+              | 600 > | NOAA Radiometer ERBE (Earth's radiation budget experiment)
+              | 601 > | NOAA Radiometer ETM+ (Enhanced thematic mapper)
+              | 604 > | NOAA Radiometer HIRS/1 (High-resolution infrared sounder/1)
+              | 605 > | NOAA Radiometer HIRS/2 (High-resolution infrared sounder/2)
+              | 606 > | NOAA Radiometer HIRS/3 (High-resolution infrared sounder/3)
+              | 607 > | NOAA Radiometer HIRS/4 (High-resolution infrared sounder/4)
+              | 615 > | NOAA Radiometer IMAGER (Imager)
+              | 616 > | NOAA Imaging multi-spectral radiometer (vis/IR) VIIRS (Visible/infrared imager radiometer suite)
+              | 617 > | NOAA Imaging multi-spectral radiometer ABI (Advanced baseline imager)
+              | 618 > | NOAA High-resolution optical imager GLM (Geostationary lightning mapper)
+              | 620 > | NOAA Atmospheric temperature and humidity sounder CrIRS/NP (Cross track infrared sounder/NPOESS)
+              | 621 > | NOAA Atmospheric temperature and humidity sounder ATMS (Advanced technology microwave sounder)
+              | 622 > | NOAA Radiometer MSS (Multispectral scanning system)
+              | 623 > | NOAA Radiometer MSU (Microwave sounding unit)
+              | 624 > | NOAA Radiometer SBUV/2 (Solar backscattter ultraviolet instrument/2)
+              | 625 > | NOAA Radiometer SBUV/3 (Solar backscattter ultraviolet instrument/3)
+              | 626 > | NOAA Radiometer SOUNDER (SOUNDER)
+              | 627 > | NOAA Radiometer SSU (Stratospheric sounding unit)
+              | 628 > | NOAA Radiometer TM (Thematic mapper)
+              | 629 > | NOAA Radiometer TOVS (HIRS/2 + MSU + SSU) (TIROS operational vertical sounder)
+              | 630 > | NOAA Radiometer VAS (VISSR atmospheric sounder)
+              | 631 > | NOAA Radiometer SSZ
+              | 645 > | NOAA Spectrometer SEM (Space environment monitor)
+              | 650 > | NRSCC Radiometer MVIRSR (10 channel) (Multispectral visible and infrared scan radiometer)
+              | 651 > | NRSCC Radiometer MVIRSR (3 channel) (Multispectral visible and infrared scan radiometer)
+              | 652 > | NRSCC Radiometer MVIRSR (5 channel) (Multispectral visible and infrared scan radiometer)
+              | 670 > | NSAU Radar RLSBO (Side looking microwave radar)
+              | 680 > | NSAU High-resolution optical imager MSU-EU (Multi-spectral radiometer with high resolution)
+              | 681 > | NSAU Imaging multi-spectral radiometer (vis/IR) MSU-UM (Visible multi-spectral radiometer)
+              | 682 > | NSAU Radiometer RM-08 (Imaging microwave radiometer)
+              | 683 > | NSAU High-resolution optical imager SU-UMS (Stereo radiometer with high resolution)
+              | 684 > | NSAU High-resolution optical imager SU-VR (Visible radiometer with high resolution)
+              | 685 > | NSAU Radiometer TRASSER
+              | 686 > | SOA Scatterometer SCAT (Scatterometer)
+              | 687 > | SOA Radar altimeter ALT (Radar altimeter)
+              | 688 > | SOA Microwave radiometer MWI (Microwave radiometer)
+              | 700 > | ROSCOSMOS Communications KONDOR-2 (Data collection and transmission system)
+              | 701 > | ROSCOSMOS Communications BRK
+              | 710 > | ROSCOSMOS Lidar ALISSA (Backscatter lidar)
+              | 712 > | ROSCOSMOS Lidar Balkan-2 lidar
+              | 715 > | ROSCOSMOS Lidar MK-4
+              | 716 > | ROSCOSMOS Lidar MK-4M
+              | 730 > | ROSCOSMOS Radar Greben (Radar altimeter)
+              | 731 > | ROSCOSMOS Radar SAR-10 (Synthetic aperture radar)
+              | 732 > | ROSCOSMOS Radar SAR-3 (Synthetic aperture radar)
+              | 733 > | ROSCOSMOS Radar SAR-70 (Synthetic aperture radar)
+              | 740 > | ROSCOSMOS Radar SLR-3 (Side looking radar)
+              | 745 > | ROSCOSMOS Radar Travers SAR
+              | 750 > | ROSCOSMOS Radiometer 174-K (Temperature and humidity profiler)
+              | 751 > | ROSCOSMOS Radiometer BTVK (Scanning television radiometer)
+              | 752 > | ROSCOSMOS Radiometer Chaika (Scanning infrared radiometer)
+              | 753 > | ROSCOSMOS Radiometer DELTA-2 (Multispectral microwave scanner)
+              | 755 > | ROSCOSMOS Radiometer IKAR-D (Multispectral microwave scanner)
+              | 756 > | ROSCOSMOS Radiometer IKAR-N (Multispectral microwave scanner)
+              | 757 > | ROSCOSMOS Radiometer IKAR-P (Multispectral microwave scanner)
+              | 760 > | ROSCOSMOS Radiometer ISP
+              | 761 > | ROSCOSMOS Radiometer KFA-1000 (Photographic camera)
+              | 762 > | ROSCOSMOS Radiometer KFA-200 (Photographic camera)
+              | 763 > | ROSCOSMOS Radiometer KFA-3000 (Photographic camera)
+              | 770 > | ROSCOSMOS Radiometer Klimat (Scanning infrared radiometer)
+              | 771 > | ROSCOSMOS Radiometer Klimat-2 (Scanning infrared radiometer)
+              | 775 > | ROSCOSMOS Radiometer MIRAS
+              | 776 > | ROSCOSMOS Radiometer MIVZA
+              | 777 > | ROSCOSMOS Radiometer MIVZA-M (Microwave scanning radiometer)
+              | 780 > | ROSCOSMOS Radiometer MR-2000
+              | 781 > | ROSCOSMOS Radiometer MR-2000M
+              | 785 > | ROSCOSMOS Radiometer MR-900 (Scanning telephotometer)
+              | 786 > | ROSCOSMOS Radiometer MR-900B (Scanning visual band telephotometer)
+              | 790 > | ROSCOSMOS Radiometer MSU-E (Multispectral high-resolution electronic scanner)
+              | 791 > | ROSCOSMOS Radiometer MSU-E1 (Multispectral high-resolution electronic scanner)
+              | 792 > | ROSCOSMOS Radiometer MSU-E2 (Multispectral high-resolution electronic scanner)
+              | 793 > | ROSCOSMOS Radiometer MSU-M
+              | 794 > | ROSCOSMOS Radiometer MSU-S (Multispectral medium-resolution scanner)
+              | 795 > | ROSCOSMOS Radiometer MSU-SK (Multispectral medium-resolution conical scanner)
+              | 796 > | ROSCOSMOS Radiometer MSU-V (Multispectral high-resolution conical scanner)
+              | 810 > | ROSCOSMOS Radiometer MTZA (Scanning microwave radiometer)
+              | 815 > | ROSCOSMOS Imaging multi-spectral radiometer (passive microwave) MZOAS (Scanning microwave radiometer)
+              | 820 > | ROSCOSMOS Imaging multi-spectral radiometer (passive microwave) R-225 (Single channel microwave radiometer)
+              | 821 > | ROSCOSMOS Radiometer R-400
+              | 822 > | ROSCOSMOS Radiometer R-600 (Single channel microwave radiometer)
+              | 830 > | ROSCOSMOS Radiometer RMS (Radiation measurement system)
+              | 835 > | ROSCOSMOS Radiometer TV camera
+              | 836 > | ROSCOSMOS Radiometer SILVA
+              | 840 > | ROSCOSMOS Spectro-radiometer SROSMO (Spectroradiometer for ocean monitoring)
+              | 850 > | ROSCOSMOS Spectrometer BUFS-2 (Backscatter spectrometer/2)
+              | 851 > | ROSCOSMOS Spectrometer BUFS-4 (Backscatter spectrometer/4)
+              | 855 > | ROSCOSMOS Spectrometer ISTOK-1 (Infrared spectrometer)
+              | 856 > | ROSCOSMOS Spectrometer SFM-2 (Spectrometer to measure direct solar radiation)
+              | 857 > | ROSCOSMOS Spectrometer DOPI
+              | 858 > | ROSCOSMOS Spectrometer KGI-4
+              | 859 > | ROSCOSMOS Spectrometer Ozon-M
+              | 860 > | ROSCOSMOS Spectrometer RMK-2
+              | 861 > | ROSCOSMOS Atmospheric temperature and humidity sounder MTVZA-GY (Module for temperature and humidity sounding in the atmosphere)
+              | 862 > | ROSCOSMOS Spectrometer IKFS-2 (Infrared Fourier spectrometer)
+              | 900 > | NOAA Radiometer MAXIE (Magnetospheric atmospheric X-ray imaging experiment)
+              | 901 > | NOAA Radiometer OLS (Operational linescan system)
+              | 905 > | NOAA Radiometer SSM/I (Mission sensor microwave imager)
+              | 906 > | NOAA Radiometer SSM/T-1 (Mission sensor microwave temperature sounder)
+              | 907 > | NOAA Radiometer SSM/T-2 (Mission sensor microwave water vapour sounder)
+              | 908 > | NOAA Radiometer SSMIS (Special sensor microwave imager sounder)
+              | 909 > | NOAA Radiometer VTPR (Vertical temperature profile radiometer)
+              | 910 > | NOAA Radiometer SXI (Solar X-ray imager)
+              | 930 > | NOAA Spectrometer EHIC (Energetic heavy ion composition experiment)
+              | 931 > | NOAA Spectrometer X-ray astronomy payload
+              | 932 > | NRSCC Imaging multi-spectral radiometer (vis/IR) IVISSR (FY-2) (Improved multispectral visible and Infrared scan radiometer (5 channels))
+              | 933 > | NRSCC Atmospheric temperature and humidity sounder IRAS (Infrared atmospheric sounder)
+              | 934 > | NRSCC Atmospheric temperature and humidity sounder MWAS (MicroWave atmospheric sounder)
+              | 935 > | NRSCC Atmospheric temperature and humidity sounder IMWAS (Improved MicroWave atmospheric sounder)
+              | 936 > | NRSCC Atmospheric temperature and humidity sounder MWHS (Microwave humidity sounder)
+              | 937 > | NRSCC Imaging multi-spectral radiometer (vis/IR) MVIRS (Moderate resolution visible and infrared imaging spectroradiometer)
+              | 938 > | NRSCC Imaging multi-spectral radiometer (passive microwave) MWRI (Microwave radiation imager)
+              | 940 > | ROSCOSMOS Atmospheric temperature and humidity sounder MTVZA-OK (Scanning microwave radiometer)
+              | 941 > | CNES Atmospheric temperature and humidity sounder SAPHIR
+              | 942 > | CNES Microwave imager MADRAS (Microwave Analysis and Detection of Rain and Atmospheric Structures)
+              | 943 > | CNSA Scatterometer SCAT (on CFOSAT) Scatterometer
+              | 944 > | NOAA Radar altimeter ALT (Altimeter)
+              | 945 > | NOAA Earth radiation budget radiometer TSIS (Total solar irradiance sensor)
+              | 946 > | NOAA Imaging multi-spectral radiometer (passive microwave) CMIS (Conical-scanning microwave imager/sounder)
+              | 947 > | NOAA Total and profile ozone OMPS (Ozone mapping and profiler suite)
+              | 948 > | NOAA Space environment atmospheric temperature and humidity sounder GPSOS (Global positioning system occultation sensor)
+              | 949 > | NOAA Magnetic field, Auroal imagery Scintillation boundary SESS (Space environmental sensor suite)
+              | 950 > | NRSCC Imaging multi-spectral radiometer (vis/IR) VIRR (Multispectral visible and infrared scan radiometer (10 channels))
+              | 951 > | NRSCC Total and profile ozone TOM (Total ozone mapper)
+              | 952 > | NRSCC Total and profile ozone OP (Ozone profiler)
+              | 953 > | CMA Microwave sounding radiometer, crosstrack scanning MWHS-2 (Microwave humidity sounder-2)
+              | 954 > | CMA Microwave sounding radiometer, crosstrack scanning MWTS-2 (Microwave temperature sounder-2)
+              | 955 > | CMA Cross-nadir scanning IR sounder HIRAS (Hyperspectral infrared atmospheric sounder))
+              | 956 > | CMA Spectrometer SBUS (Solar Backscatter Ultraviolet Sounder)
+              | 957 > | CMA Spectrometer TOU (Total Ozone Unit)
+              | 958 > | GNSS occultation sounder GNOS (Global navigation satellite system occultation sounder)
+              | 959 > | SNSB Limb-scanning sounder SMR (Sub-millimetre radiometer)
+              | 961 > | CMA Imaging multi-spectral radiometer AGRI (Advanced Geosynchronous Radiation Imager)
+              | 962 > | CMA Atmospheric temperature and humidity sounder GIIRS (Geosynchronous Interferometric Infrared Sounder)
+              | 963 > | CMA High-resolution optical imager LMI (Lightning Mapper Imager)
+              | 964 > | CMA Space Environment SEP (Space Environment Package)
+              | 965 > | CMA GNSS occultation GNOS-2 (GNSS radio occultation sounder-2)
+              | 966 > | CMA Microwave sounding radiometer, cross-track scanning MWTS-3 (Microwave temperature sounder-3)
+              | 980 > | KMA Imager AMI (Advanced Meteorological Imager)
+              | 981 > | KMA Imager MI (Meteorological Imager)
+              | 982 > | KMA Space environment KSEM (Korea Space wEather Monitor)
+              | 990 > | NASA Radiometer SMMR (Scanning multichannel microwave radiometer)
+              | 991 > | NASA Radiometer THIR (Temperature-humidity infrared radiometer)
+              | 992 > | NASA Radiometer NEMS (Nimbus-E Microwave Sounder)
+              | 993 > | NASA Radiometer SCAMS (Scanning Microwave Spectrometer)
+              | 994   | NASA Radiometer ESMR (Electrically Scanning Microwave Radiometer)
+
+  0-02-020 | SCLF ; CODE
+              | 0 > | Nimbus
+              | 1 > | VTPR
+              | 2 > | Tiros 1 (Tiros, NOAA-6 to NOAA-13)
+              | 3 > | Tiros 2 (NOAA-14 onwards)
+              | 10 > | EOS
+              | 20 > | GPM-core
+              | 31 > | DMSP
+              | 61 > | EUMETSAT Polar System (EPS)
+              | 62 > | EUMETSAT Polar System (EPS-SG)
+              | 91 > | ERS
+              | 92 > | Sentinel-3
+              | 121 > | ADEOS
+              | 122 > | GCOM
+              | 241 > | GOES
+              | 251 > | TROPICS
+              | 261 > | JASON
+              | 271 > | GMS
+              | 272 > | MTSAT
+              | 273 > | Himawari
+              | 281 > | COMS
+              | 301 > | INSAT
+              | 331 > | METEOSAT Operational Programme (MOP)
+              | 332 > | METEOSAT Transitional Programme (MTP)
+              | 333 > | METEOSAT Second Generation Programme (MSG)
+              | 334 > | METEOSAT Third Generation Programme (MTG)
+              | 351 > | GOMS
+              | 352 > | Meteor-M N2
+              | 380 > | FY-1
+              | 381 > | FY-2
+              | 382 > | FY-3
+              | 383 > | FY-4
+              | 401 > | GPS
+              | 402 > | GLONASS
+              | 403 > | GALILEO
+              | 404 > | BDS (BeiDou navigation satellite system)
+              | 405   | Quasi-Zenith Satellite System (QZSS)
+
+  0-02-021 | SIDU ; FLAG
+              | 1 > | High resolution Infrared sounder (HIRS)
+              | 2 > | Microwave sounding unit (MSU)
+              | 3 > | Stratospheric sounding unit (SSU)
+              | 4 > | AMI (Advanced microwave instrument) Wind mode
+              | 5 > | AMI (Advanced microwave instrument) Wave mode
+              | 6 > | AMI (Advanced microwave instrument) Image mode
+              | 7 > | RADAR altimeter
+              | 8   | ATSR (along track scanning radiometer)
+
+  0-02-022 | SDPT ; FLAG
+              | 1 > | Processing technique not defined
+              | 2 > | Automated statistical regression
+              | 3 > | Clear path
+              | 4 > | Partly cloudy path
+              | 5   | Cloudy path
+
+  0-02-023 | SWCM ; CODE
+              | 1 > | Wind derived from cloud motion observed in the infrared channel
+              | 2 > | Wind derived from cloud motion observed in the visible channel
+              | 3 > | Wind derived from motion observed in the water vapour channel
+              | 4 > | Wind derived from motion observed in a combination of spectral channels
+              | 5 > | Wind derived from motion observed in the water vapour channel in clear air
+              | 6 > | Wind derived from motion observed in the ozone channel
+              | 7 > | Wind derived from motion observed in water vapour channel (cloud or clear air not specified)
+              | 13   | Root-mean-square
+
+  0-02-024 | IMHC ; CODE
+              | 1 > | Table with full range of humidity variation in layer
+              | 2   | Regression technique on 2 humidity values in layer
+
+  0-02-025 | SCUC ; FLAG
+              | 2 > | HIRS (Layer precipitable water for the layers: surface to 700 hPa, 700 to 500 hPa and 500 to 300 hPa)
+              | 3 > | MSU (Layer precipitable water for the layers: surface to 700 hPa, 700 to 500 hPa and 500 to 300 hPa)
+              | 6 > | HIRS (Tropopause temperature and pressure)
+              | 7 > | MSU (Tropopause temperature and pressure)
+              | 10 > | HIRS (1, 2, 3, 8, 9, 16, 17) (Total ozone)
+              | 11 > | HIRS (1, 2, 3, 9, 17) (Total ozone)
+              | 12 > | MSU (Total ozone)
+              | 15 > | HIRS (Mean temperature for the layers: surface to 850 hPa, 850 to 700 hPa, 700 to 500 hPa, 500 to 400 hPa, 400 to 300 hPa, 300 to 200 hPa and 200 to 100 hPa)
+              | 16 > | HIRS (1, 2, 3, 4) (Mean temperature for the layers: surface to 850 hPa, 850 to 700 hPa, 700 to 500 hPa, 500 to 400 hPa, 400 to 300 hPa, 300 to 200 hPa and 200 to 100 hPa)
+              | 17 > | MSU (Mean temperature for the layers: surface to 850 hPa, 850 to 700 hPa, 700 to 500 hPa, 500 to 400 hPa, 400 to 300 hPa, 300 to 200 hPa and 200 to 100 hPa)
+              | 18 > | SKINTK (ocean only) (Mean temperature for the layers: surface to 850 hPa, 850 to 700 hPa, 700 to 500 hPa, 500 to 400 hPa, 400 to 300 hPa, 300 to 200 hPa and 200 to 100 hPa)
+              | 21 > | HIRS (1, 2, 3, 4) (Channel combinations used to obtain the mean temperatures for the layers 100 to 70 hPa, 70 to 50 hPa, 50 to 30 hPa, 30 to 10 hPa, 10 to 5 hPa, 5 to 2 hPa, 2 to 1 hPa and 1 to 0.4 hPa)
+              | 22 > | SSU (Channel combinations used to obtain the mean temperatures for the layers 100 to 70 hPa, 70 to 50 hPa, 50 to 30 hPa, 30 to 10 hPa, 10 to 5 hPa, 5 to 2 hPa, 2 to 1 hPa and 1 to 0.4 hPa)
+              | 23   | MSU (3, 4) (Channel combinations used to obtain the mean temperatures for the layers 100 to 70 hPa, 70 to 50 hPa, 50 to 30 hPa, 30 to 10 hPa, 10 to 5 hPa, 5 to 2 hPa, 2 to 1 hPa and 1 to 0.4 hPa)
+
+  0-02-030 | MCMS ; CODE
+              | 1 > | ADCP (Acoustic Doppler Current Profiler)
+              | 2 > | GEK (Geomagnetic ElectroKinetograph)
+              | 3 > | Ship's set and drift determined by fixes 3-6 hours apart
+              | 4 > | Ship's set and drift determined by fixes more than 6 hours but less than 12 hours apart
+              | 5 > | Drift of buoy
+              | 6   | ADCP (Acoustic Doppler Current Profiler)
+
+  0-02-031 | DTCC ; CODE
+              | 1 > | Instantaneous (between one hour before and time of observation)
+              | 2 > | Averaged over 3 minutes or less (between one hour before and time of observation)
+              | 3 > | Averaged over more than 3 minutes, but 6 at the most (between one hour before and time of observation)
+              | 4 > | Averaged over more than 6 minutes, but 12 at the most (between one hour before and time of observation)
+              | 5 > | Instantaneous (between two hours before and one hour before time of observation)
+              | 6 > | Averaged over 3 minutes or less (between two hours before and one hour before time of observation)
+              | 7 > | Averaged over more than 3 minutes, but 6 at the most (between two hours before and one hour before time of observation)
+              | 8 > | Averaged over more than 6 minutes, but 12 at the most (between two hours before and one hour before time of observation)
+              | 9 > | Vector or Doppler current profiling method not used
+              | 11 > | 1 hour or less
+              | 12 > | More than 1 hour but 2 at the most
+              | 13 > | More than 2 hours but 4 at the most
+              | 14 > | More than 4 hours but 8 at the most
+              | 15 > | More than 8 hours but 12 at the most
+              | 16 > | More than 12 hours but 18 at the most
+              | 17 > | More than 18 hours but 24 at the most
+              | 19   | Drift method not used
+
+  0-02-032 | IDGT ; CODE
+              | 0 > | Values at selected depths (data points fixed by the instrument or selected by any other method)
+              | 1   | Values at selected depths (data points taken from traces at significant depths)
+
+  0-02-033 | MSDM ; CODE
+              | 0 > | No salinity measured
+              | 1 > | In situ sensor, accuracy better than 0.02 0/00
+              | 2 > | In situ sensor, accuracy less than 0.02 0/00
+              | 3   | Sample analysis
+
+  0-02-034 | DROT ; CODE
+              | 0 > | Unspecified drogue
+              | 1 > | Holey sock
+              | 2 > | TRISTAR
+              | 3 > | Window shade
+              | 4 > | Parachute
+              | 5   | Non-Lagrangian sea anchor
+
+  0-02-036 | BUYTS ; CODE
+              | 0 > | Drifting buoy
+              | 1 > | Fixed buoy
+              | 2   | Sub-surface float (moving)
+
+  0-02-037 | MOTO ; CODE
+              | 1 > | Manual reading from vertical tide staff
+              | 2 > | Manual reading from single automatic recorder at station
+              | 3 > | Manual reading from multiple automatic recorders at station
+              | 4 > | Automatic reading from single automatic recorder at station without level reference check.
+              | 5   | Automatic reading from a single automatic recorder at station with level reference check, or from multiple automatic recorders.
+
+  0-02-038 | MSST ; CODE
+              | 0 > | Ship intake
+              | 1 > | Bucket
+              | 2 > | Hull contact sensor
+              | 3 > | Reversing Thermometer
+              | 4 > | STD/CTD sensor
+              | 5 > | Mechanical BT
+              | 6 > | Expendable BT
+              | 7 > | Digital BT
+              | 8 > | Thermistor chain
+              | 9 > | Infra-red scanner
+              | 10 > | Micro-wave scanner
+              | 11 > | Infrared radiometer
+              | 12 > | In line thermosalinograph
+              | 13 > | Towed body
+              | 14   | Other
+
+  0-02-039 | MWBT ; CODE
+              | 0 > | Measured wet-bulb temperature
+              | 1 > | Iced bulb measured wet-bulb temperature
+              | 2 > | Computed wet-bulb temperature
+              | 3   | Iced bulb computed wet-bulb temperature
+
+  0-02-040 | MRMV ; CODE
+              | 0 > | Ship's motion removed by averaging; Ship's velocity removed by bottom tracking
+              | 1 > | Ship's motion removed by motion compensation; Ship's velocity removed by bottom tracking
+              | 2 > | Ship's motion not removed; Ship's velocity removed by bottom tracking
+              | 3 > | Ship's motion removed by averaging; Ship's velocity removed by navigation
+              | 4 > | Ship's motion removed by motion compensation; Ship's velocity removed by navigation
+              | 5 > | Ship's motion not removed; Ship's velocity removed by navigation
+              | 6   | Doppler current profiling method not used
+
+  0-02-041 | MESF ; CODE
+              | 0 > | Information based on manual analysis
+              | 1 > | Information based on computer analysis
+              | 2 > | Information based on data assimilation
+              | 3 > | Information based on computer analysis or data assimilation manually modified
+              | 10   | Information based on the numerical weather prediction
+
+  0-02-042 | ISCS ; CODE
+              | 0 > | Value originally reported in m/s
+              | 1 > | Value originally reported in knots
+              | 2   | No sea current data available
+
+  0-02-044 | IMCW ; CODE
+              | 1 > | Longuet-Higgins (1964)
+              | 2 > | Longuet-Higgins (F3 method)
+              | 3 > | Maximum likelihood method
+              | 4   | Maximum entropy method
+
+  0-02-045 | ITOP ; CODE
+              | 0 > | Sea station
+              | 1 > | Automatic data buoy
+              | 2 > | Aircraft
+              | 3   | Satellite
+
+  0-02-046 | WMIN ; CODE
+              | 1 > | Heave sensor
+              | 2   | Slope sensor
+
+  0-02-047 | DOTT ; CODE
+              | 1 > | DART II (PMEL)
+              | 2 > | DART ETD
+              | 3 > | SAIC Tsunami Buoy (STB)
+              | 4 > | GFZ - Potsdam
+              | 5 > | INCOIS (India)
+              | 6 > | InaBuoy (Indonesia)
+              | 7   | Envirtech
+
+  0-02-048 | SSIN ; CODE
+              | 0 > | HIRS
+              | 1 > | MSU
+              | 2 > | SSU
+              | 3 > | AMSU-A
+              | 4 > | AMSU-B
+              | 5 > | AVHRR
+              | 6 > | SSMI
+              | 7 > | NSCAT
+              | 8 > | SEAWINDS
+              | 9 > | POSEIDON altimeter
+              | 10 > | JMR (JASON Microwave Radiometer)
+              | 11 > | MHS
+              | 12 > | ASCAT
+              | 13   | OSCAT2
+
+  0-02-049 | GSDP ; FLAG
+              | 1 > | Processing technique not defined
+              | 2 > | Simultaneous physical retrieval
+              | 3 > | Clear sounding
+              | 4   | Cloudy sounding
+
+  0-02-050 | GSCU ; FLAG
+              | 1 > | Channel 1 (Central wavelength 14.71 um)
+              | 2 > | Channel 2 (Central wavelength 14.37 um)
+              | 3 > | Channel 3 (Central wavelength 14.06 um)
+              | 4 > | Channel 4 (Central wavelength 13.64 um)
+              | 5 > | Channel 5 (Central wavelength 13.37 um)
+              | 6 > | Channel 6 (Central wavelength 12.66 um)
+              | 7 > | Channel 7 (Central wavelength 12.02 um)
+              | 8 > | Channel 8 (Central wavelength 11.03 um)
+              | 9 > | Channel 9 (Central wavelength 9.71 um)
+              | 10 > | Channel 10 (Central wavelength 7.43 um)
+              | 11 > | Channel 11 (Central wavelength 7.02 um)
+              | 12 > | Channel 12 (Central wavelength 6.51 um)
+              | 13 > | Channel 13 (Central wavelength 4.57 um)
+              | 14 > | Channel 14 (Central wavelength 4.52 um)
+              | 15 > | Channel 15 (Central wavelength 4.45 um)
+              | 16 > | Channel 16 (Central wavelength 4.13 um)
+              | 17 > | Channel 17 (Central wavelength 3.98 um)
+              | 18 > | Channel 18 (Central wavelength 3.74 um)
+              | 19   | Channel 19 (Central wavelength 0.969 um)
+
+  0-02-051 | IOET ; CODE
+              | 1 > | Maximum/minimum temperatures
+              | 2 > | Automated instruments
+              | 3   | Thermograph
+
+  0-02-052 | GICU ; FLAG
+              | 1 > | Channel 1 (Central wavelength 0.55-0.75 um)
+              | 2 > | Channel 2 (Central wavelength 3.9 um)
+              | 3 > | Channel 3 (Central wavelength 6.7 um)
+              | 4 > | Channel 4 (Central wavelength 10.7 um)
+              | 5   | Channel 5 (Central wavelength 12.0 um)
+
+  0-02-053 | GBTCST ; CODE
+              | 0 > | Observed brightness temperature
+              | 1 > | Brightness temperature with bias correction applied
+              | 2 > | Brightness temperature calculated from first guess
+              | 3   | Brightness temperature calculated from sounding
+
+  0-02-054 | GSPCST ; CODE
+              | 0 > | Parameter derived using observed sounder brightness temperatures
+              | 1 > | Parameter derived using observed imager brightness temperatures
+              | 2 > | Parameter derived using first guess information
+              | 3 > | Parameter derived using NMC analysis information
+              | 4   | Parameter derived using radiosonde information
+
+  0-02-055 | GSSP ; CODE
+              | 0 > | Statistics generated comparing retrieval versus radiosonde
+              | 1 > | Statistics generated comparing retrieval versus first guess
+              | 2 > | Statistics generated comparing radiosonde versus first guess
+              | 3 > | Statistics generated comparing observed versus retrieval
+              | 4 > | Statistics generated comparing observed versus first guess
+              | 5 > | Statistics generated comparing radiosonde versus imager
+              | 6 > | Statistics generated comparing radiosonde versus sounder
+              | 7 > | Statistics generated for radiosonde
+              | 8   | Statistics generated for first guess
+
+  0-02-056 | GSAS ; CODE
+              | 0 > | Sums of differences
+              | 1 > | Sums of squared differences
+              | 2 > | Sample size
+              | 3 > | Minimum difference
+              | 4   | Maximum difference
+
+  0-02-057 | OFGI ; CODE
+              | 0 > | Nested Grid Model (NGM)
+              | 1 > | Aviation Model (AVN)
+              | 2 > | Medium Range Forecast (MRF) Model
+              | 3 > | Global Data Assimilation System (GDAS) Forecast Model
+              | 4 > | Prior soundings (within 3 hours of current time)
+              | 5   | Climatology
+
+  0-02-058 | VTGG ; CODE
+              | 0 > | 12 hour and 18 hour
+              | 1 > | 18 hour and 24 hour
+              | 2 > | 6 hour and 12 hour
+              | 3   | Greater than 24 hours
+
+  0-02-059 | OANI ; CODE
+              | 0 > | NCEP Nested Grid Model (NGM) Analysis
+              | 1 > | NCEP Aviation Model (AVN) Analysis
+              | 2 > | NCEP Medium Range Forecast (MRF) Model Analysis
+              | 3   | NCEP Global Data Assimilation System (GDAS) Forecast Model Analysis
+
+  0-02-060 | OSFI ; CODE
+              | 0 > | Current surface hourly reports
+              | 1 > | Current ship reports
+              | 2 > | Current buoy reports
+              | 3 > | One hour old surface hourly reports
+              | 4 > | One hour old ship reports
+              | 5   | One hour old buoy reports
+
+  0-02-061 | ACNS ; CODE
+              | 0 > | Inertial navigation system
+              | 1   | OMEGA
+
+  0-02-062 | TADR ; CODE
+              | 0 > | ASDAR
+              | 1 > | ASDAR (ACARS also available but not operative)
+              | 2 > | ASDAR (ACARS also available and operative)
+              | 3 > | ACARS
+              | 4 > | ACARS (ASDAR also available but not operative)
+              | 5   | ACARS (ASDAR also available and operative)
+
+  0-02-064 | ROLQ ; CODE
+              | 0 > | Good
+              | 1   | Bad
+
+  0-02-066 | RGRSY ; CODE
+              | 0 > | InterMet IMS 2000
+              | 1 > | InterMet IMS 1500C
+              | 2 > | ShangHai GTC1
+              | 3 > | NanJing GTC2
+              | 4 > | NanJing GFE(L)1
+              | 5 > | MARL-A radar
+              | 6 > | VEKTOR-M radar
+              | 62   | Other
+
+  0-02-070 | OSLL ; CODE
+              | 0 > | Actual location in seconds
+              | 1 > | Actual location in minutes
+              | 2 > | Actual location in degrees
+              | 3 > | Actual location in decidegrees
+              | 4 > | Actual location in centidegrees
+              | 5 > | Referenced to checkpoint in seconds
+              | 6 > | Referenced to checkpoint in minutes
+              | 7 > | Referenced to checkpoint in degrees
+              | 8 > | Referenced to checkpoint in decidegrees
+              | 9 > | Referenced to checkpoint in centidegrees
+              | 10 > | Actual location in tenths of a minute
+              | 11   | Referenced to checkpoint in tenths of a minute
+
+  0-02-080 | BMFGR ; CODE
+              | 0 > | Kaysam
+              | 1 > | Totex
+              | 2 > | KKS
+              | 3 > | Guangzhou Shuangyi (China)
+              | 4 > | ChemChina Zhuzhou (China)
+              | 62   | Other
+
+  0-02-081 | BTYPE ; CODE
+              | 0 > | GP26
+              | 1 > | GP28
+              | 2 > | GP30
+              | 3 > | HM26
+              | 4 > | HM28
+              | 5 > | HM30
+              | 6 > | SV16
+              | 7 > | Totex TA type balloons
+              | 8 > | Totex TX type balloons
+              | 30   | Other
+
+  0-02-083 | BSHEL ; CODE
+              | 0 > | High bay
+              | 1 > | Low bay
+              | 2 > | Balloon Inflation Launch System (BILS)
+              | 3 > | Roof-top BILS
+              | 4 > | Automated unmanned sounding system
+              | 14   | Other
+
+  0-02-084 | BGTYP ; CODE
+              | 0 > | Hydrogen
+              | 1 > | Helium
+              | 2 > | Natural gas
+              | 14   | Other
+
+  0-02-092 | OPCM ; CODE
+              | 0 > | UV channel based retrieval
+              | 1 > | Visible channel based retrieval
+              | 2   | Combined UV based retrieval and visible based retrieval
+
+  0-02-095 | PSENS ; CODE
+              | 0 > | Capacitance aneroid
+              | 1 > | Derived from GPS
+              | 2 > | Resistive strain gauge
+              | 3 > | Silicon capacitor
+              | 4 > | Derived from radar height
+              | 30   | Other
+
+  0-02-096 | TSENS ; CODE
+              | 0 > | Rod thermistor
+              | 1 > | Bead thermistor
+              | 2 > | Capacitance bead
+              | 3 > | Capacitance wire
+              | 4 > | Resistive sensor
+              | 5 > | Chip thermistor
+              | 6 > | Mercury
+              | 7 > | Alcohol/glycol
+              | 30   | Other
+
+  0-02-097 | RHSENS ; CODE
+              | 0 > | VIZ Mark II Carbon Hygristor
+              | 1 > | VIZ B2 Hygristor
+              | 2 > | Vaisala A-Humicap
+              | 3 > | Vaisala H-Humicap
+              | 4 > | Capacitance sensor
+              | 5 > | Vaisala RS90
+              | 6 > | Sippican Mark IIA Carbon Hygristor
+              | 7 > | Twin alternatively-heated humicap capacitance sensor
+              | 8 > | Humicap capacitance sensor with active de-icing method
+              | 9 > | Carbon hygristor
+              | 10 > | Psychrometer
+              | 11 > | Capacitive (polymer)
+              | 12 > | Capacitive (ceramic, including metal oxide)
+              | 13 > | Resistive (generic)
+              | 14 > | Resistive (salt polymer)
+              | 15 > | Resistive (conductive polymer)
+              | 16 > | Thermal conductivity
+              | 17 > | Gravimetric
+              | 18 > | Paper-metal coil
+              | 19 > | Ordinary human hair
+              | 20 > | Rolled hair (torsion)
+              | 21 > | Goldbeater's skin
+              | 22 > | Chilled mirror hygrometer
+              | 23 > | Dew cell
+              | 24 > | Optical absorption sensor
+              | 30   | Other
+
+  0-02-099 | POLA ; CODE
+              | 0 > | HH polarisation
+              | 1 > | VV polarisation
+              | 2 > | HV polarisation real valued component
+              | 3   | HV polarisation imaginary valued component
+
+  0-02-101 | ANTYP ; CODE
+              | 0 > | Centre front fed paraboloid
+              | 1 > | Offset front fed paraboloid
+              | 2 > | Centre Cassegrain paraboloid
+              | 3 > | Offset Cassegrain paraboloid
+              | 4 > | Planar array
+              | 5 > | Coaxial collinear array
+              | 6 > | Yagi elements array
+              | 7 > | Microstrip
+              | 14   | Other
+
+  0-02-103 | RADO ; FLAG
+              | 1   | Radar antenna is protected by a radome
+
+  0-02-104 | ANPO ; CODE
+              | 0 > | Horizontal polarization
+              | 1 > | Vertical polarization
+              | 2 > | Right circular polarization
+              | 3 > | Left circular polarization
+              | 4 > | Horizontal and vertical polarization
+              | 5 > | Right and left circular polarization
+              | 6 > | Quasi-horizontal polarization
+              | 7   | Quasi-vertical polarization
+
+  0-02-115 | SFEQP ; CODE
+              | 0 > | PDB
+              | 1 > | RSOIS
+              | 2 > | ASOS
+              | 3 > | Psychrometer
+              | 4 > | F420
+              | 30   | Other
+
+  0-02-119 | RA2IO ; CODE
+              | 0 > | Intermediate Frequency Calibration Mode (IF CAL)
+              | 1 > | Built-In Test Equipment Digital (BITE DGT)
+              | 2 > | Built-In test Equipment Radio Frequency (BITE RF)
+              | 3 > | Preset tracking (PSET TRK)
+              | 4 > | Preset LOOP OUT
+              | 5 > | ACQUISITION
+              | 6   | TRACKING
+
+  0-02-131 | STCL ; FLAG
+              | 1   | STC operational
+
+  0-02-137 | RDPR ; CODE
+              | 1 > | 3:2
+              | 2 > | 4:3
+              | 3   | 5:4
+
+  0-02-138 | ANRD ; CODE
+              | 1 > | Clockwise rotation
+              | 2   | Counterclockwise rotation
+
+  0-02-139 | SIIC ; CODE
+              | 0 > | SIRAL nominal
+              | 1   | SIRAL redundant
+
+  0-02-143 | OITP ; CODE
+              | 1 > | Brewer spectrophotometer
+              | 2 > | Caver Teichert
+              | 3 > | Dobson
+              | 4 > | Dobson (Japan)
+              | 5 > | Ehmet
+              | 6 > | Fecker telescope
+              | 7 > | Hoelper
+              | 8 > | Jodmeter
+              | 9 > | Filter ozonometer M-83
+              | 10 > | Mast
+              | 11 > | Oxford
+              | 12 > | Paetzold
+              | 13 > | Regener
+              | 15 > | Vassy filter ozonometer
+              | 16 > | Carbon iodide
+              | 17 > | Surface ozone bubler
+              | 18 > | Filter ozonometer M-124
+              | 19   | ECC sonde
+
+  0-02-144 | LSTB ; CODE
+              | 0 > | Direct Sun
+              | 1 > | Direct Sun, attenuator #1
+              | 2 > | Direct Sun, attenuator #2
+              | 3 > | Focused Moon
+              | 4 > | Focused Sun
+              | 5 > | Focused Sun corrected with adjacent sky measurements
+              | 6   | Zenith Sky
+
+  0-02-145 | WSDI ; CODE
+              | 0 > | Wavelengths AD ordinary setting
+              | 1 > | Wavelengths BD ordinary setting
+              | 2 > | Wavelengths CD ordinary setting
+              | 3 > | Wavelengths CC ordinary setting
+              | 4 > | Wavelengths AD focussed image
+              | 5 > | Wavelengths BD focussed image
+              | 6 > | Wavelengths CD focussed image
+              | 7   | Wavelengths CC focussed image
+
+  0-02-146 | SCDI ; CODE
+              | 0 > | On direct sun
+              | 1 > | On direct moon
+              | 2 > | On blue zenith sky
+              | 3 > | On zenith cloud (uniform stratified layer of small opacity)
+              | 4 > | On zenith cloud (uniform or moderately variable layer of medium opacity)
+              | 5 > | On zenith cloud (uniform or moderately variable layer of large opacity)
+              | 6 > | On zenith cloud (highly variable opacity, with or without precipitation)
+              | 7 > | On zenith cloud (fog)
+              | 8 > | On zenith haze
+              | 9   | On direct sun through thin cloud, fog or haze
+
+  0-02-147 | MTCC ; CODE
+              | 1 > | Direct leased circuit
+              | 2 > | Dialed up connection
+              | 3 > | Internet ISP
+              | 4 > | DCP via satellite (MTSAT, METEOSAT, etc.)
+              | 5 > | VSAT
+              | 6 > | GAN, BGAN
+              | 7 > | Thiss terminal
+              | 8 > | Iridium satellites
+              | 9   | Mobile telephony
+
+  0-02-148 | DCLS ; CODE
+              | 1 > | Argos
+              | 2 > | GPS
+              | 3 > | GOES DCP
+              | 4 > | METEOSAT DCP
+              | 5 > | ORBCOMM
+              | 6 > | INMARSAT
+              | 7 > | Iridium
+              | 8 > | Iridium and GPS
+              | 9 > | Argos-3
+              | 10   | Argos-4
+
+  0-02-149 | BUYT ; CODE
+              | 0 > | Unspecified drifting buoy
+              | 1 > | Standard Lagrangian drifter (Global Drifter Programme)
+              | 2 > | Standard FGGE type drifting buoy (non-Lagrangian meteorological drifting buoy)
+              | 3 > | Wind measuring FGGE type drifting buoy (non-Lagrangian meteorological drifting buoy)
+              | 4 > | Ice drifter
+              | 5 > | SVPG Standard Lagrangian drifter with GPS
+              | 6 > | SVP-HR Drifter with high resolution temperature or thermistor string
+              | 8 > | Unspecified sub-surface float
+              | 9 > | SOFAR
+              | 10 > | ALACE
+              | 11 > | MARVOR
+              | 12 > | RAFOS
+              | 13 > |  PROVOR
+              | 14 > |  SOLO
+              | 15 > |  APEX
+              | 16 > | Unspecified moored buoy
+              | 17 > | Nomad
+              | 18 > | 3-metre discus
+              | 19 > | 10-12-metre discus
+              | 20 > | ODAS 30 series
+              | 21 > | ATLAS (e.g. TAO area)
+              | 22 > | TRITON buoy
+              | 23 > |  FLEX Mooring (e.g. TIP Area)
+              | 24 > | Omnidirectional waverider
+              | 25 > | Directional waverider
+              | 26 > | Sub-surface ARGO float
+              | 27 > |  PALACE
+              | 28 > |  NEMO
+              | 29 > |  NINJA
+              | 30 > | Ice Buoy/Float (POPS or ITP)
+              | 34 > |  Mooring Oceanographic 
+              | 35 > |  Mooring Meteorological 
+              | 36 > |  Mooring Multidisciplinary (OceanSITES) 
+              | 37 > |  Mooring Tide Gauge or Tsunami buoy
+              | 38 > | Ice beacon
+              | 39   | Ice mass balance buoy
+
+  0-02-150 | INCN ; CODE
+              | 1 > | HIRS 1
+              | 2 > | HIRS 2
+              | 3 > | HIRS 3
+              | 4 > | HIRS 4
+              | 5 > | HIRS 5
+              | 6 > | HIRS 6
+              | 7 > | HIRS 7
+              | 8 > | HIRS 8
+              | 9 > | HIRS 9
+              | 10 > | HIRS 10
+              | 11 > | HIRS 11
+              | 12 > | HIRS 12
+              | 13 > | HIRS 13
+              | 14 > | HIRS 14
+              | 15 > | HIRS 15
+              | 16 > | HIRS 16
+              | 17 > | HIRS 17
+              | 18 > | HIRS 18
+              | 19 > | HIRS 19
+              | 20 > | HIRS 20
+              | 21 > | MSU 1
+              | 22 > | MSU 2
+              | 23 > | MSU 3
+              | 24 > | MSU 4
+              | 25 > | SSU 1
+              | 26 > | SSU 2
+              | 27 > | SSU 3
+              | 28 > | AMSU A 1
+              | 29 > | AMSU A 2
+              | 30 > | AMSU A 3
+              | 31 > | AMSU A 4
+              | 32 > | AMSU A 5
+              | 33 > | AMSU A 6
+              | 34 > | AMSU A 7
+              | 35 > | AMSU A 8
+              | 36 > | AMSU A 9
+              | 37 > | AMSU A 10
+              | 38 > | AMSU A 11
+              | 39 > | AMSU A 12
+              | 40 > | AMSU A 13
+              | 41 > | AMSU A 14
+              | 42 > | AMSU A 15
+              | 43 > | AMSU B 1 / MHS 1
+              | 44 > | AMSU B 2 / MHS 2
+              | 45 > | AMSU B 3 / MHS 3
+              | 46 > | AMSU B 4 / MHS 4
+              | 47 > | AMSU B 5 / MHS 5
+              | 48 > | AVHRR 1
+              | 49 > | AVHRR 2
+              | 50 > | AVHRR 3a
+              | 51 > | AVHRR 3b
+              | 52 > | AVHRR 4
+              | 53   | AVHRR 5
+
+  0-02-151 | RAID ; CODE
+              | 0 > | HIRS
+              | 1 > | MSU
+              | 2 > | SSU
+              | 3 > | AMSU A1 1
+              | 4 > | AMSU A1 2
+              | 5 > | AMSU A2
+              | 6 > | AMSU B
+              | 7 > | AVHRR
+              | 9   | MHS
+
+  0-02-152 | SIDP ; FLAG
+              | 1 > | High-resolution infrared sounder (HIRS)
+              | 2 > | Microwave sounding unit (MSU)
+              | 3 > | Stratospheric sounding unit (SSU)
+              | 4 > | AMI wind mode
+              | 5 > | AMI wave mode
+              | 6 > | AMI image mode
+              | 7 > | RADAR altimeter
+              | 8 > | ATSR
+              | 9 > | Geostationary Imager
+              | 10 > | Geostationary Sounder
+              | 11 > | Geostationary Earth radiation (GERB)
+              | 12 > | Multi-channel scanning radiometer
+              | 13   | Polar orbiting imager
+
+  0-02-158 | RA2M ; FLAG
+              | 1 > | Mismatch in RED VEC HPA
+              | 2 > | Mismatch in RED VEC RFSS
+              | 3 > | PTR calibration band 320 MHz (Ku)
+              | 4 > | PTR calibration band 80 MHz (Ku)
+              | 5 > | PTR calibration band 20 MHz (Ku)
+              | 6 > | PTR calibration band 160 MHz (S)
+              | 7 > | Ku flight calibration parameters available
+              | 8   | S flight calibration parameters available
+
+  0-02-159 | MWRI ; FLAG
+              | 1 > | Temperature inconsistency
+              | 2 > | Data is missing
+              | 3 > | Redundancy channel
+              | 4 > | Power bus protection
+              | 5   | Overvoltage/Overload protection
+
+  0-02-160 | WLOR ; CODE
+              | 1 > | 10 to less than 20 mm
+              | 3 > | 20 to less than 40 mm
+              | 5 > | 40 to less than 60 mm
+              | 7 > | 60 to less than 90 mm
+              | 8 > | 90 to less than 110 mm
+              | 9   | 110 mm and greater
+
+  0-02-161 | WDPF ; FLAG
+              | 11 > | Wind height calculated from median cloud-top pressure of target
+              | 12 > | Target is cloudy
+              | 13 > | Low-level inversion
+              | 14 > | CCC method
+              | 15   | Nested tracking
+
+  0-02-162 | EHAM ; CODE
+              | 0 > | Auto editor
+              | 1 > | IRW height assignment
+              | 2 > | WV height assignment
+              | 3 > | H2O intercept height assignment
+              | 4 > | CO2 slicing height assignment
+              | 5 > | Low pixel max gradient
+              | 6 > | Higher pixel max gradient
+              | 7 > | Primary height assignment
+              | 8 > | Layer thickness assignment
+              | 9 > | Cumulative contribution function - 10 percent height
+              | 10 > | Cumulative contribution function - 50 percent height
+              | 11 > | Cumulative contribution function - 90 percent height
+              | 12 > | Cumulative contribution function - height of maximum gradient
+              | 13 > | IR/two WV channel rationing method
+              | 14 > | Composite height assignment
+              | 15 > | Optimal estimation
+              | 16 > | Inversion correction
+              | 17   | Geometric height assignment
+
+  0-02-163 | HAMD ; CODE
+              | 0 > | Auto editor
+              | 1 > | IRW height assignment
+              | 2 > | WV height assignment
+              | 3 > | H2O intercept height assignment
+              | 4 > | CO2 slicing height assignment
+              | 5 > | Low pixel max gradient
+              | 6 > | Higher pixel max gradient
+              | 7 > | Primary height assignment
+              | 8 > | Layer thickness assignment
+              | 9 > | Cumulative contribution function - 10 percent height
+              | 10 > | Cumulative contribution function - 50 percent height
+              | 11 > | Cumulative contribution function - 90 percent height
+              | 12 > | Cumulative contribution function - height of maximum gradient
+              | 13 > | IR / two WV channel ratioing method
+              | 14   | Composite height assignment
+
+  0-02-164 | TCMD ; CODE
+              | 0 > | LP - Norms least square minimum
+              | 1 > | EN - Euclidean norm with radiance correlation
+              | 2 > | CC - Cross correlation
+              | 3   | Stereo matching
+
+  0-02-165 | RDTF ; FLAG
+              | 1 > | Clear path
+              | 2 > | Partly cloudy path
+              | 3 > | Cloudy path
+              | 4 > | Apodized
+              | 5 > | Unapodized
+              | 6 > | Reconstructed
+              | 7   | Cloud cleared
+
+  0-02-166 | RDTP ; CODE
+              | 0 > | Type not defined
+              | 1 > | Automated statistical regression
+              | 2 > | Clear path
+              | 3 > | Partly cloudy path
+              | 4   | Cloudy path
+
+  0-02-167 | RDCM ; CODE
+              | 0 > | Method not defined
+              | 1 > | 1b raw radiance
+              | 2   | Processed radiance
+
+  0-02-169 | ANTP ; CODE
+              | 0 > | Cup rotor
+              | 1 > | Propeller rotor
+              | 2 > | Wind Observation Through Ambient Noise (WOTAN)
+              | 3   | Sonic
+
+  0-02-170 | ACHS ; CODE
+              | 0 > | SpectraSensors WVSS-II, Version 1
+              | 1 > | SpectraSensors WVSS-II, Version 2
+              | 2 > | SpectraSensors WVSS-II, Version 3
+              | 62   | Other
+
+  0-02-172 | PTAG ; CODE
+              | 1 > | Retrieval from a nadir sounding
+              | 2 > | Retrieval from a limb sounding
+              | 3   | Retrieval from an occultation sounding
+
+  0-02-175 | MOPM ; CODE
+              | 0 > | Manual measurement
+              | 1 > | Tipping bucket method
+              | 2 > | Weighing method
+              | 3 > | Optical method
+              | 4 > | Pressure method
+              | 5 > | Float method
+              | 6 > | Drop counter method
+              | 14   | Others
+
+  0-02-176 | MSGM ; CODE
+              | 0 > | Manual observation
+              | 1 > | Video camera method
+              | 2 > | Infra-red method
+              | 3 > | Laser method
+              | 14   | Others
+
+  0-02-177 | MODM ; CODE
+              | 0 > | Manual observation
+              | 1 > | Ultrasonic method
+              | 2 > | Video camera method
+              | 3 > | Laser method
+              | 14   | Others
+
+  0-02-178 | MLMP ; CODE
+              | 0 > | Manual observation
+              | 1 > | Optical method
+              | 2 > | Capacitive method
+              | 14   | Others
+
+  0-02-179 | TSCA ; CODE
+              | 0 > | Manual observation
+              | 1 > | VAISALA algorithm
+              | 2 > | ASOS (FAA) algorithm
+              | 3 > | AWOS (Canada) algorithm
+              | 14   | Others
+
+  0-02-180 | MPRW ; CODE
+              | 0 > | Manual observation
+              | 1 > | Optical scatter system combined with precipitation occurrence sensing system
+              | 2 > | Forward and/or back-scatter system of visible light
+              | 3 > | Forward and/or back-scatter system of infrared light
+              | 4 > | Infrared light emitting diode (IRED) system
+              | 5 > | Doppler radar system
+              | 14   | Others
+
+  0-02-181 | SPRW ; FLAG
+              | 1 > | Rain detector
+              | 2 > | Freezing rain sensor
+              | 3 > | Ice detection sensor
+              | 4 > | Hail and ice pellet sensor
+              | 20   | Others
+
+  0-02-182 | VZMS ; CODE
+              | 0 > | Manual measurement
+              | 1 > | Transmissometer system (base > 25 m)
+              | 2 > | Transmissometer system (base < 25 m)
+              | 3 > | Forward scatter system
+              | 4 > | Back scatter system
+              | 14   | Others
+
+  0-02-183 | CLDS ; CODE
+              | 0 > | Manual observation
+              | 1 > | Ceilometer system
+              | 2 > | Infrared camera system
+              | 3 > | Microwave visual camera system
+              | 4 > | Sky imager system
+              | 5 > | Video time lapsed camera system
+              | 6 > | Micro pulse lidar (MPL) system
+              | 14   | Others
+
+  0-02-184 | TLDS ; CODE
+              | 0 > | Manual observation
+              | 1 > | Lightning imaging sensor
+              | 2 > | Electrical storm identification sensor
+              | 3 > | Magnetic finder sensor
+              | 4 > | Lightning strike sensor
+              | 5 > | Flash counter
+              | 6 > | ATDnet VLF waveform correlated sensor
+              | 14   | Others
+
+  0-02-185 | MEVM ; CODE
+              | 0 > | Manual measurement
+              | 1 > | Balanced floating method
+              | 2 > | Pressure method
+              | 3 > | Ultrasonic method
+              | 4 > | Hydraulic method
+              | 14   | Others
+
+  0-02-186 | CDPP ; FLAG
+              | 1 > | Precipitation-unknown type
+              | 2 > | Liquid precipitation not freezing
+              | 3 > | Liquid freezing precipitation
+              | 4 > | Drizzle
+              | 5 > | Rain
+              | 6 > | Solid precipitation
+              | 7 > | Snow
+              | 8 > | Snow grains
+              | 9 > | Snow pellets
+              | 10 > | Ice pellets
+              | 11 > | Ice crystals
+              | 12 > | Diamond dust
+              | 13 > | Small hail
+              | 14 > | Hail
+              | 15 > | Glaze
+              | 16 > | Rime
+              | 17 > | Soft rime
+              | 18 > | Hard rime
+              | 19 > | Clear ice
+              | 20 > | Wet snow
+              | 21 > | Hoar frost
+              | 22 > | Dew
+              | 23 > | White dew
+              | 24   | Convective precipitation
+
+  0-02-187 | CDWP ; FLAG
+              | 1 > | Dust/sand whirl
+              | 2 > | Squalls
+              | 3 > | Sand storm
+              | 4 > | Dust storm
+              | 5 > | Lightning - cloud to surface
+              | 6 > | Lightning - cloud to cloud
+              | 7 > | Lightning - distant
+              | 8 > | Thunderstorm
+              | 9 > | Funnel Cloud not touching surface
+              | 10 > | Funnel cloud touching surface
+              | 11   | Spray
+
+  0-02-188 | CDOB ; FLAG
+              | 1 > | Fog
+              | 2 > | Ice fog
+              | 3 > | Steam fog
+              | 7 > | Mist
+              | 8 > | Haze
+              | 9 > | Smoke
+              | 10 > | Volcanic ash
+              | 11 > | Dust
+              | 12 > | Sand
+              | 13   | Snow
+
+  0-02-189 | CDLS ; FLAG
+              | 1 > | Manual observation
+              | 2 > | All lightning strikes without discrimination
+              | 3 > | Lightning strikes cloud to ground only
+              | 4   | All lightning strikes with discrimination between cloud to ground and cloud to cloud
+
+  0-02-191 | GHTC ; CODE
+              | 0 > | Geopotential height calculated from pressure
+              | 1 > | Geopotential height calculated from GPS height
+              | 2   | Geopotential height calculated from radar height
+
+  0-03-001 | SFSTP ; CODE
+              | 0 > | Land station (synoptic network)
+              | 1 > | Shallow water station (fixed to sea/lake floor)
+              | 2 > | Ship
+              | 3 > | Rig/platform
+              | 4 > | Moored buoy
+              | 5 > | Drifting buoy (or drifter)
+              | 6 > | Ice buoy
+              | 7 > | Land station (local network)
+              | 8 > | Land vehicle
+              | 9 > | Autonomous marine vehicle
+              | 10   | Tag attached to marine animal
+
+  0-03-003 | THHS ; CODE
+              | 0 > | Screen
+              | 1 > | Sling/Whirling
+              | 2 > | Unscreened
+              | 3 > | Radiation shield
+              | 4 > | Aspirated (e.g. Assmann)
+              | 5 > | Other shelter
+              | 6   | Handheld
+
+  0-03-004 | TPSCSH ; CODE
+              | 0 > | Stevenson screen
+              | 1 > | Marine Stevenson screen
+              | 2 > | Cylindrical section plate shield
+              | 3 > | Concentric tube
+              | 4 > | Rectangular section shield
+              | 5 > | Square section shield
+              | 6 > | Triangular section shield
+              | 7 > | Open covered lean-to
+              | 8 > | Open covered inverted V roof
+              | 9   | Integrated (e.g. Chilled Mirror)
+
+  0-03-008 | AVSCSH ; CODE
+              | 0 > | Natural ventilation in use
+              | 1 > | Artificial ventilation in use; constant flow at time of reading
+              | 2   | Artificial ventilation in use; variable flow at time of reading
+
+  0-03-010 | MSCM ; CODE
+              | 2 > | GEK (Geomagnetic ElectroKinetograph)
+              | 3 > | Ship's set and drift determined by fixes 3-6 hours apart
+              | 4 > | Ship's set and drift determined by fixes more than 6 hours but less than 12 hours apart
+              | 5 > | Drift of buoy
+              | 6 > | ADCP (Acoustic Doppler Current Profiler)
+              | 7 > | ADCP (Acoustic Doppler Current Profiler) bottom tracking mode
+              | 8 > | Electromagnetic sensor
+              | 9 > | Rotor and vane
+              | 10   | Lowered ADCP
+
+  0-03-011 | MDCL ; CODE
+              | 0 > | Depth calculated using fall rate equation
+              | 1   | Depth calculated from water pressure/equation of state
+
+  0-03-012 | SDOM ; CODE
+              | 0 > | Anderraa oxygen optode
+              | 1   | Winkler bottle
+
+  0-03-016 | POSRS ; CODE
+              | 0 > | Fast lane between the wheel tracks
+              | 1 > | Fast lane between the wheel tracks in the opposite direction
+              | 2 > | Fast lane in the wheel tracks
+              | 3 > | Fast lane in the wheel tracks in the opposite direction
+              | 4 > | Slow lane between the wheel tracks
+              | 5 > | Slow lane between the wheel tracks in the opposite direction
+              | 6 > | Slow lane in the wheel tracks
+              | 7   | Slow lane in the wheel tracks in the opposite direction
+
+  0-03-017 | TOSTX ; FLAG
+              | 1 > | Automatic
+              | 2 > | Manned
+              | 3 > | Event-triggered
+              | 4   | Longer time period than the standard
+
+  0-03-018 | TPROAD ; CODE
+              | 0 > | Free track without further information
+              | 1 > | Free track, embankment
+              | 2 > | Free track, flat relative to surroundings
+              | 3 > | Free track, water basin(s) in vicinity
+              | 4 > | Free track, forest
+              | 5 > | Free track, cliff
+              | 6 > | Free track, on hilltop
+              | 7 > | Free track, on hilltop, forest
+              | 8 > | Free track, in valley
+              | 9 > | Free track, in valley, forest
+              | 10 > | Free track, north inclination
+              | 11 > | Free track, north inclination, forest
+              | 12 > | Free track, south inclination
+              | 13 > | Free track, south inclination, forest
+              | 20 > | Bridge without further information
+              | 21 > | Bridge across a valley in an urban area
+              | 22 > | Bridge across a valley with forest/meadows/fields
+              | 23 > | Bridge across street/track
+              | 24 > | Bridge across big river/canal
+              | 25 > | Bridge across river/canal of medium size
+              | 26   | Bridge across a small stream/loading canal
+
+  0-03-019 | TPCONS ; CODE
+              | 0 > | Asphalt
+              | 1 > | Concrete
+              | 2 > | Concrete construction
+              | 3 > | Steel-girder construction
+              | 4 > | Box girder bridge
+              | 5 > | Orthotropic slab
+              | 6   | Drain asphalt
+
+  0-03-020 | MTHHS ; CODE
+              | 0 > | Wood
+              | 1 > | Metal alloy
+              | 2 > | Plastic/GRP
+              | 3   | Reed/grass/leaf
+
+  0-03-021 | HYGH ; CODE
+              | 0 > | Unheated
+              | 1 > | Heated
+              | 2   | Not applicable
+
+  0-03-022 | INSTO ; CODE
+              | 0 > | National hydro meteorological/weather service
+              | 1 > | Other
+              | 2   | Standards institute
+
+  0-03-023 | CLTHS ; CODE
+              | 0 > | Single v section louvers
+              | 1 > | Overlapping louvers
+              | 2 > | Double v section louvers
+              | 3 > | Non-overlapping louvers
+              | 4 > | Vented, non-louvered
+              | 5   | Not applicable
+
+  0-03-027 | TPFR ; CODE
+              | 0 > | Solo (single radiosonde)
+              | 1 > | Block
+              | 2 > | Bar
+              | 3 > | Cross
+              | 4 > | T-rig
+              | 5 > | Double T-rig
+              | 6   | Complex
+
+  0-03-028 | MSWEM ; CODE
+              | 1 > | Multi point manual snow survey
+              | 2 > | Single point manual snow water equivalent measurement
+              | 3 > | Snow pillow or snow scale
+              | 4 > | Passive gamma
+              | 5 > | Cosmic ray attenuation
+              | 6   | Time domain reflectometry
+
+  0-04-059 | TOMV ; FLAG
+              | 1 > | 00 UTC
+              | 2 > | 06 UTC
+              | 3 > | 12 UTC
+              | 4 > | 18 UTC
+              | 5   | Other hours
+
+  0-04-080 | .AVP.... ; CODE
+              | 0 > | Spot values
+              | 1 > | Less than 15 minutes
+              | 2 > | From 15 to 45 minutes
+              | 3 > | More than 45 minutes
+              | 9   | Data not available
+
+  0-05-069 | RCVCH ; CODE
+              | 0 > | Mie
+              | 1 > | Rayleigh
+              | 2   | Cross polar
+
+  0-08-001 | VSIG ; FLAG
+              | 1 > | Surface
+              | 2 > | Standard level
+              | 3 > | Tropopause level
+              | 4 > | Maximum wind level
+              | 5 > | Significant level, temperature and/or relative humidity
+              | 6   | Significant level, wind
+
+  0-08-002 | VSSO ; CODE
+              | 0 > | Observing rules for base of lowest cloud and cloud types of FM 12 SYNOP and FM 13 SHIP apply
+              | 1 > | First non - Cb significant layer
+              | 2 > | Second non - Cb significant layer
+              | 3 > | Third non - Cb significant layer
+              | 4 > | Cumulonimbus layer
+              | 5 > | Ceiling
+              | 6 > | Clouds not detected below the following height(s)
+              | 7 > | Low cloud
+              | 8 > | Middle cloud
+              | 9 > | High cloud
+              | 10 > | Cloud layer with base below the station level and top above the station level
+              | 11 > | Cloud layer with base and top below the station level
+              | 20 > | No clouds detected by the cloud detection system
+              | 21 > | First instrument detected cloud layer
+              | 22 > | Second instrument detected cloud layer
+              | 23 > | Third instrument detected cloud layer
+              | 24 > | Fourth instrument detected cloud layer
+              | 62   | Value not applicable
+
+  0-08-003 | VSAT ; CODE
+              | 0 > | Surface
+              | 1 > | Base of Satellite sounding
+              | 2 > | Cloud top
+              | 3 > | Tropopause
+              | 4 > | Precipitable water
+              | 5 > | Sounding Radiances
+              | 6 > | Mean Temperatures
+              | 7 > | Ozone
+              | 8 > | Low cloud
+              | 9 > | Med Cloud
+              | 10   | High cloud
+
+  0-08-004 | POAF ; CODE
+              | 2 > | Unsteady (UNS)
+              | 3 > | Level flight, routine observation (LVR)
+              | 4 > | Level flight, highest wind encountered (LVW)
+              | 5 > | Ascending (ASC)
+              | 6   | Descending (DES)
+
+  0-08-005 | SSFO ; CODE
+              | 1 > | Storm center
+              | 2 > | Outer limit or edge of storm
+              | 3 > | Location of maximum wind
+              | 4 > | Location of the storm in the perturbed analysis
+              | 5   | Location of the storm in the analysis
+
+  0-08-006 | OVSS ; FLAG
+              | 1 > | Surface
+              | 2 > | Standard level
+              | 3 > | Tropopause level
+              | 4 > | Prominent maximum level
+              | 5 > | Prominent minimum level
+              | 6 > | Minimum pressure level
+              | 8   | Level of undetermined significance
+
+  0-08-007 | DIMS ; CODE
+              | 0 > | Point
+              | 1 > | Line
+              | 2 > | Area
+              | 3   | Volume
+
+  0-08-008 | RVSS ; FLAG
+              | 1 > | Surface
+              | 2 > | Standard level
+              | 3 > | Tropopause level
+              | 4 > | Level of beta radiation maximum
+              | 5 > | Level of gamma radiation maximum
+              | 6 > | Minimum pressure level
+              | 8   | Level of undetermined significance
+
+  0-08-009 | DPOF ; CODE
+              | 0 > | Level flight, routine observation, unsteady
+              | 1 > | Level flight, highest wind encountered, unsteady
+              | 2 > | Unsteady (UNS)
+              | 3 > | Level flight, routine observation (LVR)
+              | 4 > | Level flight, highest wind encountered (LVW)
+              | 5 > | Ascending (ASC)
+              | 6 > | Descending (DES)
+              | 7 > | Ascending, observation intervals selected by time increments
+              | 8 > | Ascending, observation intervals selected by time increments, unsteady
+              | 9 > | Ascending, observation intervals selected by pressure increments
+              | 10 > | Ascending, observation intervals selected by pressure increments, unsteady
+              | 11 > | Descending, observation intervals selected by time increments
+              | 12 > | Descending, observation intervals selected by time increments, unsteady
+              | 13 > | Descending, observation intervals selected by pressure increments
+              | 14   | Descending, observation intervals selected by pressure increments, unsteady
+
+  0-08-010 | SFCQ ; CODE
+              | 1 > | Bare soil
+              | 2 > | Bare rock
+              | 3 > | Land grass cover
+              | 4 > | Water (lake, sea)
+              | 5 > | Flood water underneath
+              | 6 > | Snow
+              | 7 > | Ice
+              | 8 > | Runway or road
+              | 9 > | Ship or platform deck in steel
+              | 10 > | Ship or platform deck in wood
+              | 11 > | Ship or platform deck partly covered with rubber mat
+              | 12   | Building roof
+
+  0-08-011 | METFET ; CODE
+              | 0 > | Quasi stationary front at the surface
+              | 1 > | Quasi stationary front above the surface
+              | 2 > | Warm front at the surface
+              | 3 > | Warm front above the surface
+              | 4 > | Cold front at the surface
+              | 5 > | Cold front above the surface
+              | 6 > | Occlusion
+              | 7 > | Instability line
+              | 8 > | Intertropical front
+              | 9 > | Convergence line
+              | 10 > | Jet stream
+              | 11 > | Cloud clear
+              | 12 > | Cloud
+              | 13 > | Turbulence
+              | 14 > | Storm
+              | 15 > | Airframe icing
+              | 16 > | Phenomenon
+              | 17 > | Volcano
+              | 18 > | Atmospherics
+              | 20 > | Special clouds
+              | 21 > | Thunderstorm
+              | 22 > | Tropical cyclone
+              | 23 > | Mountain Wave
+              | 24 > | Duststorm
+              | 25   | Sandstorm
+
+  0-08-012 | LSQL ; CODE
+              | 0 > | Land
+              | 1 > | Sea
+              | 2   | Coast
+
+  0-08-013 | DNQL ; CODE
+              | 0 > | Night
+              | 1 > | Day
+              | 2   | Twilight
+
+  0-08-014 | RVRQ ; CODE
+              | 0 > | 10 minute mean value   normal value
+              | 1 > | 10 minute mean value   above the upper limit for assessments of RVR (P)
+              | 2 > | 10 minute mean value  below the lower limit for assessments of RVR (M)
+              | 3 > | one minute minimum value   normal value
+              | 4 > | one minute minimum value   above the upper limit for assessments of RVR (P)
+              | 5 > | one minute minimum value   below the lower limit for assessments of RVR (M)
+              | 6 > | one minute maximum value   normal value
+              | 7 > | one minute maximum value   above the upper limit for assessments of RVR (P)
+              | 8   | one minute maximum value   below the lower limit for assessments of RVR (M)
+
+  0-08-015 | SIGS ; CODE
+              | 0 > | Single sensor
+              | 1 > | Primary sensor
+              | 2   | Secondary sensor (backup)
+
+  0-08-016 | CHQL ; CODE
+              | 0 > | NOSIG
+              | 1 > | BECMG
+              | 2 > | TEMPO
+              | 3   | FM
+
+  0-08-017 | FCQL ; CODE
+              | 0 > | FM
+              | 1 > | TL
+              | 2   | AT
+
+  0-08-018 | SLIT ; FLAG
+              | 1 > | Land is present
+              | 2 > | Surface ice map indicates ice is present
+              | 11 > | Ice map data not available
+              | 12   | Attenuation map data not available
+
+  0-08-019 | CIQL ; CODE
+              | 1 > | ATS (Air Traffic Service) unit serving FIR (Flight Information Region)
+              | 2 > | FIR (Flight Information Region)
+              | 3 > | UIR (Upper Information Region)
+              | 4 > | CTA (Control Area)
+              | 5 > | VAAC (Volcanic Ash Advisory Centre)
+              | 6   | MWO (Meteorological Watch Office) issuing SIGMET
+
+  0-08-021 | TSIG ; CODE
+              | 1 > | Time series
+              | 2 > | Time averaged
+              | 3 > | Accumulated
+              | 4 > | Forecast
+              | 5 > | Forecast time series
+              | 6 > | Forecast time averaged
+              | 7 > | Forecast accumulated
+              | 8 > | Ensemble mean
+              | 9 > | Ensemble mean time series
+              | 10 > | Ensemble mean time averaged
+              | 11 > | Ensemble mean accumulated
+              | 12 > | Ensemble mean forecast
+              | 13 > | Ensemble mean forecast time series
+              | 14 > | Ensemble mean forecast time averaged
+              | 15 > | Ensemble mean forecast accumulated
+              | 16 > | Analysis
+              | 17 > | Start of phenomenon
+              | 18 > | Radiosonde launch time
+              | 19 > | Start of orbit
+              | 20 > | End of orbit
+              | 21 > | Time of ascending node
+              | 22 > | Time of occurrence of wind shift
+              | 23 > | Monitoring period
+              | 24 > | Agreed time limit for report reception
+              | 25 > | Nominal reporting time
+              | 26 > | Time of last known position
+              | 27 > | First guess
+              | 28 > | Start of scan
+              | 29 > | End of scan or time of ending
+              | 30   | Time of occurrence
+
+  0-08-023 | FOST ; CODE
+              | 2 > | Maximum value
+              | 3 > | Minimum value
+              | 4 > | Mean value
+              | 5 > | Median value
+              | 6 > | Modal value
+              | 7 > | Mean absolute error
+              | 9 > | Best estimate of standard deviation (N-1)
+              | 10 > | Standard deviation (N)
+              | 11 > | Harmonic mean
+              | 12 > | Root-mean-square vector error
+              | 13 > | Root-mean-square
+              | 14 > | Root-mean-square error
+              | 32   | Vector mean
+
+  0-08-024 | DFST ; CODE
+              | 2 > | Observed minus maximum
+              | 3 > | Observed minus minimum
+              | 4 > | Observed minus mean
+              | 5 > | Observed minus median
+              | 6 > | Observed minus mode
+              | 11 > | Observed minus climatology (anomaly)
+              | 12 > | Observed minus analyzed value
+              | 13 > | Observed minus initialized analyzed value
+              | 14 > | Observed minus forecast value
+              | 21 > | Observed minus interpolated value
+              | 22   | Observed minus hydrostatically calculated value
+
+  0-08-025 | TDQL ; CODE
+              | 0 > | Universal Time Coordinated (UTC) minus Local Standard Time (LST)
+              | 1 > | Local Standard Time
+              | 2 > | Universal Time Coordinated (UTC) minus Satellite clock
+              | 5   | Time difference from edge of processing segment
+
+  0-08-026 | MTXSIG ; CODE
+              | 0 > | Averaging kernel matrix
+              | 1 > | Correlation matrix (C)
+              | 2 > | Lower triangular correlation matrix square root (L from C=LL^T)
+              | 3   | Inverse of lower triangular correlation matrix square root (L**-1)
+
+  0-08-029 | RSST ; CODE
+              | 0 > | Open ocean or semi-enclosed sea
+              | 1 > | Enclosed sea or lake
+              | 2 > | Continental ice
+              | 3 > | Land
+              | 4 > | Low inland (below sea level)
+              | 5 > | Mix of land and water
+              | 6 > | Mix of land and low inland
+              | 11 > | River
+              | 12 > | Lake
+              | 13 > | Sea
+              | 14 > | Glacier
+              | 15 > | Urban land
+              | 16 > | Rural land
+              | 17 > | Suburban land
+              | 18   | Sea ice
+
+  0-08-032 | SOOP ; CODE
+              | 0 > | Routine operation
+              | 1 > | Event triggered by storm surge
+              | 2 > | Event triggered by tsunami
+              | 3 > | Event triggered manually
+              | 4 > | Installation testing
+              | 5   | Maintenance testing
+
+  0-08-033 | MDPC ; CODE
+              | 1 > | Percentage confidence calculated using cloud fraction
+              | 2 > | Percentage confidence calculated using standard deviation of temperature
+              | 3 > | Percentage confidence calculated using probability of cloud contamination
+              | 4   | Percentage confidence calculated using normality of distribution
+
+  0-08-034 | TSQL ; CODE
+              | 0 > | Secondary sampling: averaged
+              | 1 > | Secondary sampling: discrete
+              | 2 > | Secondary sampling: mixed
+              | 3 > | Near-surface sampling: averaged, pumped
+              | 4 > | Near-surface sampling: averaged, unpumped
+              | 5 > | Near-surface sampling: discrete, pumped
+              | 6 > | Near-surface sampling: discrete, unpumped
+              | 7 > | Near-surface sampling: mixed, pumped
+              | 8   | Near-surface sampling: mixed, unpumped
+
+  0-08-035 | TOME ; CODE
+              | 0 > | Global
+              | 1 > | Regional
+              | 2 > | National
+              | 3 > | Special
+              | 4   | Bilateral
+
+  0-08-036 | TSPM ; CODE
+              | 0 > | WMO Secretariat
+              | 1 > | WMO
+              | 2 > | RSMC
+              | 3 > | NMC
+              | 4 > | RTH
+              | 5 > | Observing site
+              | 6   | Other
+
+  0-08-037 | BLCSIG ; CODE
+              | 0 > | Manufacturer's baseline unit check
+              | 1 > | Weather screen
+              | 2   | GRUAN standard humidity chamber
+
+  0-08-038 | INDSIG ; CODE
+              | 0 > | Verified instrument reading
+              | 1   | Reference instrument reading
+
+  0-08-039 | TSIGAF ; CODE
+              | 0 > | Issue time of forecast
+              | 1 > | Time of commencement of period of the forecast
+              | 2 > | Time of ending of period of the forecast
+              | 3 > | Forecast time of maximum temperature
+              | 4 > | Forecast time of minimum temperature
+              | 5 > | Time of beginning of the forecast change
+              | 6   | Time of ending of the forecast change
+
+  0-08-040 | LEVSIG ; CODE
+              | 0 > | High-resolution data sample
+              | 1 > | Within 20 hPa of surface
+              | 2 > | Pressure less than 10 hPa (i.e. 9, 8, 7, etc.) when no other reason applies
+              | 3 > | Base pressure level for stability index
+              | 4 > | Begin doubtful temperature, height data
+              | 5 > | Begin missing data (all elements)
+              | 6 > | Begin missing relative humidity data
+              | 7 > | Begin missing temperature data
+              | 8 > | Highest level reached before balloon descent because of icing or turbulence
+              | 9 > | End doubtful temperature, height data
+              | 10 > | End missing data (all elements)
+              | 11 > | End missing relative humidity data
+              | 12 > | End missing temperature data
+              | 13 > | Zero degrees C crossing(s) for RADAT
+              | 14 > | Standard pressure level
+              | 15 > | Operator added level
+              | 16 > | Operator deleted level
+              | 17 > | Balloon re ascended beyond previous highest ascent level
+              | 18 > | Significant RH level
+              | 19 > | RH level selection terminated
+              | 20 > | Surface level
+              | 21 > | Significant temperature level
+              | 22 > | Mandatory temperature level
+              | 23 > | Flight termination level
+              | 24 > | Tropopause(s)
+              | 25 > | Aircraft report
+              | 26 > | Interpolated (generated) level
+              | 27 > | Mandatory wind level
+              | 28 > | Significant wind level
+              | 29 > | Maximum wind level
+              | 30 > | Incremental wind level (fixed regional)
+              | 31 > | Incremental height level (generated)
+              | 32 > | Wind termination level
+              | 33 > | Pressure 100 to 110 hPa, when no other reason applies
+              | 34 > | Freezing level base
+              | 35 > | Freezing level top
+              | 36 > | Flight level base
+              | 37 > | Flight level top
+              | 38 > | Top of wind sounding
+              | 39 > | Bottom of wind sounding
+              | 40 > | Significant thermodynamic level (inversion)
+              | 41 > | Significant RH level (per NCDC criteria)
+              | 42 > | Significant temperature level (per NCDC)
+              | 43 > | Begin missing wind data
+              | 44 > | End missing wind data
+              | 60 > | Level of 80-knot isotach above jet
+              | 61 > | Level of 80-knot isotach below jet
+              | 62   | Other
+
+  0-08-041 | DATSIG ; CODE
+              | 0 > | Parent site
+              | 1 > | Observation site
+              | 2 > | Balloon manufacture date
+              | 3 > | Balloon launch point
+              | 4 > | Surface observation
+              | 5 > | Surface observation displacement from launch point
+              | 6 > | Flight level observation
+              | 7 > | Flight level termination point
+              | 8 > | IFR Ceiling and Visibility
+              | 9 > | Mountain obscuration
+              | 10 > | Strong surface wind
+              | 11 > | Freezing level
+              | 12 > | Multiple freezing level
+              | 13   | Instrument manufacture date
+
+  0-08-042 | VSIGX ; FLAG
+              | 1 > | Surface
+              | 2 > | Standard level
+              | 3 > | Tropopause level
+              | 4 > | Maximum wind level
+              | 5 > | Significant temperature level
+              | 6 > | Significant humidity level
+              | 7 > | Significant wind level
+              | 8 > | Beginning of missing temperature data
+              | 9 > | End of missing temperature data
+              | 10 > | Beginning of missing humidity data
+              | 11 > | End of missing humidity data
+              | 12 > | Beginning of missing wind data
+              | 13 > | End of missing wind data
+              | 14 > | Top of wind sounding
+              | 15 > | Level determined by regional decision
+              | 16 > | Freezing level
+              | 17   | Pressure level originally indicated by height as the vertical coordinate
+
+  0-08-043 | ATCT ; CODE
+              | 0 > | Ozone
+              | 1 > | Water vapour
+              | 2 > | Methane
+              | 3 > | Carbon dioxide
+              | 4 > | Carbon monoxide
+              | 5 > | Nitrogen dioxide
+              | 6 > | Nitrous oxide
+              | 7 > | Formaldehyde
+              | 8 > | Sulfur dioxide
+              | 9 > | Volcanic sulphur dioxide
+              | 25 > | Particulate Matter < 1.0 microns
+              | 26 > | Particulate Matter < 2.5 microns
+              | 27 > | Particulate Matter < 10 microns
+              | 28 > | Aerosols (generic)
+              | 29 > | Smoke (generic)
+              | 30 > | Crustal Material (generic dust)
+              | 31 > | Volcanic Ash
+              | 32 > | Cloud
+              | 33   | Cloud and aerosols
+
+  0-08-046 | ACCT ; CODE
+              | 0 > | Ozone (O3)
+              | 1 > | Water vapour (H2O)
+              | 2 > | Methane (CH4)
+              | 3 > | Carbon dioxide (CO2)
+              | 4 > | Carbon monoxide (CO)
+              | 5 > | Nitrogen dioxide (NO2)
+              | 6 > | Nitrous oxide (N2O)
+              | 7 > | Formaldehyde (HCHO)
+              | 8 > | Sulphur dioxide (SO2)
+              | 9 > | Ammonia (NH3)
+              | 10 > | Ammonium cation (NH4+)
+              | 11 > | Nitrogen monoxide (NO)
+              | 12 > | Atomic oxygen (O)
+              | 13 > | Nitrate radical (NO3)
+              | 14 > | Hydroperoxyl radical (HOO)
+              | 15 > | Dinitrogen pentoxide (N2O5)
+              | 16 > | Nitrous acid (HONO)
+              | 17 > | Nitric acid (HNO3)
+              | 18 > | Peroxynitric acid (HO2NO2)
+              | 19 > | Hydrogen peroxide (H2O2)
+              | 20 > | Dihydrogen (H2)
+              | 21 > | Atomic nitrogen (N)
+              | 22 > | Sulphate anion (SO4--)
+              | 23 > | Atomic radon (Rn)
+              | 24 > | Mercury vapour (Hg(0))
+              | 25 > | Mercury(II) cation (Hg2+)
+              | 26 > | Atomic chlorine (Cl)
+              | 27 > | Chlorine monoxide (ClO)
+              | 28 > | Dichlorine peroxide (Cl2O2)
+              | 29 > | Hypochlorous acid (HClO)
+              | 30 > | Chlorine nitrate (ClONO2)
+              | 31 > | Chlorine dioxide (ClO2)
+              | 32 > | Atomic bromine (Br)
+              | 33 > | Bromine monoxide (BrO)
+              | 34 > | Bromine chloride (BrCl)
+              | 35 > | Hydrogen bromide (HBr)
+              | 36 > | Hypobromous acid (HBrO)
+              | 37 > | Bromine nitrate (BrONO2)
+              | 38 > | Dioxygen (O2)
+              | 39 > | Nitryl chloride (NO2Cl)
+              | 40 > | Sulphuric Acid (H2SO4)
+              | 41 > | Hydrogen sulphide (H2S)
+              | 42 > | Sulphur trioxide (SO3)
+              | 43 > | Bromine (Br2)
+              | 44 > | Hydrofluoric acid (HF)
+              | 45 > | Sulfur hexaflouride (SF6)
+              | 46 > | Chlorine (Cl2)
+              | 10000 > | Hydroxyl radical (OH)
+              | 10001 > | Methyl peroxy radical (CH3OO)
+              | 10002 > | Methyl hydroperoxide (CH3O2H)
+              | 10004 > | Methanol (CH3OH)
+              | 10005 > | Formic acid (CH3OOH)
+              | 10006 > | Hydrogen Cyanide (HCN)
+              | 10007 > | Aceto nitrile (CH3CN)
+              | 10008 > | Ethane (C2H6)
+              | 10009 > | Ethene (= Ethylene) (C2H4)
+              | 10010 > | Ethyne (= Acetylene) (C2H2)
+              | 10011 > | Ethanol (C2H5OH)
+              | 10012 > | Acetic acid (C2H5OOH)
+              | 10013 > | Peroxyacetyl nitrate (CH3C(O)OONO2)
+              | 10014 > | Propane (C3H8)
+              | 10015 > | Propene (C3H6)
+              | 10016 > | Butanes (all isomers)
+              | 10017 > | Isoprene (C5H10)
+              | 10018 > | Alpha pinene (C10H16)
+              | 10019 > | Beta pinene (C10H16)
+              | 10020 > | Limonene (C10H16)
+              | 10021 > | Benzene (C6H6)
+              | 10022 > | Toluene (C7H8)
+              | 10023 > | Xylene (C8H10)
+              | 10024 > | Methanesulphonic acid
+              | 10025 > | Methylglyoxal (2-oxopropanal)
+              | 10026 > | Peroxyacetyl radical
+              | 10027 > | Methacrylic acid (2-methylprop-2-enoic acid)
+              | 10028 > | Methacrolein (2-methylprop-2-enal)
+              | 10029 > | Acetone (propan-2-one)
+              | 10030 > | Ethyl dioxidanyl radical
+              | 10031 > | Butadiene (buta-1,3-diene)
+              | 10032 > | Acetaldehyde (ethanal)
+              | 10033 > | Glycolaldehyde (hydroxyethanal)
+              | 10034 > | Cresol (methylphenol), all isomers
+              | 10035 > | Peracetic acid (ethaneperoxoic acid)
+              | 10036 > | 2-hydroxyethyl oxidanyl radical
+              | 10037 > | 2-hydroxyethyl dioxidanyl radical
+              | 10038 > | Glyoxal (oxaldehyde)
+              | 10039 > | Isopropyl dioxidanyl radical
+              | 10040 > | Isopropyl hydroperoxide (2-hydroperoxypropane)
+              | 10041 > | Hydroxyacetone (1-hydroxypropan-2-one)
+              | 10042 > | Peroxyacetic acid (ethaneperoxoic acid)
+              | 10043 > | Methyl vinyl ketone (but-3-en-2-one)
+              | 10044 > | Phenoxy radical
+              | 10045 > | Methyl radical
+              | 10046 > | Carbonyl sulphide (carbon oxide sulphide)
+              | 10047 > | Dibromomethane (CH2BR2)
+              | 10048 > | Methoxy radical
+              | 10049 > | Tribromomethane (CHBR3)
+              | 10050 > | Formyl radical (oxomethyl radical)
+              | 10051 > | Hydroxymethyl dioxidanyl radical
+              | 10052 > | Ethyl hydroperoxide
+              | 10053 > | 3-hydroxypropyl dioxidanyl radical
+              | 10054 > | 3-hydroxypropyl hydroperoxide
+              | 10055 > | Methyl-peroxy-nitrate (Nitroperoxy-methane)
+              | 10056 > | 2-lambda-1-Oxidanyloxy-2-methylbut-3-en-1-ol (4-Hydroxy-3-methyl-1-butene-3-ylperoxy radical)
+              | 10057 > | 2-lambda-1-Oxidanyloxy-3-methylbut-3-en-1-ol (2-Hydroxy-1-isopropenylethylperoxy radical)
+              | 10058 > | (Z)-4-Hydroperoxy-2-methyl-2-butenal
+              | 10059 > | (Z)-4-Hydroperoxy-3-methyl-2-butenal
+              | 10500 > | Dimethyl sulphide (CH3SCH3 (DMS))
+              | 10501 > | Dimethyl sulphoxide ((CH3)2SO (DMSO))
+              | 20001 > | Hydrogen chloride (HCl)
+              | 20002 > | CFC-11
+              | 20003 > | CFC-12
+              | 20004 > | CFC-113
+              | 20005 > | CFC-113a
+              | 20006 > | CFC-114
+              | 20007 > | CFC-115
+              | 20008 > | HCFC-22
+              | 20009 > | HCFC-141b
+              | 20010 > | HCFC-142b
+              | 20011 > | Halon-1202
+              | 20012 > | Halon-1211
+              | 20013 > | Halon-1301
+              | 20014 > | Halon-2402
+              | 20015 > | Methyl chloride (HCC-40)
+              | 20016 > | Carbon tetrachloride (HCC-10)
+              | 20017 > | HCC-140a (CH3CCl3)
+              | 20018 > | Methyl bromide (HBC-40B1)
+              | 20019 > | Hexachlorocyclohexane (HCH) all isomers
+              | 20020 > | Alpha hexachlorocyclohexane both enantiomers
+              | 20021 > | Hexachlorobiphenyl (PCB-153)
+              | 20022 > | HCFC 141a (1,1-dichloro-2-fluoro-ethane)
+              | 30000 > | Radioactive pollutant (tracer, defined by originating centre)
+              | 30010 > | Tritium (Hydrogen 3)
+              | 30011 > | Tritium organic bounded
+              | 30012 > | Tritium inorganic
+              | 30013 > | Beryllium 7
+              | 30014 > | Beryllium 10
+              | 30015 > | Carbon 14
+              | 30016 > | Carbon 14 carbon dioxide
+              | 30017 > | Carbon 14 other gases
+              | 30018 > | Nitrogen 13
+              | 30019 > | Nitrogen 16
+              | 30020 > | Fluorine 18
+              | 30021 > | Sodium 22
+              | 30022 > | Phosphate 32
+              | 30023 > | Phosphate 33
+              | 30024 > | Sulfur 35
+              | 30025 > | Chlorine 36
+              | 30026 > | Potassium 40
+              | 30027 > | Argon 41
+              | 30028 > | Calcium 41
+              | 30029 > | Calcium 45
+              | 30030 > | Titanium 44
+              | 30031 > | Scandium 46
+              | 30032 > | Vanadium 48
+              | 30033 > | Vanadium 49
+              | 30034 > | Chrome 51
+              | 30035 > | Manganese 52
+              | 30036 > | Manganese 54
+              | 30037 > | Iron 55
+              | 30038 > | Iron 59
+              | 30039 > | Cobalt 56
+              | 30040 > | Cobalt 57
+              | 30041 > | Cobalt 58
+              | 30042 > | Cobalt 60
+              | 30043 > | Nickel 59
+              | 30044 > | Nickel 63
+              | 30045 > | Zinc 65
+              | 30046 > | Gallium 67
+              | 30047 > | Gallium 68
+              | 30048 > | Germanium 68
+              | 30049 > | Germanium 69
+              | 30050 > | Arsenic 73
+              | 30051 > | Selenium 75
+              | 30052 > | Selenium 79
+              | 30053 > | Rubidium 81
+              | 30055 > | Rubidium 84
+              | 30056 > | Rubidium 86
+              | 30057 > | Rubidium 87
+              | 30058 > | Rubidium 88
+              | 30059 > | Krypton 85
+              | 30060 > | Krypton 85 metastable
+              | 30061 > | Krypton 87
+              | 30062 > | Krypton 88
+              | 30063 > | Krypton 89
+              | 30064 > | Strontium 85
+              | 30065 > | Strontium 89
+              | 30066 > | Strontium 89/90
+              | 30067 > | Strontium 90
+              | 30068 > | Strontium 91
+              | 30069 > | Strontium 92
+              | 30070 > | Yttrium 87
+              | 30071 > | Yttrium 88
+              | 30072 > | Yttrium 90
+              | 30073 > | Yttrium 91
+              | 30074 > | Yttrium 91 metastable
+              | 30075 > | Yttrium 92
+              | 30076 > | Yttrium 93
+              | 30077 > | Zirconium 89
+              | 30078 > | Zirconium 93
+              | 30079 > | Zirconium 95
+              | 30080 > | Zirconium 97
+              | 30081 > | Niobium 93 metastable
+              | 30082 > | Niobium 94
+              | 30083 > | Niobium 95
+              | 30084 > | Niobium 95 metastable
+              | 30085 > | Niobium 97
+              | 30086 > | Niobium 97 metastable
+              | 30087 > | Molybdenum 93
+              | 30088 > | Molybdenum 99
+              | 30089 > | Technetium 95 metastable
+              | 30090 > | Technetium 96
+              | 30091 > | Technetium 99
+              | 30092 > | Technetium 99 metastable
+              | 30093 > | Rhodium 99
+              | 30094 > | Rhodium 101
+              | 30095 > | Rhodium 102 metastable
+              | 30096 > | Rhodium 103 metastable
+              | 30097 > | Rhodium 105
+              | 30098 > | Rhodium 106
+              | 30099 > | Palladium 100
+              | 30100 > | Palladium 103
+              | 30101 > | Palladium 107
+              | 30102 > | Ruthenium 103
+              | 30103 > | Ruthenium 105
+              | 30104 > | Ruthenium 106
+              | 30105 > | Silver 108 metastable
+              | 30106 > | Silver 110 metastable
+              | 30107 > | Cadmium 109
+              | 30108 > | Cadmium 113 metastable
+              | 30109 > | Cadmium 115 metastable
+              | 30110 > | Indium 114 metastable
+              | 30111 > | Tin 113
+              | 30112 > | Tin 119 metastable
+              | 30113 > | Tin 121 metastable
+              | 30114 > | Tin 122
+              | 30115 > | Tin 123
+              | 30116 > | Tin 126
+              | 30117 > | Antimony 124
+              | 30118 > | Antimony 125
+              | 30119 > | Antimony 126
+              | 30120 > | Antimony 127
+              | 30121 > | Antimony 129
+              | 30122 > | Tellurium 123 metastable
+              | 30123 > | Tellurium 125 metastable
+              | 30124 > | Tellurium 127
+              | 30125 > | Tellurium 127 metastable
+              | 30126 > | Tellurium 129
+              | 30127 > | Tellurium 129 metastable
+              | 30128 > | Tellurium 131 metastable
+              | 30129 > | Tellurium 132
+              | 30130 > | Iodine 123
+              | 30131 > | Iodine 124
+              | 30132 > | Iodine 125
+              | 30133 > | Iodine 126
+              | 30134 > | Iodine 129
+              | 30135 > | Iodine 129 elementary gaseous
+              | 30136 > | Iodine 129 organic bounded
+              | 30137 > | Iodine 131
+              | 30138 > | Iodine 131 elementary gaseous
+              | 30139 > | Iodine 131 organic bounded
+              | 30140 > | Iodine 131 gaseous elementary and organic bounded
+              | 30141 > | Iodine 131 aerosol
+              | 30142 > | Iodine 132
+              | 30143 > | Iodine 132 elementary gaseous
+              | 30144 > | Iodine 132 organic bounded
+              | 30145 > | Iodine 132 gaseous elementary and organic bounded
+              | 30146 > | Iodine 132 aerosol
+              | 30147 > | Iodine 133
+              | 30148 > | Iodine 133 elementary gaseous
+              | 30149 > | Iodine 133 organic bounded
+              | 30150 > | Iodine 133 gaseous elementary and organic bounded
+              | 30151 > | Iodine 133 aerosol
+              | 30152 > | Iodine 134
+              | 30153 > | Iodine 134 elementary gaseous
+              | 30154 > | Iodine 134 organic bounded
+              | 30155 > | Iodine 135
+              | 30156 > | Iodine 135 elementary gaseous
+              | 30157 > | Iodine 135 organic bounded
+              | 30158 > | Iodine 135 gaseous elementary and organic bounded
+              | 30159 > | Iodine 135 aerosol
+              | 30160 > | Xenon 131 metastable
+              | 30161 > | Xenon 133
+              | 30162 > | Xenon 133 metastable
+              | 30163 > | Xenon 135
+              | 30164 > | Xenon 135 metastable
+              | 30165 > | Xenon 137
+              | 30166 > | Xenon 138
+              | 30167 > | Xenon sum of all Xenon isotopes
+              | 30168 > | Caesium 131
+              | 30169 > | Caesium 134
+              | 30170 > | Caesium 135
+              | 30171 > | Caesium 136
+              | 30172 > | Caesium 137
+              | 30173 > | Barium 133
+              | 30174 > | Barium 137 metastable
+              | 30175 > | Barium 140
+              | 30176 > | Cerium 139
+              | 30177 > | Cerium 141
+              | 30178 > | Cerium 143
+              | 30179 > | Cerium 144
+              | 30180 > | Lanthanum 140
+              | 30181 > | Lanthanum 141
+              | 30182 > | Praseodymium 143
+              | 30183 > | Praseodymium 144
+              | 30184 > | Praseodymium 144 metastable
+              | 30185 > | Samarium 145
+              | 30186 > | Samarium 147
+              | 30187 > | Samarium 151
+              | 30188 > | Neodymium 147
+              | 30189 > | Promethium 146
+              | 30190 > | Promethium 147
+              | 30191 > | Promethium 151
+              | 30192 > | Europium 152
+              | 30193 > | Europium 154
+              | 30194 > | Europium 155
+              | 30195 > | Gadolinium 153
+              | 30196 > | Terbium 160
+              | 30197 > | Holmium 166 metastable
+              | 30198 > | Thulium 170
+              | 30199 > | Ytterbium 169
+              | 30200 > | Hafnium 175
+              | 30201 > | Hafnium 181
+              | 30202 > | Tantalum 179
+              | 30203 > | Tantalum 182
+              | 30204 > | Rhenium 184
+              | 30205 > | Iridium 192
+              | 30206 > | Mercury 203
+              | 30207 > | Thallium 204
+              | 30208 > | Thallium 207
+              | 30209 > | Thallium 208
+              | 30210 > | Thallium 209
+              | 30211 > | Bismuth 205
+              | 30212 > | Bismuth 207
+              | 30213 > | Bismuth 210
+              | 30214 > | Bismuth 211
+              | 30215 > | Bismuth 212
+              | 30216 > | Bismuth 213
+              | 30217 > | Bismuth 214
+              | 30218 > | Polonium 208
+              | 30219 > | Polonium 210
+              | 30220 > | Polonium 212
+              | 30221 > | Polonium 213
+              | 30222 > | Polonium 214
+              | 30223 > | Polonium 215
+              | 30224 > | Polonium 216
+              | 30225 > | Polonium 218
+              | 30226 > | Lead 209
+              | 30227 > | Lead 210
+              | 30228 > | Lead 211
+              | 30229 > | Lead 212
+              | 30230 > | Lead 214
+              | 30231 > | Astatine 217
+              | 30232 > | Radon 219
+              | 30233 > | Radon 220
+              | 30234 > | Radon 222
+              | 30235 > | Francium 221
+              | 30236 > | Francium 223
+              | 30237 > | Radium 223
+              | 30238 > | Radium 224
+              | 30239 > | Radium 225
+              | 30240 > | Radium 226
+              | 30241 > | Radium 228
+              | 30242 > | Actinium 225
+              | 30243 > | Actinium 227
+              | 30244 > | Actinium 228
+              | 30245 > | Thorium 227
+              | 30246 > | Thorium 228
+              | 30247 > | Thorium 229
+              | 30248 > | Thorium 230
+              | 30249 > | Thorium 231
+              | 30250 > | Thorium 232
+              | 30251 > | Thorium 234
+              | 30252 > | Protactinium 231
+              | 30253 > | Protactinium 233
+              | 30254 > | Protactinium 234 metastable
+              | 30255 > | Uranium 232
+              | 30256 > | Uranium 233
+              | 30257 > | Uranium 234
+              | 30258 > | Uranium 235
+              | 30259 > | Uranium 236
+              | 30260 > | Uranium 237
+              | 30261 > | Uranium 238
+              | 30262 > | Plutonium 236
+              | 30263 > | Plutonium 238
+              | 30264 > | Plutonium 239
+              | 30265 > | Plutonium 240
+              | 30266 > | Plutonium 241
+              | 30267 > | Plutonium 242
+              | 30268 > | Plutonium 244
+              | 30269 > | Neptunium 237
+              | 30270 > | Neptunium 238
+              | 30271 > | Neptunium 239
+              | 30272 > | Americium 241
+              | 30273 > | Americium 242
+              | 30274 > | Americium 242 metastable
+              | 30275 > | Americium 243
+              | 30276 > | Curium 242
+              | 30277 > | Curium 243
+              | 30278 > | Curium 244
+              | 30279 > | Curium 245
+              | 30280 > | Curium 246
+              | 30281 > | Curium 247
+              | 30282 > | Curium 248
+              | 30283 > | Curium 243/244
+              | 30284 > | Plutonium 238/Americium 241
+              | 30285 > | Plutonium 239/240
+              | 30286 > | Berkelium 249
+              | 30287 > | Californium 249
+              | 30288 > | Californium 250
+              | 30289 > | Californium 252
+              | 30290 > | Sum aerosol particulates
+              | 30291 > | Sum Iodine
+              | 30292 > | Sum noble gas
+              | 30293 > | Activation gas
+              | 30294 > | Cs-137 equivalent
+              | 30295 > | Carbon 13
+              | 30296 > | Lead (Pb)
+              | 30297 > | Tellurium 131
+              | 30298 > | Neodymium 137
+              | 40000 > | Singlet sigma oxygen (dioxygen (sigma singlet))
+              | 40001 > | Singlet delta oxygen (dioxygen (delta singlet))
+              | 40002 > | Singlet excited oxygen atom
+              | 40003 > | Triplet ground state oxygen atom
+              | 60000 > | HOx radical (OH+HO2)
+              | 60001 > | Total inorganic and organic peroxy radicals (HO2 + RO2) (RO2)
+              | 60002 > | Passive Ozone
+              | 60003 > | NOx expressed as nitrogen (NOx)
+              | 60004 > | All nitrogen oxides (NOx) expressed as nitrogen (NOx)
+              | 60005 > | Total inorganic chlorine (Clx)
+              | 60006 > | Total inorganic bromine (Brx)
+              | 60007 > | Total inorganic chlorine except HCl, ClONO2: ClOx
+              | 60008 > | Total inorganic bromine except HBr, BrONO2: BrOx
+              | 60009 > | Lumped Alkanes
+              | 60010 > | Lumped Alkenes
+              | 60011 > | Lumped Aromatic Compounds
+              | 60012 > | Lumped Terpenes
+              | 60013 > | Non-methane volatile organic compounds expressed as carbon (NMVOC)
+              | 60014 > | Anthropogenic non-methane volatile organic compounds expressed as carbon (aNMVOC)
+              | 60015 > | Biogenic non-methane volatile organic compounds expressed as carbon (bNMVOC)
+              | 60016 > | Lumped oxygenated hydrocarbons (OVOC)
+              | 60017 > | NOx expressed as nitrogen dioxide (NO2)
+              | 60018 > | Organic aldehydes
+              | 60019 > | Organic peroxides
+              | 60020 > | Organic nitrates
+              | 60021 > | Ethers
+              | 60022 > | Amines
+              | 60023 > | Ketones
+              | 60024 > | Dicarbonyls unsaturated
+              | 60025 > | Hydroxy dicarbonyls unsaturated
+              | 60026 > | Hydroxy ketones
+              | 60027 > | Oxides
+              | 60028 > | Peroxyacyl nitrates
+              | 60029 > | Aromatic peroxide radicals (Aryl dioxydanyl radicals)
+              | 60030 > | Biogenic secondary organic compound
+              | 60031 > | Anthropogenic secondary organic compound
+              | 60032 > | All hydroxy-peroxide products of the reaction of hydroxy-isoprene adducts with oxygen
+              | 60033 > | Anthropogenic volatile organic compounds
+              | 60034 > | Biomass burning volatile organic compounds
+              | 62000 > | Total aerosol
+              | 62001 > | Dust dry
+              | 62002 > | Water in ambient
+              | 62003 > | Ammonium dry
+              | 62004 > | Nitrate dry
+              | 62005 > | Nitric acid trihydrate
+              | 62006 > | Sulphate dry
+              | 62007 > | Mercury dry
+              | 62008 > | Sea salt dry
+              | 62009 > | Black carbon dry
+              | 62010 > | Particulate organic matter dry
+              | 62011 > | Primary particulate organic matter dry
+              | 62012 > | Secondary particulate organic matter dry
+              | 62013 > | Black carbon hydrophilic dry
+              | 62014 > | Black carbon hydrophobic dry
+              | 62015 > | Particulate organic matter hydrophilic dry
+              | 62016 > | Particulate organic matter hydrophobic dry
+              | 62017 > | Nitrate hydrophilic dry
+              | 62018 > | Nitrate hydrophobic dry
+              | 62020 > | Smoke - high absorption
+              | 62021 > | Smoke - low absorption
+              | 62022 > | Aerosol - high absorption
+              | 62023 > | Aerosol - low absorption
+              | 62025 > | Volcanic ash
+              | 62026 > | Particulate matter (PM)
+              | 62028 > | Total aerosol hydrophilic
+              | 62029 > | Total aerosol hydrophobic
+              | 62030 > | Primary particulate inorganic matter dry
+              | 62031 > | Secondary particulate inorganic matter dry
+              | 62032 > | Biogenic secondary organic aerosol
+              | 62033 > | Anthropogenic secondary organic aerosol
+              | 62034 > | Rain water
+              | 62035 > | Cloud water
+              | 62036 > | Brown carbon dry
+              | 62100 > | Alnus (Alder) pollen
+              | 62101 > | Betula (Birch) pollen
+              | 62102 > | Castanea (Chestnut) pollen
+              | 62103 > | Carpinus (Hornbeam) pollen
+              | 62104 > | Corylus (Hazel) pollen
+              | 62105 > | Fagus (Beech) pollen
+              | 62106 > | Fraxinus (Ash) pollen
+              | 62107 > | Pinus (Pine) pollen
+              | 62108 > | Platanus (Plane) pollen
+              | 62109 > | Populus (Cottonwood, Poplar) pollen
+              | 62110 > | Quercus (Oak) pollen
+              | 62111 > | Salix (Willow) pollen
+              | 62112 > | Taxus (Yew) pollen
+              | 62113 > | Tilia (Lime, Linden) pollen
+              | 62114 > | Ulmus (Elm) pollen
+              | 62115 > | Olea (Olive) pollen
+              | 62200 > | Ambrosia (Ragweed, Burr-ragweed) pollen
+              | 62201 > | Artemisia (Sagebrush, Wormwood, Mugwort) pollen
+              | 62202 > | Brassica (Rape, Broccoli, Brussels Sprouts, Cabbage, Cauliflower, Collards, Kale, Kohlrabi, Mustard, Rutabaga) pollen
+              | 62203 > | Plantago (Plantain) pollen
+              | 62204 > | Rumex (Dock, Sorrel) pollen
+              | 62205 > | Urtica (Nettle) pollen
+              | 62300   | Poaceae (Grass family) pollen
+
+  0-08-050 | QNMV ; CODE
+              | 1 > | Pressure
+              | 2 > | Temperature
+              | 3 > | Extreme temperature
+              | 4 > | Vapour pressure
+              | 5 > | Precipitation
+              | 6 > | Sunshine duration
+              | 7 > | Maximum temperature
+              | 8 > | Minimum temperature
+              | 9   | Wind
+
+  0-08-051 | QNMVX ; CODE
+              | 1 > | Pressure
+              | 2 > | Temperature
+              | 3 > | Extreme temperature
+              | 4 > | Vapour pressure
+              | 5 > | Precipitation
+              | 6   | Sunshine duration
+
+  0-08-052 | CNDO ; CODE
+              | 0 > | Mean wind speed over a 10-minute period observed or recorded equal to or more than 10 m s**-1 or 20 knots
+              | 1 > | Mean wind speed over a 10-minute period observed or recorded equal to or more than 20 m s**-1 or 40 knots
+              | 2 > | Mean wind speed over a 10-minute period observed or recorded equal to or more than 30 m s**-1 or 60 knots
+              | 3 > | Maximum temperature less than 273.15 K
+              | 4 > | Maximum temperature equal to or more than 298.15 K
+              | 5 > | Maximum temperature equal to or more than 303.15 K
+              | 6 > | Maximum temperature equal to or more than 308.15 K
+              | 7 > | Maximum temperature equal to or more than 313.15 K
+              | 8 > | Minimum temperature less than 273.15 K
+              | 9 > | Maximum temperature equal to or more than 273.15 K
+              | 10 > | Precipitation equal to or more than 1.0 kg m**-2
+              | 11 > | Precipitation equal to or more than 5.0 kg m**-2
+              | 12 > | Precipitation equal to or more than 10.0 kg m**-2
+              | 13 > | Precipitation equal to or more than 50.0 kg m**-2
+              | 14 > | Precipitation equal to or more than 100.0 kg m**-2
+              | 15 > | Precipitation equal to or more than 150.0 kg m**-2
+              | 16 > | Snow depth more than 0.00 m
+              | 17 > | Snow depth more than 0.01 m
+              | 18 > | Snow depth more than 0.10 m
+              | 19 > | Snow depth more than 0.50 m
+              | 20 > | Horizontal visibility less than 50 m
+              | 21 > | Horizontal visibility less than 100 m
+              | 22 > | Horizontal visibility less than 1000 m
+              | 23 > | Hail
+              | 24   | Thunderstorm
+
+  0-08-053 | DOQL ; CODE
+              | 0 > | Value occurred on only one day in the month
+              | 1   | Value occurred on more than one day in the month
+
+  0-08-054 | QWSG ; CODE
+              | 0 > | Wind speed or gust is as reported
+              | 1   | Wind speed is greater than that reported (P in METAR/TAF/SPECI)
+
+  0-08-060 | SSMS ; CODE
+              | 1 > | Range
+              | 2 > | Azimuth
+              | 3 > | Horizontal
+              | 4 > | Vertical
+              | 5 > | North/South
+              | 6   | East/West
+
+  0-08-065 | SGIN ; CODE
+              | 0 > | No sun-glint
+              | 1   | Sun-glint
+
+  0-08-066 | STIN ; CODE
+              | 0 > | Opaque
+              | 1   | Semi-transparent
+
+  0-08-070 | TAPQ ; CODE
+              | 2 > | Earth located instrument counts, calibration coefficients and housekeeping (level 1b)
+              | 3 > | Earth located calibrated radiances (level 1c)
+              | 4   | Mapped to a common footprint, Earth located calibrated radiances (level 1d)
+
+  0-08-072 | PIXT ; CODE
+              | 0 > | Mixed
+              | 1 > | Clear
+              | 2 > | Cloudy
+              | 3 > | Probably clear
+              | 4   | Probably cloudy
+
+  0-08-074 | AETP ; CODE
+              | 0 > | Open ocean or semi-enclosed sea
+              | 1   | Non-ocean like
+
+  0-08-075 | STKO ; CODE
+              | 0 > | Ascending orbit
+              | 1   | Descending orbit
+
+  0-08-076 | TOBD ; CODE
+              | 0 > | Ku
+              | 1 > | C
+              | 2 > | Long-wave infrared
+              | 3 > | Medium-wave infrared
+              | 4 > | Short-wave infrared
+              | 5 > | M
+              | 6 > | I
+              | 7   | Day/night
+
+  0-08-077 | DSST ; CODE
+              | 0 > | Land
+              | 1 > | Sea
+              | 2 > | Coastal
+              | 3 > | Open ocean or semi-enclosed sea
+              | 4 > | Enclosed sea or lake
+              | 5   | Continental ice
+
+  0-08-079 | CSFP ; CODE
+              | 0 > | Normal issue
+              | 1 > | Correction to a previously issued product (COR)
+              | 2 > | Amendment to a previously issued product (AMD)
+              | 3 > | Correction to a previously issued amended product (COR AMD)
+              | 4 > | Cancellation of a previously issued product (CNL)
+              | 5 > | No product available (NIL)
+              | 6 > | Special report (SPECI)
+              | 7   | Corrected special report (SPECI COR)
+
+  0-08-080 | QFQF ; CODE
+              | 0 > | Total water pressure profile
+              | 1 > | Total water temperature profile
+              | 2 > | Total water salinity profile
+              | 3 > | Total water conductivity profile
+              | 4 > | Total water depth
+              | 10 > | Water pressure at a level
+              | 11 > | Water temperature at a level
+              | 12 > | Salinity at a level
+              | 13 > | Water depth at a level
+              | 14 > | Sea/water current speed at a level
+              | 15 > | Sea/water current direction at a level
+              | 16 > | Dissolved oxygen at a level
+              | 20   | Position
+
+  0-08-081 | TOEQ ; CODE
+              | 0 > | Sensor
+              | 1 > | Transmitter
+              | 2 > | Receiver
+              | 3   | Observing platform
+
+  0-08-082 | ACSH ; CODE
+              | 0 > | Sensor height is not modified
+              | 1   | Sensor height is modified to standard level
+
+  0-08-083 | NOVI ; FLAG
+              | 1 > | Adjusted to or with respect to representative height of sensor above local ground (or deck of marine platform)
+              | 2 > | Adjusted to or with respect to representative height of sensor above water surface
+              | 3 > | Adjusted with respect to standard surface roughness
+              | 4 > | Adjusted with respect to wind speed
+              | 5 > | Adjusted with respect to temperature
+              | 6 > | Adjusted with respect to pressure
+              | 7 > | Adjusted with respect to humidity
+              | 8 > | Adjusted with respect to evaporation
+              | 9   | Adjusted with respect to wetting losses
+
+  0-08-085 | BEAMI ; CODE
+              | 0 > | Fore beam
+              | 1 > | Mid beam
+              | 2   | Aft beam
+
+  0-08-086 | VSNWP ; FLAG
+              | 1 > | Model "ground" surface
+              | 2 > | Standard level
+              | 3 > | Tropopause level
+              | 4 > | Maximum wind level
+              | 5 > | Significant temperature level
+              | 6 > | Significant humidity level
+              | 7 > | Significant wind level
+              | 8 > | Vertically interpolated level (This should be set to 1 for points on the vertical profile that fall between the model's native vertical levels)
+              | 9 > | Virtual station height
+              | 10   | Level of best fit
+
+  0-08-087 | CPOS ; CODE
+              | 0 > | Upper left
+              | 1 > | Upper right
+              | 2 > | Lower right
+              | 3   | Lower left
+
+  0-08-088 | MAPSIG ; CODE
+              | 0 > | Top view (geographical longitude on X axis and latitude on Y axis)
+              | 1 > | North-South view (transect with geographical longitude on X axis and vertical height on Y axis)
+              | 2   | East-West view (transect with geographical latitude on X axis and vertical height on Y axis)
+
+  0-08-091 | CRDSIG ; CODE
+              | 0 > | Satellite coordinates
+              | 1 > | Observation coordinates
+              | 2 > | Start of observation
+              | 3 > | End of observation
+              | 4 > | Horizontal center of gravity of the observation
+              | 5 > | Vertical center of gravity of the observation
+              | 6 > | Top of the observation
+              | 7 > | Bottom of the observation
+              | 8 > | Projection origin
+              | 9   | Coordinates of true scale
+
+  0-08-092 | MUNCEX ; CODE
+              | 0 > | Standard uncertainty
+              | 1   | Combined standard uncertainty
+
+  0-08-093 | MUNCSG ; CODE
+              | 0 > | Total uncertainty
+              | 1 > | Systematic component of uncertainty
+              | 2   | Random component of uncertainty
+
+  0-08-094 | MCAVGDTM ; CODE
+              | 0 > | Average of maximum and minimum values: Tm = (Tx + Tn)/2
+              | 1 > | Average of 8 tri-hourly observations
+              | 2 > | Average of 24 hourly observations
+              | 3 > | Weighted average of 3 observations: Tm = (aT1 + bT2 + cT3)
+              | 4 > | Weighted average of 3 observations and also maximum and minimum values: Tm= (aT1 + bT2 + cT3 + dTx + eTn)
+              | 5 > | Automatic weather station complete integration from minute data
+              | 6   | Average of 4 six-hourly observations
+
+  0-08-095 | SMQCTM ; CODE
+              | 1 > | 1A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 2 > | 1B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 3 > | 1C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 4 > | 1D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 6 > | 2A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 7 > | 2B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 8 > | 2C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 9 > | 2D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 11 > | 3A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 12 > | 3B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 13 > | 3C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 14 > | 3D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 16 > | 4A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 17 > | 4B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 18 > | 4C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 19 > | 4D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 21 > | 5A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 22 > | 5B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 23 > | 5C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 24 > | 5D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 26 > | 1 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 27 > | 2 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 28 > | 3 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 29 > | 4 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 30 > | 5 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 31 > | A (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 32 > | B (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 33 > | C (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 34   | D (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+
+  0-08-096 | SMQCPC ; CODE
+              | 1 > | 1A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 2 > | 1B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 3 > | 1C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 4 > | 1D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 6 > | 2A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 7 > | 2B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 8 > | 2C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 9 > | 2D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 11 > | 3A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 12 > | 3B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 13 > | 3C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 14 > | 3D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 16 > | 4A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 17 > | 4B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 18 > | 4C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 19 > | 4D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 21 > | 5A (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 22 > | 5B (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 23 > | 5C (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 24 > | 5D (Siting Classification according to ISO/WMO standard 119289:2014(E) and Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition)
+              | 26 > | 1 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 27 > | 2 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 28 > | 3 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 29 > | 4 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 30 > | 5 (Siting Classification according to ISO/WMO standard 119289:2014(E), Measurement Quality Classification is missing)
+              | 31 > | A (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 32 > | B (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 33 > | C (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+              | 34   | D (Measurement Quality Classification according to the Guide to Instruments and Methods of Observation (WMO-No. 8), 2020 Edition, Siting Classification is missing)
+
+  0-08-097 | MCAVGITM ; CODE
+              | 0 > | The average of six temperature sensors placed throughout the payload
+              | 1 > | Average of WF-band IFP and RFE sensors for channels 1 to 8
+              | 2   | Average of G-band RFE sensor for channels 9 to 12
+
+  0-10-063 | CHPT ; CODE
+              | 0 > | Increasing, then decreasing; atmospheric pressure the same or higher than 3 hours ago
+              | 1 > | Increasing, then steady; or increasing, then increasing more slowly; atmospheric pressure now higher than 3 hours ago
+              | 2 > | Increasing (steadily or unsteadily); atmospheric pressure now higher than 3 hours ago
+              | 3 > | Decreasing or steady, then increasing; or increasing, then increasing more rapidly; atmospheric pressure now higher than 3 hours ago
+              | 4 > | Steady; atmospheric pressure the same as 3 hours ago
+              | 5 > | Decreasing, then increasing; atmospheric pressure the same or lower than 3 hours ago
+              | 6 > | Decreasing, then steady; or decreasing, then decreasing more slowly; atmospheric pressure now lower than 3 hours ago
+              | 7 > | Decreasing (steadily or unsteadily); atmospheric pressure now lower than 3 hours ago
+              | 8   | Steady or increasing, then decreasing; or decreasing, then decreasing more rapidly; atmospheric pressure now lower than 3 hours ago
+
+  0-10-064 | SIGCL ; CODE
+              | 0 > | Subsonic
+              | 1 > | Transonic
+              | 2   | Supersonic
+
+  0-11-030 | DGOTX ; CODE
+              | 0 > | Nil, in cloud
+              | 1 > | Light, in cloud
+              | 2 > | Moderate, in cloud
+              | 3 > | Severe, in cloud
+              | 4 > | Nil, in clear air
+              | 5 > | Light, in clear air
+              | 6 > | Moderate, in clear air
+              | 7 > | Severe, in clear air
+              | 8 > | Nil, cloud/clear air not specified
+              | 9 > | Light, cloud/clear air not specified
+              | 10 > | Moderate, cloud/clear air not specified
+              | 11 > | Severe, cloud/clear air not specified
+              | 12 > | Extreme, in clear air
+              | 13 > | Extreme, in cloud
+              | 14 > | Extreme, cloud/clear air not specified
+              | 15 > | Light, isolated moderate
+              | 16 > | Light, occasional moderate
+              | 17 > | Light, frequently moderate
+              | 18 > | Moderate, isolated severe
+              | 19 > | Moderate, occasional severe
+              | 20 > | Moderate, frequently severe
+              | 21 > | Severe, isolated extreme
+              | 22 > | Severe, occasional extreme
+              | 23   | Severe, frequently extreme
+
+  0-11-031 | DGOT ; CODE
+              | 0 > | Nil, in cloud
+              | 1 > | Light, in cloud
+              | 2 > | Moderate, in cloud
+              | 3 > | Severe, in cloud
+              | 4 > | Nil, in clear air
+              | 5 > | Light, in clear air
+              | 6 > | Moderate, in clear air
+              | 7 > | Severe, in clear air
+              | 8 > | Nil, cloud/clear air not specified
+              | 9 > | Light, cloud/clear air not specified
+              | 10 > | Moderate, cloud/clear air not specified
+              | 11 > | Severe, cloud/clear air not specified
+              | 12 > | Extreme, in clear air
+              | 13 > | Extreme, in cloud
+              | 14   | Extreme, cloud/clear air not specified
+
+  0-11-037 | TRBXST ; CODE
+              | 0 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.1 m**(2/3) s**-1
+              | 1 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.2 and >= 0.1 m**(2/3) s**-1
+              | 2 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value < 0.2 and >= 0.1 m**(2/3) s**-1
+              | 3 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.3 and >= 0.2 m**(2/3) s**-1
+              | 4 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value < 0.3 and >= 0.2 m**(2/3) s**-1
+              | 5 > | Average value of eddy dissipation rate < 0.3 and >= 0.2 m**(2/3) s**-1, and peak value < 0.3 and >= 0.2 m**(2/3) s**-1
+              | 6 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.4 and >= 0.3 m**(2/3) s**-1
+              | 7 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value < 0.4 and >= 0.3 m**(2/3) s**-1
+              | 8 > | Average value of eddy dissipation rate < 0.3 and >= 0.2 m**(2/3) s**-1, and peak value < 0.4 and >= 0.3 m**(2/3) s**-1
+              | 9 > | Average value of eddy dissipation rate < 0.4 and >= 0.3 m**(2/3) s**-1, and peak value < 0.4 and >= 0.3 m**(2/3) s**-1
+              | 10 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.5 and >= 0.4 m**(2/3) s**-1
+              | 11 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value < 0.5 and >= 0.4 m**(2/3) s**-1
+              | 12 > | Average value of eddy dissipation rate < 0.3 and >= 0.2 m**(2/3) s**-1, and peak value < 0.5 and >= 0.4 m**(2/3) s**-1
+              | 13 > | Average value of eddy dissipation rate < 0.4 and >= 0.3 m**(2/3) s**-1, and peak value < 0.5 and >= 0.4 m**(2/3) s**-1
+              | 14 > | Average value of eddy dissipation rate < 0.5 and >= 0.4 m**(2/3) s**-1, and peak value < 0.5 and >= 0.4 m**(2/3) s**-1
+              | 15 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 16 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 17 > | Average value of eddy dissipation rate < 0.3 and >= 0.2 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 18 > | Average value of eddy dissipation rate < 0.4 and >= 0.3 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 19 > | Average value of eddy dissipation rate < 0.5 and >= 0.4 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 20 > | Average value of eddy dissipation rate < 0.8 and >= 0.5 m**(2/3) s**-1, and peak value < 0.8 and >= 0.5 m**(2/3) s**-1
+              | 21 > | Average value of eddy dissipation rate < 0.1 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 22 > | Average value of eddy dissipation rate < 0.2 and >= 0.1 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 23 > | Average value of eddy dissipation rate < 0.3 and >= 0.2 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 24 > | Average value of eddy dissipation rate < 0.4 and >= 0.3 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 25 > | Average value of eddy dissipation rate < 0.5 and >= 0.4 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 26 > | Average value of eddy dissipation rate < 0.8 and >= 0.5 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 27 > | Average value of eddy dissipation rate >= 0.8 m**(2/3) s**-1, and peak value >= 0.8 m**(2/3) s**-1
+              | 28   | Nil
+
+  0-11-038 | TOPEDR ; CODE
+              | 0 > | min < 1 prior to observation time
+              | 1 > | 1 <= min < 2 prior to observation time
+              | 2 > | 2 <= min < 3 prior to observation time
+              | 3 > | 3 <= min < 4 prior to observation time
+              | 4 > | 4 <= min < 5 prior to observation time
+              | 5 > | 5 <= min < 6 prior to observation time
+              | 6 > | 6 <= min < 7 prior to observation time
+              | 7 > | 7 <= min < 8 prior to observation time
+              | 8 > | 8 <= min < 9 prior to observation time
+              | 9 > | 9 <= min < 10 prior to observation time
+              | 10 > | 10 <= min < 11 prior to observation time
+              | 11 > | 11 <= min < 12 prior to observation time
+              | 12 > | 12 <= min < 13 prior to observation time
+              | 13 > | 13 <= min < 14 prior to observation time
+              | 14 > | 14 <= min < 15 prior to observation time
+              | 15   | No timing information available
+
+  0-11-039 | XTOPEDR ; CODE
+              | 0 > | min < 1 prior to observation time
+              | 1 > | 1 <= min < 2 prior to observation time
+              | 2 > | 2 <= min < 3 prior to observation time
+              | 3 > | 3 <= min < 4 prior to observation time
+              | 4 > | 4 <= min < 5 prior to observation time
+              | 5 > | 5 <= min < 6 prior to observation time
+              | 6 > | 6 <= min < 7 prior to observation time
+              | 7 > | 7 <= min < 8 prior to observation time
+              | 8 > | 8 <= min < 9 prior to observation time
+              | 9 > | 9 <= min < 10 prior to observation time
+              | 10 > | 10 <= min < 11 prior to observation time
+              | 11 > | 11 <= min < 12 prior to observation time
+              | 12 > | 12 <= min < 13 prior to observation time
+              | 13 > | 13 <= min < 14 prior to observation time
+              | 14 > | 14 <= min < 15 prior to observation time
+              | 15 > | 15 <= min < 16 prior to observation time
+              | 16 > | 16 <= min < 17 prior to observation time
+              | 17 > | 17 <= min < 18 prior to observation time
+              | 18 > | 18 <= min < 19 prior to observation time
+              | 19 > | 19 <= min < 20 prior to observation time
+              | 20 > | 20 <= min < 21 prior to observation time
+              | 21 > | 21 <= min < 22 prior to observation time
+              | 22 > | 22 <= min < 23 prior to observation time
+              | 23 > | 23 <= min < 24 prior to observation time
+              | 24 > | 24 <= min < 25 prior to observation time
+              | 25 > | 25 <= min < 26 prior to observation time
+              | 26 > | 26 <= min < 27 prior to observation time
+              | 27 > | 27 <= min < 28 prior to observation time
+              | 28 > | 28 <= min < 29 prior to observation time
+              | 29 > | 29 <= min < 30 prior to observation time
+              | 30 > | 30 <= min < 31 prior to observation time
+              | 31 > | 31 <= min < 32 prior to observation time
+              | 32 > | 32 <= min < 33 prior to observation time
+              | 33 > | 33 <= min < 34 prior to observation time
+              | 34 > | 34 <= min < 35 prior to observation time
+              | 35 > | 35 <= min < 36 prior to observation time
+              | 36 > | 36 <= min < 37 prior to observation time
+              | 37 > | 37 <= min < 38 prior to observation time
+              | 38 > | 38 <= min < 39 prior to observation time
+              | 39 > | 39 <= min < 40 prior to observation time
+              | 40 > | 40 <= min < 41 prior to observation time
+              | 41 > | 41 <= min < 42 prior to observation time
+              | 42 > | 42 <= min < 43 prior to observation time
+              | 43 > | 43 <= min < 44 prior to observation time
+              | 44 > | 44 <= min < 45 prior to observation time
+              | 45 > | 45 <= min < 46 prior to observation time
+              | 46 > | 46 <= min < 47 prior to observation time
+              | 47 > | 47 <= min < 48 prior to observation time
+              | 48 > | 48 <= min < 49 prior to observation time
+              | 49 > | 49 <= min < 50 prior to observation time
+              | 50 > | 50 <= min < 51 prior to observation time
+              | 51 > | 51 <= min < 52 prior to observation time
+              | 52 > | 52 <= min < 53 prior to observation time
+              | 53 > | 53 <= min < 54 prior to observation time
+              | 54 > | 54 <= min < 55 prior to observation time
+              | 55 > | 55 <= min < 56 prior to observation time
+              | 56 > | 56 <= min < 57 prior to observation time
+              | 57 > | 57 <= min < 58 prior to observation time
+              | 58 > | 58 <= min < 59 prior to observation time
+              | 59 > | 59 <= min < 60 prior to observation time
+              | 60   | No timing information available
+
+  0-13-038 | SADF ; CODE
+              | 0 > | Not superadiabatic
+              | 1   | Superadiabatic
+
+  0-13-039 | TERN ; CODE
+              | 0 > | Sea ice
+              | 1   | Snow on land
+
+  0-13-040 | SFLG ; CODE
+              | 0 > | Land
+              | 2 > | Near coast
+              | 3 > | Ice
+              | 4 > | Possible ice
+              | 5 > | Ocean
+              | 6 > | Coast
+              | 7 > | Inland water (e.g. river, lake, wetland, swamp)
+              | 8 > | Snow cover
+              | 9 > | Sea ice
+              | 10 > | Standing water (e.g. temporary flooding)
+              | 11   | Snow
+
+  0-13-041 | PGSC ; CODE
+              | 1 > | A
+              | 2 > | A - B
+              | 3 > | B
+              | 4 > | B - C
+              | 5 > | C
+              | 6 > | D
+              | 7 > | E
+              | 8 > | F
+              | 9   | G
+
+  0-13-051 | FRGP ; CODE
+              | 0 > | Smaller than any value in the 30 year period
+              | 1 > | In the first quintile
+              | 2 > | In the second quintile
+              | 3 > | In the third quintile
+              | 4 > | In the fourth quintile
+              | 5 > | In the fifth quintile
+              | 6   | Greater than any value in the 30 year period
+
+  0-13-056 | CIPR ; CODE
+              | 0 > | No precipitation
+              | 1 > | Light intermittent
+              | 2 > | Moderate intermittent
+              | 3 > | Heavy intermittent
+              | 4 > | Very heavy intermittent
+              | 5 > | Light continuous
+              | 6 > | Moderate continuous
+              | 7 > | Heavy continuous
+              | 8 > | Very heavy continuous
+              | 9   | Variable - alternatively light and heavy
+
+  0-13-057 | TBEPR ; CODE
+              | 0 > | No precipitation
+              | 1 > | Within the last hour
+              | 2 > | 1 to 2 hours ago
+              | 3 > | 2 to 3 hours ago
+              | 4 > | 3 to 4 hours ago
+              | 5 > | 4 to 5 hours ago
+              | 6 > | 5 to 6 hours ago
+              | 7 > | 6 to 8 hours ago
+              | 8 > | 8 to 10 hours ago
+              | 9   | More than 10 hours ago
+
+  0-15-025 | TYPO ; CODE
+              | 0 > | Ozone
+              | 11 > | Fine particulate matter (diameter <   2.5 microns)
+              | 12   | Fine particulate matter (diameter < 10    microns)
+
+  0-19-001 | STMFE1 ; CODE
+              | 0 > | Depression or low (extratroplcal)
+              | 1 > | Tropical depression
+              | 2 > | Tropical storm
+              | 3 > | Severe tropical storm
+              | 4 > | Typhoon
+              | 10   | Dust/sandstorm
+
+  0-19-008 | STMFE8 ; CODE
+              | 1 > | Shallow (top of circulation below 700 hPa level)
+              | 2 > | Medium (top between 700 hPa and 400 hPa level)
+              | 3   | Deep (top above 400 hPa level)
+
+  0-19-010 | STMFE10 ; CODE
+              | 1 > | Minimum value of sea level pressure
+              | 2   | Maximum value of 850 hPa relative vorticity
+
+  0-19-100 | TIEC ; CODE
+              | 3 > | During the preceding 15 minutes
+              | 4 > | During the preceding 30 minutes
+              | 5 > | During the preceding 1 hour
+              | 6 > | During the preceding 2 hours
+              | 7 > | During the preceding 3 hours
+              | 8 > | During the preceding 6 hours
+              | 9 > | During a period of more than 6 hours
+              | 10   | Undetermined
+
+  0-19-101 | APCE ; CODE
+              | 1 > | Eye visible on radar scope, accuracy good (within 10 km)
+              | 2 > | Eye visible on radar scope, accuracy fair (within 30 km)
+              | 3 > | Eye visible on radar scope, accuracy poor (within 50 km)
+              | 4 > | Position of the centre within the area covered by the radar scope, determination by means of the spiral-band overlay, accuracy good (within 10 km)
+              | 5 > | Position of the centre within the area covered by the radar scope, determination by means of the spiral-band overlay, accuracy fair (within 30 km)
+              | 6 > | Position of the centre within the area covered by the radar scope, determination by means of the spiral-band overlay, accuracy poor (within 50 km)
+              | 7 > | Position of the centre outside the area covered by the radar scope, extrapolation by means of the spiral-band overlay
+              | 10   | Accuracy undetermined
+
+  0-19-102 | SDOE ; CODE
+              | 0 > | Circular
+              | 1 > | Elliptical - the minor axis is at least 3/4 the length of the major axis
+              | 2 > | Elliptical - the minor axis is less than 3/4 the length well defined of the major axis
+              | 3 > | Apparent double eye
+              | 4 > | Other shape
+              | 5 > | Ill defined
+              | 6   | Undetermined
+
+  0-19-103 | DMAE ; CODE
+              | 0 > | Less than 5 km
+              | 1 > | 5 to less than 10 km
+              | 2 > | 10 to less than 15 km
+              | 3 > | 15 to less than 20 km
+              | 4 > | 20 to less than 25 km
+              | 5 > | 25 to less than 30 km
+              | 6 > | 30 to less than 35 km
+              | 7 > | 35 to less than 40 km
+              | 8 > | 40 to less than 50 km
+              | 9 > | 50 km and greater
+              | 10   | Undetermined
+
+  0-19-104 | CE30 ; CODE
+              | 0 > | Eye has first become visible during the past 30 minutes
+              | 1 > | No significant change in the characteristics or size of the eye
+              | 2 > | Eye has become smaller with no other significant change in characteristics
+              | 3 > | Eye has become larger with no other significant change in characteristics
+              | 4 > | Eye has become less distinct with no significant change in size
+              | 5 > | Eye has become less distinct and decreased in size
+              | 6 > | Eye has become less distinct and increased in size
+              | 7 > | Eye has become more distinct with no significant change in size
+              | 8 > | Eye has become more distinct and decreased in size
+              | 9 > | Eye has become more distinct and increased in size
+              | 10   | Change in character and size of eye cannot be determined
+
+  0-19-105 | DOBC ; CODE
+              | 0 > | 0 to less than 100 km
+              | 1 > | 100 to less than 200 km
+              | 2 > | 200 to less than 300 km
+              | 3 > | 300 to less than 400 km
+              | 4 > | 400 to less than 500 km
+              | 5 > | 500 to less than 600 km
+              | 6 > | 600 to less than 800 km
+              | 7 > | 800 km or more
+              | 10   | Doubtful or undetermined
+
+  0-19-107 | TIMC ; CODE
+              | 0 > | Less than 1 hour
+              | 1 > | 1 to less than 2 hours
+              | 2 > | 2 to less than 3 hours
+              | 3 > | 3 to less than 6 hours
+              | 4 > | 6 to less than 9 hours
+              | 5 > | 9 to less than 12 hours
+              | 6 > | 12 to less than 15 hours
+              | 7 > | 15 to less than 18 hours
+              | 8 > | 18 to less than 21 hours
+              | 9   | 21 to less than 30 hours
+
+  0-19-108 | AGPC ; CODE
+              | 0 > | Cyclone centre within 10 km of the transmitted position
+              | 1 > | Cyclone centre within 20 km of the transmitted position
+              | 2 > | Cyclone centre within 50 km of the transmitted position
+              | 3 > | Cyclone centre within 100 km of the transmitted position
+              | 4 > | Cyclone centre within 200 km of the transmitted position
+              | 5 > | Cyclone centre within 300 km of the transmitted position
+              | 6   | Cyclone centre undetermined
+
+  0-19-109 | MWFC ; CODE
+              | 0 > | Less than 1 deg of latitude
+              | 1 > | 1 deg to less than 2 deg of latitude
+              | 2 > | 2 deg to less than 3 deg of latitude
+              | 3 > | 3 deg to less than 4 deg of latitude
+              | 4 > | 4 deg to less than 5 deg of latitude
+              | 5 > | 5 deg to less than 6 deg of latitude
+              | 6 > | 6 deg to less than 7 deg of latitude
+              | 7 > | 7 deg to less than 8 deg of latitude
+              | 8 > | 8 deg to less than 9 deg of latitude
+              | 9 > | 9 deg of latitude or more
+              | 10   | Undetermined
+
+  0-19-110 | A24C ; CODE
+              | 0 > | Much weakening
+              | 1 > | Weakening
+              | 2 > | No change
+              | 3 > | Intensification
+              | 4 > | Strong Intensification
+              | 9 > | Not observed previously
+              | 10   | Undetermined
+
+  0-19-113 | CPDT ; CODE
+              | 1 > | Curved Band
+              | 2 > | Shear
+              | 3 > | Eye
+              | 4 > | Banding Eye
+              | 5 > | Central Dense Overcast (CDO)
+              | 6 > | Embedded Center
+              | 7   | Center Cold Cover (CCC)
+
+  0-19-117 | CPPT ; CODE
+              | 1 > | A (Curved Band)
+              | 2 > | B (CDO)
+              | 3   | C (Shear)
+
+  0-19-119 | TFTN ; CODE
+              | 1 > | DT-number
+              | 2 > | PT-number
+              | 3   | MET-number
+
+  0-20-003 | PRWE ; CODE
+              | 0 > | Cloud development not observed or not observable
+              | 1 > | Clouds generally dissolving or becoming less developed
+              | 2 > | State of sky on the whole unchanged
+              | 3 > | Clouds generally forming or developing
+              | 4 > | Visibility reduced by smoke, e.g. veldt or forest fires, Industrial smoke or volcanic ashes
+              | 5 > | Haze
+              | 6 > | Widespread dust in suspension in the air, not raised by wind at or near the station at the time of observation
+              | 7 > | Dust or sand raised by wind at or near the station at the time of observation, but no well developed dust whirl(s) or sand whirl(s), and no duststorm or sandstorm seen; or, In the case of sea stations and coastal stations, blowing spray at the station
+              | 8 > | Well developed dust whirl(s) or sand whirl(s) seen at or near the station during the preceding hour or at the same time of observation, but no duststorm or sandstorm
+              | 9 > | Duststorm or sandstorm within sight at the time of observation, or at the station during the preceding hour
+              | 10 > | Mist
+              | 11 > | Patches of shallow fog or ice fog
+              | 12 > | More or less continuous shallow fog or ice fog
+              | 13 > | Lightning visible, no thunder heard
+              | 14 > | Precipitation within sight, not reaching the ground or the surface of the sea
+              | 15 > | Precipitation within sight, reaching the ground or the surface of the sea, but distant, i.e. estimated to be more than 5 km from the station
+              | 16 > | Precipitation within sight, reaching the ground or the surface of the sea, near to, but not at the station
+              | 17 > | Thunderstorm, but no precipitation at the time of observation
+              | 18 > | Squalls, at or within sight of the station during the preceding hour or at the time of observation
+              | 19 > | Funnel cloud(s), at or within sight of the station during the preceding hour or at the time of observation
+              | 20 > | Drizzle (not freezing) or snow grains, not falling as showers
+              | 21 > | Rain (not freezing), not falling as showers
+              | 22 > | Snow, not falling as showers
+              | 23 > | Rain and snow or ice pellets, not falling as showers
+              | 24 > | Freezing drizzle or freezing rain, not falling as showers
+              | 25 > | Shower(s) of rain
+              | 26 > | Shower(s) of snow, or of rain and snow
+              | 27 > | Shower(s) of hail, or of rain and hail
+              | 28 > | Fog or Ice fog
+              | 29 > | Thunderstorm (with or without precipitation)
+              | 30 > | Slight or moderate duststorm or sandstorm, has decreased during the preceding hour
+              | 31 > | Slight or moderate duststorm or sandstorm, no appreciable change during the preceding hour
+              | 32 > | Slight or moderate duststorm or sandstorm, has begun or increased during the preceding hour
+              | 33 > | Severe duststorm or sandstorm, has decreased during the preceding hour
+              | 34 > | Severe duststorm or sandstorm, no appreciable change during the preceding hour
+              | 35 > | Severe duststorm or sandstorm, has begun or increased during the preceding hour
+              | 36 > | Slight or moderate drifting snow, generally low (below eye level)
+              | 37 > | Heavy drifting snow, generally low (below eye level)
+              | 38 > | Slight or moderate drifting snow, generally high (above eye level)
+              | 39 > | Heavy drifting snow, generally high (above eye level)
+              | 40 > | Fog or ice fog at a distance at the time of observation, but not at the station during the preceding hour, the fog or ice fog extending to a level above that of the observer
+              | 41 > | Fog or ice fog in patches
+              | 42 > | Fog or ice fog with sky visible, and has become thinner during the preceding hour
+              | 43 > | Fog or ice fog with sky invisible, and has become thinner during the preceding hour
+              | 44 > | Fog or ice fog with sky visible, and no appreciable change during the preceding hour
+              | 45 > | Fog or ice fog with sky invisible, and no appreciable change during the preceding hour
+              | 46 > | Fog or ice fog with sky visible, and has begun or has become thicker during the preceding hour
+              | 47 > | Fog or ice fog with sky invisible, and has begun or has become thicker during the preceding hour
+              | 48 > | Fog, depositing rime, sky visible
+              | 49 > | Fog, depositing rime, sky invisible
+              | 50 > | Drizzle, not freezing, intermittent, and slight at time of observation
+              | 51 > | Drizzle, not freezing, continuous, and slight at time of observation
+              | 52 > | Drizzle, not freezing, intermittent, and moderate at time of observation
+              | 53 > | Drizzle, not freezing, continuous, and moderate at time of observation
+              | 54 > | Drizzle, not freezing, intermittent, and heavy (dense) at time of observation
+              | 55 > | Drizzle, not freezing, continuous, and heavy (dense) at time of observation
+              | 56 > | Drizzle, freezing, slight
+              | 57 > | Drizzle, freezing, moderate or heavy (dense)
+              | 58 > | Drizzle and rain, slight
+              | 59 > | Drizzle and rain, moderate or heavy
+              | 60 > | Rain, not freezing, intermittent, and slight at time of observation
+              | 61 > | Rain, not freezing, continuous, and slight at time of observation
+              | 62 > | Rain, not freezing, intermittent, and moderate at time of observation
+              | 63 > | Rain, not freezing, continuous, and moderate at time of observation
+              | 64 > | Rain, not freezing, intermittent, and heavy at time of observation
+              | 65 > | Rain, not freezing, continuous, and heavy at time of observation
+              | 66 > | Rain, freezing, slight
+              | 67 > | Rain, freezing, moderate or heavy
+              | 68 > | Rain or drizzle and snow, light
+              | 69 > | Rain or drizzle and snow, moderate or heavy
+              | 70 > | Intermittent snowflakes, slight at time of observation
+              | 71 > | Continuous snowflakes, slight at time of observation
+              | 72 > | Intermittent snowflakes, moderate at time of observation
+              | 73 > | Continuous snowflakes, moderate at time of observation
+              | 74 > | Intermittent snowflakes, heavy at time of observation
+              | 75 > | Continuous snowflakes, heavy at time of observation
+              | 76 > | Diamond dust (with or without fog)
+              | 77 > | Snow grains (with or without fog)
+              | 78 > | Isolated star like snow crystals (with or without fog)
+              | 79 > | Ice pellets
+              | 80 > | Rain shower(s), slight
+              | 81 > | Rain shower(s), moderate or heavy
+              | 82 > | Rain shower(s), violent
+              | 83 > | Shower(s) of rain and snow mixed, slight
+              | 84 > | Shower(s) of rain and snow mixed, moderate or heavy
+              | 85 > | Snow shower(s), slight
+              | 86 > | Snow shower(s), moderate or heavy
+              | 87 > | Shower(s) of snow pellets or small hail, with or without rain or rain and snow mixed - slight
+              | 88 > | Shower(s) of snow pellets or small hail, with or without rain or rain and snow mixed - moderate or heavy
+              | 89 > | Shower(s) of hail, with or without rain or rain and snow mixed, not associated with thunder - slight
+              | 90 > | Shower(s) of hail, with or without rain or rain and snow mixed, not associated with thunder - moderate or heavy
+              | 91 > | Slight rain at time of observation, and thunderstorm during preceding hour but not at time of observation
+              | 92 > | Moderate or heavy rain at time of observation, and thunderstorm during preceding hour but not at time of observation
+              | 93 > | Slight snow, or rain and snow mixed or hail at time of observation, and thunderstorm during preceding hour but not at time of observation
+              | 94 > | Moderate or heavy snow, or rain and snow mixed or hail at time of observation, and thunderstorm during preceding hour but not at time of observation
+              | 95 > | Thunderstorm, slight or moderate, without hail, but with rain and/or snow at time of observation
+              | 96 > | Thunderstorm, slight or moderate, with hail at time of observation
+              | 97 > | Thunderstorm, heavy, without hail, but with rain and/or snow at time of observation
+              | 98 > | Thunderstorm combined with duststorm or sandstorm at time of observation.
+              | 99 > | Thunderstorm, heavy, with hail at time of observation
+              | 100 > | No significant weather observed
+              | 101 > | Clouds generally dissolving or becoming less developed during the past hour
+              | 102 > | State of sky on the whole unchanged during the past hour
+              | 103 > | Clouds generally forming or developing during the past hour
+              | 104 > | Haze or smoke, or dust in suspension in the air, visibility equal to, or greater than, 1 km
+              | 105 > | Haze or smoke, or dust In suspension in the air, visibility less than 1 km
+              | 110 > | Mist
+              | 111 > | Diamond dust
+              | 112 > | Distant lightning
+              | 118 > | Squalls
+              | 120 > | Fog
+              | 121 > | PRECIPITATION
+              | 122 > | Drizzle (not freezing) or snow grains
+              | 123 > | Rain (not freezing)
+              | 124 > | Snow
+              | 125 > | Freezing drizzle or freezing rain
+              | 126 > | Thunderstorm (with or without precipitation)
+              | 127 > | Blowing OR DRIFTING SNOW OR SAND
+              | 128 > | Blowing or drifting snow or sand, visibility equal to, or greater than, 1 km
+              | 129 > | Blowing or drifting snow or sand, visibility less than 1 km
+              | 130 > | FOG
+              | 131 > | Fog or ice fog in patches
+              | 132 > | Fog or ice fog, has become thinner during the past hour
+              | 133 > | Fog or ice fog, no appreciable change during the past hour
+              | 134 > | Fog or ice fog, has begun or become thicker during the past hour
+              | 135 > | Fog, depositing rime
+              | 140 > | PRECIPITATION
+              | 141 > | Precipitation, slight or moderate
+              | 142 > | Precipitation, heavy
+              | 143 > | Liquid precipitation, slight or moderate
+              | 144 > | Liquid precipitation, heavy
+              | 145 > | Solid precipitation, slight or moderate
+              | 146 > | Solid precipitation, heavy
+              | 147 > | Freezing precipitation, slight or moderate
+              | 148 > | Freezing precipitation, heavy
+              | 150 > | DRIZZLE
+              | 151 > | Drizzle, not freezing, slight
+              | 152 > | Drizzle, not freezing, moderate
+              | 153 > | Drizzle, not freezing, heavy
+              | 154 > | Drizzle, freezing, slight
+              | 155 > | Drizzle, freezing, moderate
+              | 156 > | Drizzle, freezing, heavy
+              | 157 > | Drizzle and rain, slight
+              | 158 > | Drizzle and rain, moderate or heavy
+              | 160 > | RAIN
+              | 161 > | Rain, not freezing, slight
+              | 162 > | Rain, not freezing, moderate
+              | 163 > | Rain, not freezing, heavy
+              | 164 > | Rain, freezing, slight
+              | 165 > | Rain, freezing, moderate
+              | 166 > | Rain, freezing, heavy
+              | 167 > | Rain (or drizzle) and snow, slight
+              | 168 > | Rain (or drizzle) and snow, moderate or heavy
+              | 170 > | SNOW
+              | 171 > | Snow, slight
+              | 172 > | Snow, moderate
+              | 173 > | Snow, heavy
+              | 174 > | Ice pellets, slight
+              | 175 > | Ice pellets, moderate
+              | 176 > | Ice pellets, heavy
+              | 177 > | Snow grains
+              | 178 > | Ice crystals
+              | 180 > | SHOWER(S) or intermittent PRECIPITATION
+              | 181 > | Rain shower(s) or intermittent rain, slight
+              | 182 > | Rain shower(s) or intermittent rain, moderate
+              | 183 > | Rain shower(s) or intermittent rain, heavy
+              | 184 > | Rain shower(s) or intermittent rain, violent
+              | 185 > | Snow shower(s) or intermittent snow, slight
+              | 186 > | Snow shower(s) or intermittent snow, moderate
+              | 187 > | Snow shower(s) or intermittent snow, heavy
+              | 189 > | Hail
+              | 190 > | THUNDERSTORM
+              | 191 > | Thunderstorm, slight or moderate, with no precipitation
+              | 192 > | Thunderstorm, slight or moderate, with rain showers and/or snow showers
+              | 193 > | Thunderstorm, slight or moderate, with hail
+              | 194 > | Thunderstorm, heavy, with no precipitation
+              | 195 > | Thunderstorm, heavy, With rain showers and/or snow showers
+              | 196 > | Thunderstorm, heavy, with hail
+              | 199 > | Tornado
+              | 204 > | Volcanic ash suspended In the air aloft
+              | 206 > | Thick dust haze, visibility less than 1 km
+              | 207 > | Blowing spray at the station
+              | 208 > | Drifting dust (sand)
+              | 209 > | Wall of dust or sand in distance (like haboob)
+              | 210 > | Snow haze
+              | 211 > | Whiteout
+              | 213 > | Lightning, cloud to surface
+              | 217 > | Dry thunderstorm
+              | 219 > | Tornado cloud (destructive) at or within sight of the station during preceding hour or at the time of observation
+              | 220 > | Deposition of volcanic ash
+              | 221 > | Deposition of dust or sand
+              | 222 > | Deposition of dew
+              | 223 > | Deposition of wet snow
+              | 224 > | Deposition of soft rime
+              | 225 > | Deposition of hard rime
+              | 226 > | Deposition of hoarfrost
+              | 227 > | Deposition of glaze
+              | 228 > | Deposition of ice crust (ice slick)
+              | 230 > | Duststorm or sandstorm with temperature below 0 degrees Celsius
+              | 239 > | Blowing snow, impossible to determine whether snow is falling or not
+              | 241 > | Fog on sea
+              | 242 > | Fog in valleys
+              | 243 > | Arctic or Antarctic sea smoke
+              | 244 > | Steam fog (sea, lake or river)
+              | 245 > | Steam log (land)
+              | 246 > | Fog over ice or snow cover
+              | 247 > | Dense fog, visibility 60-90 m
+              | 248 > | Dense fog, visibility 30-60 m
+              | 249 > | Dense fog, visibility less than 30 m
+              | 250 > | Drizzle, rate of fall less than 0.10 mm h**-1
+              | 251 > | Drizzle, rate of fall 0.10-0.19 mm h**-1
+              | 252 > | Drizzle, rate of fall 0.20-0.39 mm h**-1
+              | 253 > | Drizzle, rate of fall 0.40-0.79 mm h**-1
+              | 254 > | Drizzle, rate of fall 0.80-1.59 mm h**-1
+              | 255 > | Drizzle, rate of fall 1.60-3.19 mm h**-1
+              | 256 > | Drizzle, rate of fall 3.20-6.39 mm h**-1
+              | 257 > | Drizzle, rate of fall more 6.40 mm h**-1 or more
+              | 259 > | Drizzle and snow
+              | 260 > | Rain, rate of fall less than 1.0 mm h**-1
+              | 261 > | Rain, rate of fall 1.0-1.9 mm h**-1
+              | 262 > | Rain, rate of fall 2.0-3.9 mm h**-1
+              | 263 > | Rain, rate of fall 4.0-7.9 mm h**-1
+              | 264 > | Rain, rate of fall 8.0-15.9 mm h**-1
+              | 265 > | Rain, rate of fall 16.0-31.9 mm h**-1
+              | 266 > | Rain, rate of fall 32.0-63.9 mm h**-1
+              | 267 > | Rain, rate of fall more 64.0 mm h**-1 or more
+              | 270 > | Snow, rate of fall less than 1.0 cm h**-1
+              | 271 > | Snow, rate of fall 1.0-1.9 cm h**-1
+              | 272 > | Snow, rate of fall 2.0-3.9 cm h**-1
+              | 273 > | Snow, rate of fall 4.0-7.9 cm h**-1
+              | 274 > | Snow, rate of fall 8.0-15.9 cm h**-1
+              | 275 > | Snow, rate of fall 16.0-31.9 cm h**-1
+              | 276 > | Snow, rate of fall 32.0-63.9 cm h**-1
+              | 277 > | Snow, rate of fall more 64.0 cm h**-1 or more
+              | 278 > | Snow or Ice crystal precipitation from a clear sky
+              | 279 > | Wet snow, freezing on contact
+              | 280 > | Precipitation of rain
+              | 281 > | Precipitation of rain, freezing
+              | 282 > | Precipitation of rain and snow mixed.
+              | 283 > | Precipitation of snow
+              | 284 > | Precipitation of snow pellets or small hall
+              | 285 > | Precipitation of snow pellets or small hail, with rain
+              | 286 > | Precipitation of snow pellets or small hail, with rain and snow mixed
+              | 287 > | Precipitation of snow pellets or small hail, with snow
+              | 288 > | Precipitation of hail
+              | 289 > | Precipitation of hail, with rain
+              | 290 > | Precipitation of hall, with rain and snow mixed
+              | 291 > | Precipitation of hail, with snow
+              | 292 > | Shower(s) or thunderstorm over sea
+              | 293 > | Shower(s) or thunderstorm over mountains
+              | 508 > | No significant phenomenon to report, present and past weather omitted
+              | 509 > | No observation, data not available, present and past weather omitted
+              | 510   | Present and past weather missing, but expected
+
+  0-20-004 | PSW1 ; CODE
+              | 0 > | Cloud covering 1/2 or less of the sky throughout the appropriate period
+              | 1 > | Cloud covering more than 1/2 of the sky during part of the appropriate period and covering 1/2 or less during part of the period
+              | 2 > | Cloud covering more than 1/2 of the sky throughout the appropriate period
+              | 3 > | Sandstorm, duststorm or blowing snow
+              | 4 > | Fog or ice fog or thick haze
+              | 5 > | Drizzle
+              | 6 > | Rain
+              | 7 > | Snow, or rain and snow mixed
+              | 8 > | Shower(s)
+              | 9 > | Thunderstorm(s) with or without precipitation
+              | 10 > | No significant weather observed
+              | 11 > | Visibility REDUCED
+              | 12 > | Blowing phenomena, visibility reduced
+              | 13 > | FOG
+              | 14 > | PRECIPITATION
+              | 15 > | Drizzle
+              | 16 > | Rain
+              | 17 > | Snow or ice pellets
+              | 18 > | Showers or intermittent precipitation
+              | 19   | Thunderstorm
+
+  0-20-005 | PSW2 ; CODE
+              | 0 > | Cloud covering 1/2 or less of the sky throughout the appropriate period
+              | 1 > | Cloud covering more than 1/2 of the sky during part of the appropriate period and covering 1/2 or less during part of the period
+              | 2 > | Cloud covering more than 1/2 of the sky throughout the appropriate period
+              | 3 > | Sandstorm, duststorm or blowing snow
+              | 4 > | Fog or ice fog or thick haze
+              | 5 > | Drizzle
+              | 6 > | Rain
+              | 7 > | Snow, or rain and snow mixed
+              | 8 > | Shower(s)
+              | 9 > | Thunderstorm(s) with or without precipitation
+              | 10 > | No significant weather observed
+              | 11 > | Visibility REDUCED
+              | 12 > | Blowing phenomena, visibility reduced
+              | 13 > | FOG
+              | 14 > | PRECIPITATION
+              | 15 > | Drizzle
+              | 16 > | Rain
+              | 17 > | Snow or ice pellets
+              | 18 > | Showers or intermittent precipitation
+              | 19   | Thunderstorm
+
+  0-20-006 | FLTR ; CODE
+              | 0 > | Low Instrument Flight Rules - Ceiling < 500 feet and/or Visibility < 1 mile
+              | 1 > | Instrument Flight Rules - Ceiling < 1000 feet and/or Visibility < 3 miles
+              | 2 > | Marginal Visual Flight Rules - 1000 feet <= Ceiling < 3000 feet and/or 3 miles <= Visibility < 5 miles
+              | 3   | Visual Flight Rules - Ceiling >= 3000 feet and/or Visibility >= 5 miles
+
+  0-20-008 | CDFA ; CODE
+              | 0 > | Sky Clear
+              | 1 > | Few
+              | 2 > | Scattered
+              | 3 > | Broken
+              | 4 > | Overcast
+              | 6 > | Scattered/Broken
+              | 7 > | Broken/Overcast
+              | 8 > | Isolated
+              | 9 > | Isolated embedded
+              | 10 > | Occasional
+              | 11 > | Occasional embedded
+              | 12 > | Frequent
+              | 13 > | Dense
+              | 14 > | Layers
+              | 15 > | Obscured (OBSC)
+              | 16 > | Embedded (EMBD)
+              | 17   | Frequent embedded
+
+  0-20-009 | GWEI ; CODE
+              | 1 > | NSC Nil Significant Cloud
+              | 2 > | CAVOK
+              | 3 > | SKC Sky Clear
+              | 4 > | NSW Nil Significant Weather
+              | 5   | NCD No clouds detected
+
+  0-20-011 | CLAM ; CODE
+              | 0 > | 0
+              | 1 > | 1 okta or less, but not zero
+              | 2 > | 2 oktas
+              | 3 > | 3 oktas
+              | 4 > | 4 oktas
+              | 5 > | 5 oktas
+              | 6 > | 6 oktas
+              | 7 > | 7 oktas or more, but not 8 oktas
+              | 8 > | 8 oktas
+              | 9 > | Sky obscured by fog and/or other meteorological phenomena
+              | 10 > | Sky partially obscured by fog and/or other meteorological phenomena
+              | 11 > | Scattered
+              | 12 > | Broken
+              | 13   | Few
+
+  0-20-012 | CLTP ; CODE
+              | 0 > | Cirrus (Ci)
+              | 1 > | Cirrocumulus (Cc)
+              | 2 > | Cirrostratus (Cs)
+              | 3 > | Altocumulus (Ac)
+              | 4 > | Altostratus (As)
+              | 5 > | Nimbostratus (Ns)
+              | 6 > | Stratocumulus (Sc)
+              | 7 > | Stratus(St)
+              | 8 > | Cumulus (Cu)
+              | 9 > | Cumulonimbus (Cb)
+              | 10 > | No CH clouds
+              | 11 > | Cirrus fibratus, sometimes uncinus, not progressively invading the sky
+              | 12 > | Cirrus spissatus, in patches or entangled sheaves, which usually do not increase and sometimes seem to be the remains of the upper part of a Cumulonimbus; or Cirrus castellanus or floccus
+              | 13 > | Cirrus spissatus cumulonimbogenitus
+              | 14 > | Cirrus uncinus or fibratus, or both, progressively invading the sky; they generally thicken as a whole
+              | 15 > | Cirrus (often in bands) and Cirrostratus, or Cirrostratus alone, progressively invading the sky; they generally thicken as a whole, but the continuous veil does not reach 45 degrees above the horizon
+              | 16 > | Cirrus (often in bands) and Cirrostratus, or Cirrostratus alone, progressively Invading the sky; they generally thicken as a whole; the continuous veil extends more than 45 degrees above the horizon, without the sky being totally covered
+              | 17 > | Cirrostratus covering the whole sky
+              | 18 > | Cirrostratus not progressively invading the sky and not entirely covering It
+              | 19 > | Cirrocumulus alone, or Cirrocumulus predominant among the CH clouds
+              | 20 > | No CM clouds
+              | 21 > | Altostratus translucidus
+              | 22 > | Altostratus opacus or Nimbostratus
+              | 23 > | Altocumulus translucidus at a single level
+              | 24 > | Patches (often Lenticular) of Altocumulus translucidus, continually changing and occurring at one or more levels
+              | 25 > | Altocumulus translucidus in bands, or one or more layers of Altocumulus translucidus or opacus, progressively Invading the sky;these Altocumulus clouds generally thicken as a whole
+              | 26 > | Altocumulus cumulogenitus (or cumulonimbogenitus)
+              | 27 > | Altocumulus translucidus or opacus In two or more layers, or Altocumulus opacus In a single layer, not progressively Invading the sky, or Altocumulus with Altostratus or Nimbostratus
+              | 28 > | Altocumulus castellanus or floccus
+              | 29 > | Altocumulus of a chaotic sky, generally at several levels
+              | 30 > | No CL clouds
+              | 31 > | Cumulus humilis or Cumulus fractus other than of bad weather, or both
+              | 32 > | Cumulus mediocris or congestus, Towering cumulus (TCU), with or without Cumulus of species fractus or humilis or Stratocumulus, all having their bases at the same level
+              | 33 > | Cumulonimbus calvus, with or without Cumulus, Stratocumulus or Stratus
+              | 34 > | Stratocumulus cumulogenitus
+              | 35 > | Stratocumulus other than Stratocumulus cumulogenitus
+              | 36 > | Stratus nebulosus or Stratus fractus other than of bad weather, or both
+              | 37 > | Stratus fractus or Cumulus fractus of bad weather, or both (pannus),usually below Altostratus or Nimbostratus
+              | 38 > | Cumulus and Stratocumulus other than Stratocumulus cumulogenitus, with bases at different levels
+              | 39 > | Cumulonimbus capillatus (often with an anvil), with or without Cumulonimbus calvus, Cumulus, Stratocumulus, Stratus or pannus
+              | 40 > | CH
+              | 41 > | CM
+              | 42 > | CL
+              | 43 > | Clear
+              | 44 > | Liquid water
+              | 45 > | Supercooled liquid water
+              | 46 > | Mixed phase
+              | 47 > | Optically thick ice
+              | 48 > | Optically thin ice
+              | 49 > | Multilayered ice
+              | 59 > | Cloud not visible owing to darkness, fog, duststorm, sandstorm, or other analogous phenomena
+              | 60 > | CH clouds Invisible owing to darkness, fog, blowing dust or sand, or other similar phenomena, or because of a continuous layer of lower clouds
+              | 61 > | CM clouds Invisible owing to darkness, fog, blowing dust or sand, or other similar phenomena, or because of continuous layer of lower clouds
+              | 62   | CL clouds invisible owing to darkness, fog, blowing dust or sand, or other similar phenomena
+
+  0-20-017 | CTDS ; CODE
+              | 0 > | Isolated cloud fragments of clouds
+              | 1 > | Continuous cloud
+              | 2 > | Broken cloud - small breaks, flat tops
+              | 3 > | Broken cloud - large breaks, flat tops
+              | 4 > | Continuous cloud
+              | 5 > | Broken cloud - small breaks, undulating tops
+              | 6 > | Broken cloud - large breaks, undulating tops
+              | 7 > | Continuous or almost continuous waves with towering clouds above the top of the layer
+              | 8 > | Groups of waves with towering clouds above the top of the layer
+              | 9   | Two or more layers at different levels
+
+  0-20-018 | RWYT ; CODE
+              | 0 > | Increasing (U)
+              | 1 > | Decreasing (D)
+              | 2   | No distinct change (N)
+
+  0-20-021 | PRTP ; FLAG
+              | 1 > | Precipitation-unknown type
+              | 2 > | Liquid precipitation not freezing
+              | 3 > | Liquid freezing precipitation
+              | 4 > | Drizzle
+              | 5 > | Rain
+              | 6 > | Solid precipitation
+              | 7 > | Snow
+              | 8 > | Snow grains
+              | 9 > | Snow pellets
+              | 10 > | Ice pellets
+              | 11 > | Ice crystals
+              | 12 > | Diamond dust
+              | 13 > | Small hail
+              | 14 > | Hail
+              | 15 > | Glaze
+              | 16 > | Rime
+              | 17 > | Soft rime
+              | 18 > | Hard rime
+              | 19 > | Clear ice
+              | 20 > | Wet snow
+              | 21 > | Hoar frost
+              | 22 > | Dew
+              | 23   | White dew
+
+  0-20-022 | PRCH ; CODE
+              | 0 > | No precipitation
+              | 1 > | Continuous
+              | 2 > | Intermittent
+              | 3 > | Shower
+              | 4 > | Not reaching ground
+              | 5   | Deposition
+
+  0-20-023 | OWEP ; FLAG
+              | 1 > | Dust/sand whirl
+              | 2 > | Squalls
+              | 3 > | Sand storm
+              | 4 > | Dust storm
+              | 5 > | Lightning - cloud to surface
+              | 6 > | Lightning - cloud to cloud
+              | 7 > | Lightning - distant
+              | 8 > | Thunderstorm
+              | 9 > | Funnel Cloud not touching surface
+              | 10 > | Funnel cloud touching surface
+              | 11 > | Spray
+              | 12 > | Water-spout
+              | 13 > | Wind shear
+              | 14   | Dust devils
+
+  0-20-024 | INTP ; CODE
+              | 0 > | No phenomena
+              | 1 > | Light
+              | 2 > | Moderate
+              | 3 > | Heavy
+              | 4 > | Violent
+              | 5 > | Severe
+              | 6   | Very severe
+
+  0-20-025 | OBSC ; FLAG
+              | 1 > | Fog
+              | 2 > | Ice fog
+              | 3 > | Steam fog
+              | 7 > | Mist
+              | 8 > | Haze
+              | 9 > | Smoke
+              | 10 > | Volcanic ash
+              | 11 > | Dust
+              | 12 > | Sand
+              | 13 > | Snow
+              | 14 > | Cloud
+              | 15 > | Precipitation
+              | 16   | Impossible to determine whether snow is falling or not
+
+  0-20-026 | OBCH ; CODE
+              | 0 > | No change
+              | 1 > | Shallow
+              | 2 > | Patches
+              | 3 > | Partial
+              | 4 > | Freezing
+              | 5 > | Low drifting
+              | 6 > | Blowing
+              | 7 > | Increasing
+              | 8 > | Decreasing
+              | 9 > | In suspension in the air
+              | 10 > | Wall
+              | 11 > | Dense
+              | 12 > | Whiteout
+              | 13   | Drifting and blowing
+
+  0-20-027 | PHEO ; FLAG
+              | 1 > | At time of observation
+              | 2 > | In past hour
+              | 3 > | In time period for past weather W1W2
+              | 4 > | In time period specified
+              | 6 > | Below station level
+              | 7 > | At the station
+              | 8   | In the vicinity
+
+  0-20-028 | ECIN ; CODE
+              | 0 > | No change (NC)
+              | 1 > | Forecast to weaken (WKN)
+              | 2   | Forecast to intensify (INTSF)
+
+  0-20-029 | RFLAG ; CODE
+              | 0 > | No rain
+              | 1   | Rain
+
+  0-20-032 | ROIA ; CODE
+              | 0 > | Ice not building up
+              | 1 > | Ice building up slowly
+              | 2 > | Ice building up rapidly
+              | 3 > | Ice melting or breaking up slowly
+              | 4   | Ice melting or breaking up rapidly
+
+  0-20-033 | COIA ; FLAG
+              | 1 > | Icing from ocean spray
+              | 2 > | Icing from fog
+              | 3   | Icing from rain
+
+  0-20-034 | SICE ; CODE
+              | 0 > | No sea ice in sight
+              | 1 > | Ship in open lead more than 1.0 nautical mile wide, or ship in fast ice with boundary beyond limit of visibility
+              | 2 > | Sea ice present in concentrations less than 3/10 (3/8) open water or very open pack ice
+              | 3 > | 4/10 to 6/10 (3/8 to less than 6/8), open pack ice
+              | 4 > | 7/10 to 8/10 (6/8 to less 7/8), close pack ice
+              | 5 > | 9/10 or more, but not 10/10 (7/8 to less than 8/8), very close pack ice
+              | 6 > | Strips and patches of pack ice with open water between
+              | 7 > | Strips and patches of close or very close pack ice with areas of lesser concentration between
+              | 8 > | Fast ice with open water, very open or open pack Ice to seaward of the ice boundary
+              | 9 > | Fast ice with close or very close pack ice to seaward of the boundary
+              | 14   | Unable to report, because of darkness, lack of visibility, or because ship is more than 0.5 nautical mile away from ice edge
+
+  0-20-035 | AICE ; CODE
+              | 0 > | No ice of land origin
+              | 1 > | 1-5 icebergs, no growlers or bergy bits
+              | 2 > | 6-10 icebergs, no growlers or bergy bits
+              | 3 > | 11-20 icebergs, no growlers or bergy bits
+              | 4 > | Up to and including 10 growlers and bergy bits - no icebergs
+              | 5 > | More than 10 growlers and bergy bits - no icebergs
+              | 6 > | 1-5 icebergs, with growlers and bergy bits
+              | 7 > | 6-10 icebergs, with growlers and bergy bits
+              | 8 > | 11-20 icebergs, with growlers and bergy bits
+              | 9 > | More than 20 icebergs, with growlers and bergy bits - a major hazard to navigation
+              | 14   | Unable to report, because of darkness, lack of visibility or because only sea ice is visible
+
+  0-20-036 | ICESI ; CODE
+              | 0 > | Ship in open water with floating ice in sight
+              | 1 > | Ship In easily penetrable ice; conditions improving
+              | 2 > | Ship In easily penetrable ice; conditions not changing
+              | 3 > | Ship in easily penetrable ice; conditions worsening
+              | 4 > | Ship in ice difficult to penetrate; conditions improving
+              | 5 > | Ship in ice difficult to penetrate; conditions not changing
+              | 6 > | Ship in ice difficult to penetrate and conditions worsening. Ice forming and floe freezing together
+              | 7 > | Ship in ice difficult to penetrate and conditions worsening. Ice under slight pressure
+              | 8 > | Ship in ice difficult to penetrate and conditions worsening. Ice under moderate or severe pressure
+              | 9 > | Ship in ice difficult to penetrate and conditions worsening. Ship beset
+              | 30   | Unable to report, because of darkness or lack of visibility
+
+  0-20-037 | ICEDV ; CODE
+              | 0 > | New ice only (frazil ice, grease ice, slush, shuga)
+              | 1 > | Nilas or ice rind, less than 10 cm thick
+              | 2 > | Young ice (grey ice, grey white ice), 10-30 cm thick
+              | 3 > | Predominantly new and/or young ice with some first year ice
+              | 4 > | Predominantly thin first year ice with some new and/or young ice
+              | 5 > | All thin first year ice (30-70 cm thick)
+              | 6 > | Predominantly medium first year ice (70-120 cm thick) and thick first year ice (>120 cm thick) with some thinner (younger) first year ice
+              | 7 > | All medium and thick first year ice
+              | 8 > | Predominantly medium and thick first year ice with some old ice (usually more than 2 metres thick)
+              | 9 > | Predominantly old ice
+              | 30   | Unable to report, because of darkness, lack of visibility or because only ice of land origin is visible or because ship is more than 0.5 nautical mile away from ice edge
+
+  0-20-040 | EDRS ; CODE
+              | 0 > | Drift snow ended before the hour of observation
+              | 1 > | Intensity diminishing
+              | 2 > | No change
+              | 3 > | Intensity increasing
+              | 4 > | Continues, apart from interruption lasting less than 30 minutes
+              | 5 > | General drift snow has become drift snow near the ground
+              | 6 > | Drift snow near the ground has become general drift snow
+              | 7   | Drift snow has started again after an interruption of more than 30 minutes
+
+  0-20-041 | AFIC ; CODE
+              | 0 > | No icing
+              | 1 > | Light icing
+              | 2 > | Light icing In cloud
+              | 3 > | Light icing In precipitation
+              | 4 > | Moderate icing
+              | 5 > | Moderate icing in cloud
+              | 6 > | Moderate icing in precipitation
+              | 7 > | Severe icing
+              | 8 > | Severe icing in cloud
+              | 9 > | Severe icing in precipitation
+              | 10 > | Trace of icing
+              | 11 > | Trace of icing in cloud
+              | 12   | Trace of icing in precipitation
+
+  0-20-042 | AFICP ; CODE
+              | 0 > | No icing
+              | 1   | Icing present
+
+  0-20-045 | SCLD ; CODE
+              | 0 > | No SLD conditions present
+              | 1   | SLD conditions present
+
+  0-20-048 | EVFE ; CODE
+              | 0 > | Stability
+              | 1 > | Diminution
+              | 2 > | Intensification
+              | 3   | Unknown
+
+  0-20-050 | CLDI ; CODE
+              | 1 > | 1st low cloud
+              | 2 > | 2nd low cloud
+              | 3 > | 3rd low cloud
+              | 4 > | 1st medium cloud
+              | 5 > | 2nd medium cloud
+              | 6 > | 3rd medium cloud
+              | 7 > | 1st high cloud
+              | 8   | 2nd high cloud
+
+  0-20-055 | STST ; CODE
+              | 0 > | Cumulus, if any, are quite small; generally less than 2/8 coverage, except on windward slopes of elevated terrain; average width of cloud is at least as great as its vertical thickness
+              | 1 > | Cumulus of intermediate size with cloud cover less than 5/8; average cloud width is more than its vertical thickness; towers are vertical with little or no evidence of precipitation, except along slopes of elevated terrain; a general absence of middle and upper clouds
+              | 2 > | Swelling Cumulus with rapidly growing tall turrets which decrease in size with height and whose tops tend to separate from the longer cloud body and evaporate within minutes of the separation
+              | 3 > | Swelling Cumulus with towers having a pronounced tilt in a downwind direction; vertical cloud thickness is more than one and a half times that of its average width
+              | 4 > | Swelling Cumulus with towers having a pronounced tilt in an upwind direction; vertical cloud thickness is more than one and a half times that of its average width
+              | 5 > | Tall Cumulus congestus with vertical thickness more than twice the average width; not organized in clusters or lines; one or more layers of clouds extend out from the cloud towers, although no continuous cloud layers exist
+              | 6 > | Isolated Cumulonimbus or large clusters of Cumulus turrets separated by wide areas in which clouds are absent; cloud bases are generally dark with showers observed in most cells; some scattered middle and upper clouds may be present; individual Cumulus cells are one to two times higher than they are wide
+              | 7 > | Numerous Cumulus extending through the middle troposphere with broken to overcast sheets of middle clouds and/or Cirrostratus; Cumulus towers do not decrease generally in size with height; ragged dark cloud bases with some showers present
+              | 8 > | Continuous dense middle clouds and/or Cirrostratus cloud sheets with some large isolated Cumulonimbus or Cumulus congestus clouds penetrating these sheets; light rain occasionally observed from the Altostratus; Cumulonimbus bases ragged and dark with showers visible
+              | 9 > | Continuous sheets of middle clouds and/or Cirrostratus with Cumulonimbus and Cumulus congestus in organized lines or cloud bands; rain is generally observed from Altostratus sheets and heavy showers from Cumulonimbus; wind has a squally character
+              | 10   | State of sky unknown or not described by any of the above
+
+  0-20-056 | CLDP ; CODE
+              | 0 > | Unknown
+              | 1 > | Water
+              | 2 > | Ice
+              | 3 > | Mixed
+              | 4 > | Clear
+              | 5   | Supercooled liquid water
+
+  0-20-062 | SOGR ; CODE
+              | 0 > | Surface of ground dry (without cracks and no appreciable amount of dust or loose sand)
+              | 1 > | Surface of ground moist
+              | 2 > | Surface of ground wet (standing water in small or large pools on surface)
+              | 3 > | Flooded
+              | 4 > | Surface of ground frozen
+              | 5 > | Glaze on ground
+              | 6 > | Loose dry dust or sand not covering ground completely
+              | 7 > | Thin cover of loose dry dust or sand covering ground completely
+              | 8 > | Moderate or thick cover of loose dry dust or sand covering ground completely
+              | 9 > | Extremely dry with cracks
+              | 10 > | Ground predominantly covered by ice
+              | 11 > | Compact or wet snow (with or without ice) covering less than one half of the ground
+              | 12 > | Compact or wet snow (with or without ice) covering at least one half of the ground but ground not completely covered
+              | 13 > | Even layer of compact or wet snow covering ground completely
+              | 14 > | Uneven layer of compact or wet snow covering ground completely
+              | 15 > | Loose dry snow covering less than one half of the ground
+              | 16 > | Loose dry snow covering at least one half of the ground (but not completely)
+              | 17 > | Even layer of loose dry snow covering ground completely
+              | 18 > | Uneven layer of loose dry snow covering ground completely
+              | 19   | Snow covering ground completely; deep drifts
+
+  0-20-063 | PHES ; CODE
+              | 1 > | Highest wind speed gusts greater than 11.5 m/s
+              | 2 > | Highest wind speed gusts greater than 17.5 m/s
+              | 7 > | Visibility greater than 100000 m
+              | 10 > | Mirage - No specification
+              | 11 > | Mirage - Image of distant object raised (looming)
+              | 12 > | Mirage - Image of distant object raised clear above the horizon
+              | 13 > | Mirage - Inverted image of distant object
+              | 14 > | Mirage - Complex, multiple images of distant object (images not inverted)
+              | 15 > | Mirage - Complex, multiple images of distant object (some images being inverted)
+              | 16 > | Mirage - Sun or moon seen appreciably distorted
+              | 17 > | Mirage - Sun visible, although astronomically below the horizon
+              | 18 > | Mirage - Moon visible, although astronomically below the horizon
+              | 20 > | Day darkness, bad, worst in direction specified
+              | 21 > | Day darkness, very bad, worst in direction specified
+              | 22 > | Day darkness, black, worst in direction specified
+              | 31 > | Slight coloration of clouds at sunrise associated with a tropical disturbance
+              | 32 > | Deep-red coloration of clouds at sunrise associated with a tropical disturbance
+              | 33 > | Slight coloration of clouds at sunset associated with a tropical disturbance
+              | 34 > | Deep-red coloration of clouds at sunset associated with a tropical disturbance
+              | 35 > | Convergence of CH clouds at a point below 45 degrees forming or increasing and associated with a tropical disturbance
+              | 36 > | Convergence of CH clouds at a point above 45 degrees associated with a tropical disturbance
+              | 37 > | Convergence of CH clouds at a point below 45 degrees dissolving or diminishing and associated with a tropical disturbance
+              | 38 > | Convergence of CH clouds at a point above 45 degrees associated with a tropical disturbance
+              | 40 > | Hoar frost on horizontal surfaces
+              | 41 > | Hoar frost on horizontal and vertical surfaces
+              | 42 > | Precipitation containing sand or desert dust
+              | 43 > | Precipitation containing volcanic ash
+              | 50 > | Calm or light wind followed by a squall
+              | 51 > | Calm or light wind followed by a succession of squalls
+              | 52 > | Gusty weather followed by a squall
+              | 53 > | Gusty weather followed by a succession of squalls
+              | 54 > | Squall followed by gusty weather
+              | 55 > | General gusty weather with squall at intervals
+              | 56 > | Squall approaching station
+              | 57 > | Line squall
+              | 58 > | Squall with drifting or blowing dust or sand
+              | 59 > | Line squall with drifting or blowing dust or sand
+              | 60 > | Temperature steady
+              | 61 > | Temperature falling, without going below 0 degrees Celsius
+              | 62 > | Temperature rising, without going above 0 degrees Celsius
+              | 63 > | Temperature falling to a value below 0 degrees Celsius
+              | 64 > | Temperature rising to a value above 0 degrees Celsius
+              | 65 > | Irregular variation, oscillations of temperature passing through 0 degrees Celsius
+              | 66 > | Irregular variation, oscillations of temperature not passing through 0 degrees Celsius
+              | 67 > | Variation of temperature not observed
+              | 69 > | Variation of temperature unknown owing to lack of thermograph
+              | 70 > | Visibility has not varied (sun visible) towards direction specified
+              | 71 > | Visibility has not varied (sun invisible) towards direction specified
+              | 72 > | Visibility has increased (sun visible) towards direction specified
+              | 73 > | Visibility has increased (sun invisible) towards direction specified
+              | 74 > | Visibility has decreased (sun visible) towards direction specified
+              | 75 > | Visibility has decreased (sun invisible) towards direction specified
+              | 76 > | Fog coming from direction specified
+              | 77 > | Fog has lifted, without dissipating
+              | 78 > | Fog has dispersed without regard to direction
+              | 79 > | Moving patches or banks of fog
+              | 80 > | Brocken spectre
+              | 81 > | Rainbow
+              | 82 > | Solar or lunar halo
+              | 83 > | Parhelia or anthelia
+              | 84 > | Sun pillar
+              | 85 > | Corona
+              | 86 > | Twilight glow
+              | 87 > | Twilight glow on the mountains
+              | 88 > | Mirage
+              | 89 > | Zodiacal light
+              | 90   | St. Elmos fire
+
+  0-20-071 | AFRA ; CODE
+              | 0 > | No assessment
+              | 1 > | Accuracy less than 50 km, and rate less than 1 per second
+              | 2 > | Accuracy between 50 and 200 km, and rate less than 1 per second
+              | 3 > | Accuracy more than 200 km, and rate less than 1 per second
+              | 4 > | Accuracy less than 50 km, and rate 1 or more per second
+              | 5 > | Accuracy between 50 and 200 km, and rate 1 or more per second
+              | 6 > | Accuracy more than 200 km, and rate 1 or more per second
+              | 7 > | Accuracy less than 50 km, and rate too rapid to count
+              | 8 > | Accuracy between 50 and 200 km, and rate too rapid to count
+              | 9   | Accuracy more than 200 km, and rate too rapid to count
+
+  0-20-085 | GCRW ; CODE
+              | 0 > | Cleared (CLRD//)
+              | 1   | All runways closed (SNOCLO)
+
+  0-20-086 | RWDP ; CODE
+              | 0 > | Clear and dry
+              | 1 > | Damp
+              | 2 > | Wet with water patches
+              | 3 > | Rime and frost covered (depth normally less than 1 mm)
+              | 4 > | Dry snow
+              | 5 > | Wet snow
+              | 6 > | Slush
+              | 7 > | Ice
+              | 8 > | Compacted or rolled snow
+              | 9   | Frozen ruts or ridges
+
+  0-20-087 | RWCT ; CODE
+              | 1 > | Less than 10% of runway covered
+              | 2 > | 11% to 25% of runway covered
+              | 5 > | 26% to 50% of runway covered
+              | 9   | 51% to 100% of runway covered
+
+  0-20-089 | RWFC ; CODE
+              | 0 > | 0.00
+              | 1 > | 0.01
+              | 2 > | 0.02
+              | 3 > | 0.03
+              | 4 > | 0.04
+              | 5 > | 0.05
+              | 6 > | 0.06
+              | 7 > | 0.07
+              | 8 > | 0.08
+              | 9 > | 0.09
+              | 10 > | 0.10
+              | 11 > | 0.11
+              | 12 > | 0.12
+              | 13 > | 0.13
+              | 14 > | 0.14
+              | 15 > | 0.15
+              | 16 > | 0.16
+              | 17 > | 0.17
+              | 18 > | 0.18
+              | 19 > | 0.19
+              | 20 > | 0.20
+              | 21 > | 0.21
+              | 22 > | 0.22
+              | 23 > | 0.23
+              | 24 > | 0.24
+              | 25 > | 0.25
+              | 26 > | 0.26
+              | 27 > | 0.27
+              | 28 > | 0.28
+              | 29 > | 0.29
+              | 30 > | 0.30
+              | 31 > | 0.31
+              | 32 > | 0.32
+              | 33 > | 0.33
+              | 34 > | 0.34
+              | 35 > | 0.35
+              | 36 > | 0.36
+              | 37 > | 0.37
+              | 38 > | 0.38
+              | 39 > | 0.39
+              | 40 > | 0.40
+              | 41 > | 0.41
+              | 42 > | 0.42
+              | 43 > | 0.43
+              | 44 > | 0.44
+              | 45 > | 0.45
+              | 46 > | 0.46
+              | 47 > | 0.47
+              | 48 > | 0.48
+              | 49 > | 0.49
+              | 50 > | 0.50
+              | 51 > | 0.51
+              | 52 > | 0.52
+              | 53 > | 0.53
+              | 54 > | 0.54
+              | 55 > | 0.55
+              | 56 > | 0.56
+              | 57 > | 0.57
+              | 58 > | 0.58
+              | 59 > | 0.59
+              | 60 > | 0.60
+              | 61 > | 0.61
+              | 62 > | 0.62
+              | 63 > | 0.63
+              | 64 > | 0.64
+              | 65 > | 0.65
+              | 66 > | 0.66
+              | 67 > | 0.67
+              | 68 > | 0.68
+              | 69 > | 0.69
+              | 70 > | 0.70
+              | 71 > | 0.71
+              | 72 > | 0.72
+              | 73 > | 0.73
+              | 74 > | 0.74
+              | 75 > | 0.75
+              | 76 > | 0.76
+              | 77 > | 0.77
+              | 78 > | 0.78
+              | 79 > | 0.79
+              | 80 > | 0.80
+              | 81 > | 0.81
+              | 82 > | 0.82
+              | 83 > | 0.83
+              | 84 > | 0.84
+              | 85 > | 0.85
+              | 86 > | 0.86
+              | 87 > | 0.87
+              | 88 > | 0.88
+              | 89 > | 0.89
+              | 90 > | 0.90
+              | 91 > | Braking action poor
+              | 92 > | Braking action medium to poor
+              | 93 > | Braking action medium
+              | 94 > | Braking action medium to good
+              | 95 > | Braking action good
+              | 99   | Unreliable
+
+  0-20-090 | SPCL ; CODE
+              | 1 > | Nacreous clouds
+              | 2 > | Noctilucent clouds
+              | 3 > | Clouds from waterfalls
+              | 4 > | Clouds from fires
+              | 5   | Clouds from volcanic eruptions
+
+  0-20-101 | LONA ; CODE
+              | 1 > | Schistocerca gregaria
+              | 2 > | Locusta migratoria
+              | 3 > | Nomadacris septemfasciata
+              | 4 > | Oedaleus senegalensis
+              | 5 > | Anracridium spp
+              | 6 > | Other locusts
+              | 7 > | Other grasshoppers
+              | 8 > | Other crickets
+              | 9   | Spodoptera exempt
+
+  0-20-102 | LOCO ; CODE
+              | 0 > | Green
+              | 1 > | Green or black
+              | 2 > | Black
+              | 3 > | Yellow and black
+              | 4 > | Straw/grey
+              | 5 > | Pink
+              | 6 > | Dark red/brown
+              | 7 > | Mixed red and yellow
+              | 8 > | Yellow
+              | 9   | Other
+
+  0-20-103 | SDLO ; CODE
+              | 0 > | Hoppers (nymphs, larvae), stage 1
+              | 1 > | Hoppers (nymphs, larvae), stage 2 or mixed 1, 2 instars (stages)
+              | 2 > | Hoppers (nymphs, larvae), stage 3 or mixed 2, 3 instars
+              | 3 > | Hoppers (nymphs, larvae), stage 4 or mixed 3, 4 instars
+              | 4 > | Hoppers (nymphs, larvae), stage 5 or mixed 4, 5 instars
+              | 5 > | Hoppers (nymphs, larvae), stage mixed, all or many instars
+              | 6 > | Fledglings (wings too soft for sustained flight)
+              | 7 > | Immature adults
+              | 8 > | Mixed maturity adults
+              | 9   | Mature adults
+
+  0-20-104 | OSLO ; CODE
+              | 0 > | Hoppers only, mainly in bands or clusters
+              | 1 > | Winged adults in the vicinity more than 10 kilometres from point of observation
+              | 2 > | Locusts in flight, a few seen at the station
+              | 3 > | Locusts at the station, most of them on the ground
+              | 4 > | Locusts, some on ground and others in flight at a height less than 10 metres
+              | 5 > | Locusts, some on ground and others in flight at a height greater than 10 metres
+              | 6 > | Locusts, most in flight at a height less than 10 metres
+              | 7 > | Locusts, most in flight at a height greater than 10 metres
+              | 8 > | Locusts, all over inflicting severe damage to vegetation, no extermination operation
+              | 9   | Locusts, all over inflicting severe damage to vegetation, extermination operation in progress
+
+  0-20-105 | SSLO ; CODE
+           | 0-20-104=0
+              | 1 > | Area covered by isolated bands < 10 m**2
+              | 2 > | Area covered by isolated bands 10-100 m**2
+              | 3 > | Area covered by isolated bands 100-1000 m**2
+              | 4 > | Area covered by isolated bands 1000-10000 m**2
+              | 5 > | Area covered by isolated bands 1-10 ha
+              | 6 > | Area covered by isolated bands > 10 ha
+              | 7 > | Area covered by dispersed bands < 100 km**2
+              | 8 > | Area covered by dispersed bands 100-1000 km**2
+              | 9 > | Area covered by dispersed bands > 1000 km**2
+           | 0-20-104=7,5,9,6,4,8,2,3,1
+              | 0 > | Small swarm less than 1 km**2 or adults in ground, tens or hundreds of individuals visible simultaneously, duration of passage less than 1 hour ago
+              | 1 > | Small swarm less than 1 km**2 or adults in ground, tens or hundreds of individuals visible simultaneously, duration of passage 1 to 6 hours ago
+              | 2 > | Small swarm less than 1 km**2 or adults in ground, tens or hundreds of individuals visible simultaneously, duration of passage over 6 hours ago
+              | 3 > | Medium swarm or scattered adults, several visible simultaneously, duration of passage less than 1 hour ago
+              | 4 > | Medium swarm or scattered adults, several visible simultaneously, duration of passage 1 to 6 hours ago
+              | 5 > | Medium swarm or scattered adults, several visible simultaneously, duration of passage over 6 hours ago
+              | 6 > | Large swarm or isolated adults, seen singly, duration of passage less than 1 hour ago
+              | 7 > | Large swarm or isolated adults, seen singly, duration of passage 1 to 6 hours ago
+              | 8 > | Large swarm or isolated adults, seen singly, duration of passage over 6 hours ago
+              | 9 > | More than one swarm of locusts
+              | 10   | Size of swarm and/or duration of passage not determined owing to darkness or similar phenomena
+
+  0-20-106 | LOPD ; CODE
+              | 1 > | Thin density swarm (swarm visible only when near enough for individual locusts to be discerned)
+              | 2 > | Medium density swarm
+              | 3 > | Dense swarm (obscuring nearby features, e.g. trees)
+              | 4 > | Isolated hoppers seen singly
+              | 5   | Scattered hoppers, several visible simultaneously
+
+  0-20-107 | DMLO ; CODE
+              | 1 > | Generally in the direction NE
+              | 2 > | Generally in the direction E
+              | 3 > | Generally in the direction SE
+              | 4 > | Generally in the direction S
+              | 5 > | Generally in the direction SW
+              | 6 > | Generally in the direction W
+              | 7 > | Generally in the direction NW
+              | 8 > | Generally in the direction N
+              | 9   | Specific direction indeterminable
+
+  0-20-108 | EXTV ; CODE
+              | 0 > | Bare ground
+              | 1 > | Dry, presence of few and isolated shrubs
+              | 2 > | Sparse vegetation (sprouting)
+              | 3 > | Dense vegetation (sprouting)
+              | 4 > | Sparse vegetation (growing)
+              | 5 > | Dense vegetation (growing)
+              | 6 > | Sparse vegetation in flower
+              | 7   | Dense vegetation in flower
+
+  0-20-119 | PLRTS ; CODE
+              | 0 > | Not defined
+              | 1 > | Positive
+              | 2   | Negative
+
+  0-20-124 | LSOR ; CODE
+              | 0 > | Not defined
+              | 1 > | Lightning stroke
+              | 2   | Lightning flash, by manual observation, or if equipment insensitive to stroke resolution
+
+  0-20-136 | SUCT ; CODE
+              | 0 > | Isolated cumulus humilis and/or cumulus mediocris of vertical development
+              | 1 > | Numerous cumulus humilis and/or cumulus mediocris of vertical development
+              | 2 > | Isolated cumulus congestus of vertical development
+              | 3 > | Numerous cumulus congestus of vertical development
+              | 4 > | Isolated cumulonimbus of vertical development
+              | 5 > | Numerous cumulonimbus of vertical development
+              | 6 > | Isolated cumulus and cumulonimbus of vertical development
+              | 7 > | Numerous cumulus and cumulonimbus of vertical development
+              | 11 > | Isolated orographic clouds, pileus, incus, forming
+              | 12 > | Isolated orographic clouds, pileus, incus, not changing
+              | 13 > | Isolated orographic clouds, pileus, incus, dissolving
+              | 14 > | Irregular banks of orographic cloud, fohn bank, etc., forming
+              | 15 > | Irregular banks of orographic cloud, fohn bank, etc., not changing
+              | 16 > | Irregular banks of orographic cloud, fohn bank, etc., dissolving
+              | 17 > | Compact layer of orographic cloud, fohn bank, etc., forming
+              | 18 > | Compact layer of orographic cloud, fohn bank, etc., not changing
+              | 19 > | Compact layer of orographic cloud, fohn bank, etc., dissolving
+              | 20 > | All mountains open, only small amounts of cloud present
+              | 21 > | Mountains partly covered with detached clouds (not more than half the peaks can be seen)
+              | 22 > | All mountains slopes covered, peaks and passes free
+              | 23 > | Mountains open on observer's side (only small amounts of cloud present), but a continuous wall of cloud on the other side
+              | 24 > | Clouds low above the mountains, but all slopes and mountains open (only small amounts of cloud on the slopes)
+              | 25 > | Clouds low above the mountains, peaks partly covered by precipitation trails or clouds
+              | 26 > | All peaks covered but passes open, slopes either open or covered
+              | 27 > | Mountains generally covered but some peaks free, slopes wholly or partially covered
+              | 28 > | All peaks, passes and slopes covered
+              | 29 > | Mountains cannot be seen owing to darkness, fog, snowstorm, precipitation, etc.
+              | 35 > | Non-persistent condensation trails
+              | 36 > | Persistent condensation trails covering less than 1/8 of the sky
+              | 37 > | Persistent condensation trails covering 1/8 of the sky
+              | 38 > | Persistent condensation trails covering 2/8 of the sky
+              | 39 > | Persistent condensation trails covering 3/8 or more of the sky
+              | 40 > | No cloud or mist observed from a higher level
+              | 41 > | Mist, clear above observed from a higher level
+              | 42 > | Fog patches observed from a higher level
+              | 43 > | Layer of slight fog observed from a higher level
+              | 44 > | Layer of thick fog observed from a higher level
+              | 45 > | Some isolated clouds observed from a higher level
+              | 46 > | Isolated clouds and fog below observed from a higher level
+              | 47 > | Many isolated clouds observed from a higher level
+              | 48 > | Sea of isolated clouds observed from a higher level
+              | 49   | Bad visibility obscuring the downward view observed from a higher level
+
+  0-20-137 | EVOC ; CODE
+              | 0 > | No change
+              | 1 > | Cumulification
+              | 2 > | Slow elevation
+              | 3 > | Rapid elevation
+              | 4 > | Elevation and stratification
+              | 5 > | Slow lowering
+              | 6 > | Rapid lowering
+              | 7 > | Stratification
+              | 8 > | Stratification and lowering
+              | 9   | Rapid change
+
+  0-20-138 | ROADSC ; CODE
+              | 0 > | Dry
+              | 1 > | Moist
+              | 2 > | Wet
+              | 3 > | Rime
+              | 4 > | Snow
+              | 5 > | Ice
+              | 6 > | Glaze
+              | 7   | Not dry
+
+  0-21-066 | WSPC ; FLAG
+              | 1 > | Process equipment not working
+              | 2 > | Equipment failed
+              | 3 > | PRF code changed during image generation
+              | 4 > | Sampling window changed during image generation
+              | 5 > | Gain changed during image generation
+              | 6 > | Chirp replica exceeds specified values
+              | 7 > | Input data mean and standard deviation of in-phase and quadrature out of range
+              | 8 > | Doppler centroid confidence > MMCC value
+              | 9 > | Doppler centroid absolute value > PRF/2
+              | 10 > | Doppler ambiguity confidence < MMCC value
+              | 11   | Output data mean and standard deviation =< MMCC value
+
+  0-21-067 | WSPC2 ; FLAG
+              | 1 > | No forebeam calculation
+              | 2 > | No midbeam calculation
+              | 3 > | No aftbeam calculation
+              | 4 > | Forebeam arcing detected
+              | 5 > | Midbeam arcing detected
+              | 6 > | Aftbeam arcing detected
+              | 7 > | Any beam noise content above or equal to threshold
+              | 8 > | Land (any land in cell footprint)
+              | 9 > | Autonomous ambiguity removal not used
+              | 10 > | Meteorological background not used
+              | 11 > | Minimum residual exceeded threshold
+              | 12   | Frame checksum error detected
+
+  0-21-068 | RAPC ; FLAG
+              | 1 > | Standard deviation of wind speed outside MMCC limit
+              | 2 > | Standard deviation of significant wave height outside MMCC limit
+              | 3 > | Standard deviation of altitude outside MMCC limit
+              | 4 > | Mean peakiness outside MMCC limit
+              | 5 > | Frame checksum error detected
+              | 6 > | Height-time loop time constant correction not performed
+              | 7   | Not enough measurements (N<10)
+
+  0-21-069 | SSPC ; FLAG
+              | 1 > | 12.0 um channel present in source data
+              | 2 > | 11.0 um channel present in source data
+              | 3 > | 3.7 um channel present in source data
+              | 4 > | 1.6 um channel present in source data
+              | 5 > | Cloud identification used 1.6 um histogram reflectance cloud test
+              | 6 > | 1.6 um histogram reflectance cloud test used dynamic threshold
+              | 7 > | Sun glint detected by 1.6 um reflectance cloud test
+              | 8 > | 3.7 um channel used in sea surface temperature retrieval
+              | 9   | Sea surface temperature derivation used day-time data (night time if zero)
+
+  0-21-070 | SSPC2 ; FLAG
+              | 1 > | Cell 1 (SW): nadir-only view SST used 3.7 micron channel
+              | 2 > | Cell 2 (S): nadir-only view SST used 3.7 micron channel
+              | 3 > | Cell 3 (SE): nadir-only view SST used 3.7 micron channel
+              | 4 > | Cell 4 (W): nadir-only view SST used 3.7 micron channel
+              | 5 > | Cell 5 (CTR): nadir-only view SST used 3.7 micron channel
+              | 6 > | Cell 6 (E): nadir-only view SST used 3.7 micron channel
+              | 7 > | Cell 7 (NW): nadir-only view SST used 3.7 micron channel
+              | 8 > | Cell 8 (N): nadir-only view SST used 3.7 micron channel
+              | 9 > | Cell 9 (NE): nadir-only view SST used 3.7 micron channel
+              | 10 > | Cell 1 (SW): dual view SST used 3.7 micron channel
+              | 11 > | Cell 2 (S): dual view SST used 3.7 micron channel
+              | 12 > | Cell 3 (SE): dual view SST used 3.7 micron channel
+              | 13 > | Cell 4 (W): dual view SST used 3.7 micron channel
+              | 14 > | Cell 5 (CTR): dual view SST used 3.7 micron channel
+              | 15 > | Cell 6 (E): dual view SST used 3.7 micron channel
+              | 16 > | Cell 7 (NW): dual view SST used 3.7 micron channel
+              | 17 > | Cell 8 (N): dual view SST used 3.7 micron channel
+              | 18 > | Cell 9 (NE): dual view SST used 3.7 micron channel
+              | 19 > | Nadir view contains day-time data (night if zero)
+              | 20 > | Forward view contains day-time data (night if zero)
+              | 21 > | Record contains contributions from instrument scans acquired when ERS platform not in yaw-steering mode
+              | 22   | Record contains contributions from instrument scans for which Product Confidence Data show quality is poor or unknown
+
+  0-21-072 | SACS ; FLAG
+              | 1 > | Height error correction applied instead of open loop calibration
+              | 2 > | Microwave sounder used for troposphere correction
+              | 3   | AGC output correction applied instead of open loop calibration
+
+  0-21-073 | SAIM ; FLAG
+              | 1 > | Blank data record
+              | 2 > | Test
+              | 3 > | Calibration (closed loop)
+              | 4 > | BITE
+              | 5 > | Acquisition on ice
+              | 6 > | Acquisition on ocean
+              | 7 > | Tracking on ice
+              | 8   | Tracking on ocean
+
+  0-21-076 | REIN ; CODE
+              | 0 > | Linear
+              | 1 > | Logarithmic (base e)
+              | 2   | Logarithmic (base 10)
+
+  0-21-109 | SWVQ ; FLAG
+              | 1 > | Not enough good sigma-0 available for wind retrieval
+              | 2 > | Poor azimuth diversity among sigma-0 for wind retrieval
+              | 8 > | Some portion of wind vector cell is over land
+              | 9 > | Some portion of wind vector cell is over ice
+              | 10 > | Wind retrieval not performed for wind vector cell
+              | 11 > | Reported wind speed is greater than 30 m s**-1
+              | 12   | Reported wind speed is less than or equal to 3 m s**-1
+
+  0-21-115 | SSQU ; FLAG
+              | 1 > | Sigma-0 measurement is not usable
+              | 2 > | Signal to noise ratio is low
+              | 3 > | Sigma-0 is negative
+              | 4 > | Sigma-0 is outside of acceptable range
+              | 5 > | Scatterometer pulse quality is not acceptable
+              | 6 > | Sigma-0 cell location algorithm does not converge
+              | 7 > | Frequency shift lies beyond the range of the x factor table
+              | 8 > | Spacecraft temperature is beyond calibration coefficient range
+              | 9 > | No applicable altitude records were found for this sigma-0
+              | 10   | Interpolated ephemeris data are not acceptable for this sigma-0
+
+  0-21-116 | SSMD ; FLAG
+              | 1 > | Calibration/measurement pulse flag (1)
+              | 2 > | Calibration/measurement pulse flag (2)
+              | 3 > | Outer antenna beam
+              | 4 > | Sigma-0 cell is aft of spacecraft
+              | 5 > | Current mode (1)
+              | 6 > | Current mode (2)
+              | 7 > | Effective gate width - slice resolution (1)
+              | 8 > | Effective gate width - slice resolution (2)
+              | 9 > | Effective gate width - slice resolution (3)
+              | 10 > | Low resolution mode - whole pulse data
+              | 11 > | Scatterometer electronic subsystem B
+              | 12 > | Alternate spin rate - 19.8 rpm
+              | 13 > | Receiver protection on
+              | 14 > | Slices per composite flag (1)
+              | 15 > | Slices per composite flag (2)
+              | 16   | Slices per composite flag (3)
+
+  0-21-119 | WSGF ; CODE
+              | 1 > | SASS
+              | 2 > | SASS2
+              | 3 > | NSCAT0
+              | 4 > | NSCAT1
+              | 5 > | NSCAT2
+              | 6 > | QSCAT0
+              | 7 > | QSCAT1
+              | 31 > | CMOD1
+              | 32 > | CMOD2
+              | 33 > | CMOD3
+              | 34 > | CMOD4
+              | 35   | CMOD5
+
+  0-21-144 | ALRF ; FLAG
+              | 1   | Rain
+
+  0-21-148 | TEVF ; FLAG
+              | 1 > | No short scale variation
+              | 2   | Short scale variation
+
+  0-21-150 | BEAMC ; CODE
+              | 0 > | Data from single ground station (no co-location)
+              | 1   | Data from multiple ground station (co-located data)
+
+  0-21-155 | WVCQ ; FLAG
+              | 1 > | Not enough good sigma-0 available for wind retrieval
+              | 2 > | Poor azimuth diversity among sigma-0 for wind retrieval
+              | 3 > | Any beam noise content above threshold
+              | 4 > | Product monitoring not used
+              | 5 > | Product monitoring flag
+              | 6 > | KNMI quality control fails
+              | 7 > | Variational quality control fails
+              | 8 > | Some portion of wind vector cell is over land
+              | 9 > | Some portion of wind vector cell is over ice
+              | 10 > | Wind retrieval not performed for wind vector cell
+              | 11 > | Reported wind speed is greater than 30 m s**-1
+              | 12 > | Reported wind speed is less than or equal to 3 m s**-1
+              | 13 > | Rain flag for the wind vector cell is not usable
+              | 14 > | Rain flag algorithm detects rain
+              | 15 > | No meteorological background used
+              | 16   | Data are redundant
+
+  0-21-158 | AKPEQ ; CODE
+              | 0 > | Acceptable
+              | 1   | Not acceptable
+
+  0-21-159 | ASGU ; CODE
+              | 0 > | Good
+              | 1 > | Usable
+              | 2   | Bad
+
+  0-21-169 | IPIN ; CODE
+              | 0 > | No ice present
+              | 1   | Ice present
+
+  0-22-056 | DIPR ; CODE
+              | 0 > | Upwards profile
+              | 1 > | Downwards profile
+              | 2   | Horizontal
+
+  0-22-060 | LDDS ; CODE
+              | 0 > | Drogue is detached
+              | 1 > | Drogue is attached
+              | 2   | Drogue status unknown
+
+  0-22-061 | SEST ; CODE
+              | 0 > | Calm (glassy, no waves)
+              | 1 > | Calm (rippled, wave height < 0.1 m)
+              | 2 > | Smooth (wavelets, wave height 0.1-0.5 m)
+              | 3 > | Slight (wave height 0.5-1.25 m)
+              | 4 > | Moderate (wave height 1.25-2.5 m)
+              | 5 > | Rough (wave height 2.5-4 m)
+              | 6 > | Very rough (wave height 4-6 m)
+              | 7 > | High (wave height 6-9 m)
+              | 8 > | Very high (wave height 9-14 m)
+              | 9   | Phenomenal (wave height > 14 m)
+
+  0-22-067 | IWTEMP ; CODE
+              | 1 > | Sippican T-4 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 2 > | Sippican T-4 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 11 > | Sippican T-5 (fall rate equation coefficients: a = 6.828, b = -1.82)
+              | 21 > | Sippican Fast Deep (fall rate equation coefficients: a = 6.346, b = -1.82)
+              | 31 > | Sippican T-6 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 32 > | Sippican T-6 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 41 > | Sippican T-7 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 42 > | Sippican T-7 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 51 > | Sippican Deep Blue (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 52 > | Sippican Deep Blue (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 61 > | Sippican T-10 (fall rate equation coefficients: a = 6.301, b = -2.16)
+              | 71 > | Sippican T-11 (fall rate equation coefficients: a = 1.7779, b = -0.255)
+              | 81 > | Sippican AXBT (300 m probes) (fall rate equation coefficients: a = 1.52, b = 0.0)
+              | 201 > | TSK T-4 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 202 > | TSK T-4 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 211 > | TSK T-6 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 212 > | TSK T-6 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 221 > | TSK T-7 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 222 > | TSK T-7 (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 231 > | TSK T-5 (fall rate equation coefficients: a = 6.828, b = -1.82)
+              | 241 > | TSK T-10 (fall rate equation coefficients: a = 6.301, b = -2.16)
+              | 251 > | TSK Deep Blue (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 252 > | TSK Deep Blue (fall rate equation coefficients: a = 6.691, b = -2.25)
+              | 261 > | TSK AXBT
+              | 401 > | Sparton XBT-1 (fall rate equation coefficients: a = 6.301, b = -2.16)
+              | 411 > | Sparton XBT-3 (fall rate equation coefficients: a = 5.861, b = -0.0904)
+              | 421 > | Sparton XBT-4 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 431 > | Sparton XBT-5 (fall rate equation coefficients: a = 6.828, b = -1.82)
+              | 441 > | Sparton XBT-5DB (fall rate equation coefficients: a = 6.828, b = -1.82)
+              | 451 > | Sparton XBT-6 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 461 > | Sparton XBT-7 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 462 > | Sparton XBT-7 (fall rate equation coefficients: a = 6.705, b = -2.28)
+              | 471 > | Sparton XBT-7DB (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 481 > | Sparton XBT-10 (fall rate equation coefficients: a = 6.301, b = -2.16)
+              | 491 > | Sparton XBT-20 (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 501 > | Sparton XBT-20DB (fall rate equation coefficients: a = 6.472, b = -2.16)
+              | 510 > | Sparton 536 AXBT (fall rate equation coefficients: a = 1.524, b = 0)
+              | 700 > | Sippican XCTD Standard
+              | 710 > | Sippican XCTD Deep
+              | 720 > | Sippican AXCTD
+              | 730 > | Sippican SXCTD
+              | 741 > | TSK XCTD/XCTD-1/XCTD-1N (fall rate equation coefficients: a = 3.42543, b = -0.47)
+              | 742 > | TSK XCTD-2/XCTD-2N (fall rate equation coefficients: a = 3.43898, b = -0.31)
+              | 743 > | TSK XCTD-2F (fall rate equation coefficients: a = 3.43898, b = -0.31)
+              | 744 > | TSK XCTD-3/XCTD-3N (fall rate equation coefficients: a = 5.07598, b = -0.72)
+              | 745 > | TSK XCTD-4/XCTD-4N (fall rate equation coefficients: a = 3.68081, b = -0.47)
+              | 751 > | TSK AXCTD
+              | 780 > | Sea-Bird SBE21 SEACAT Thermosalinograph
+              | 781 > | Sea-Bird SBE45 MicroTSG Thermosalinograph
+              | 800 > | Mechanical BT
+              | 810 > | Hydrocast
+              | 820 > | Thermistor chain
+              | 825 > | Temperature (sonic) and pressure probes
+              | 830 > | CTD
+              | 831 > | CTD-P-ALACE float
+              | 834 > | PROVOR V SBE
+              | 835 > | PROVOR IV
+              | 836 > | PROVOR III
+              | 837 > | ARVOR_C, SBE conductivity sensor
+              | 838 > | ARVOR_D, SBE conductivity sensor
+              | 839 > | PROVOR-II, SBE conductivity sensor
+              | 840 > | PROVOR, no conductivity sensor
+              | 841 > | PROVOR, Sea-Bird conductivity sensor
+              | 842 > | PROVOR, FSI conductivity sensor
+              | 843 > | Polar Ocean Profiling System (POPS), PROVOR, SBE CTD
+              | 844 > | Profiling Float, ARVOR, Seabird conductivity sensor
+              | 845 > | Webb Research, no conductivity sensor
+              | 846 > | Webb Research, Sea-Bird conductivity sensor
+              | 847 > | Webb Research, FSI conductivity sensor
+              | 848 > | APEX-EM, SBE conductivity sensor
+              | 849 > | APEX_D, SBE conductivity sensor
+              | 850 > | SOLO, no conductivity sensor
+              | 851 > | SOLO, Sea-Bird conductivity sensor
+              | 852 > | SOLO,  FSI conductivity sensor
+              | 853 > | Profiling Float, SOLO2 (SCRIPPS), Seabird conductivity sensor
+              | 854 > | S2A, SBE conductivity sensor
+              | 855 > | Profiling Float, NINJA, no conductivity sensor
+              | 856 > | Profiling Float, NINJA, SBE conductivity sensor
+              | 857 > | Profiling Float, NINJA, FSI conductivity sensor
+              | 858 > | Profiling Float, NINJA, TSK conductivity sensor
+              | 859 > | Profiling Float, NEMO, no conductivity
+              | 860 > | Profiling Float, NEMO, SBE conductivity sensor
+              | 861 > | Profiling Float, NEMO, FSI conductivity sensor
+              | 862 > | SOLO_D, SBE conductivity sensor
+              | 863 > | NAVIS-A, SBE conductivity sensor
+              | 864 > | NINJA_D, SBE conductivity sensor
+              | 865 > | NOVA, SBE conductivity sensor
+              | 866 > | ALAMO, No conductivity sensor
+              | 867 > | ALAMO, RBR conductivity sensor
+              | 868 > | ALAMO, SBE conductivity sensor
+              | 870 > | HM2000
+              | 871 > | COPEX
+              | 872 > | S2X
+              | 873 > | ALTO
+              | 874 > | SOLO_D_MRV
+              | 875 > | ALTO RBR
+              | 876 > | ALTO SBE
+              | 877 > | APEX RBR
+              | 878 > | ARVOR RBR
+              | 879 > | SOLO II RBR
+              | 880 > | S2A RBR
+              | 900 > | Sippican LMP-5 XBT (fall rate equation coefficients: a = 9.727, b = -0.0473)
+              | 901 > | Ice-tethered Profiler (ITP), SBE CTD
+              | 902 > | Brooke ocean moving vessel profiler (MVP)
+              | 903 > | Seabird CTD
+              | 904 > | AML oceanographic CTD
+              | 905 > | Falmouth scientific CTD
+              | 906 > | Ocean sensors CTD
+              | 907 > | Valeport CTD
+              | 908 > | Ocean science MVP
+              | 909 > | Idronaut CTD
+              | 910 > | Seabird SBE38
+              | 995 > | Instrument attached to marine mammals
+              | 996   | Instrument attached to animals other than marine mammals
+
+  0-22-068 | WTEMPR ; CODE
+              | 1 > | Sippican Strip Chart Recorder
+              | 2 > | Sippican MK2A/SSQ-61
+              | 3 > | Sippican MK-9
+              | 4 > | Sippican AN/BHQ-7/MK8
+              | 5 > | Sippican MK-12
+              | 6 > | Sippican MK-21
+              | 7 > | Sippican MK-8 Linear Recorder
+              | 8 > | Sippican MK-10
+              | 10 > | Sparton SOC BT/SV Processor Model 100
+              | 11 > | Lockheed-Sanders Model OL5005
+              | 20 > | ARGOS XBT-ST
+              | 21 > | CLS-ARGOS/Protecno XBT-ST Model-1
+              | 22 > | CLS-ARGOS/Protecno XBT-ST Model-2
+              | 30 > | BATHY Systems SA-810
+              | 31 > | Scripps Metrobyte Controller
+              | 32 > | Murayama Denki Z-60-16 III
+              | 33 > | Murayama Denki Z-60-16 II
+              | 34 > | Protecno ETSM2
+              | 35 > | Nautilus Marine Service NMS-XBT
+              | 40 > | TSK MK-2A
+              | 41 > | TSK MK-2S
+              | 42 > | TSK MK-30
+              | 43 > | TSK MK-30N
+              | 45 > | TSK MK-100
+              | 46 > | TSK MK-130 Compatible recorder for both XBT and XCTD
+              | 47 > | TSK MK-130 AXCTD recorder
+              | 48 > | TSK AXBT RECEIVER MK-300
+              | 49 > | TSK MK-150/MK-150N Compatible recorder for both XBT and XCTD
+              | 50 > | JMA ASTOS
+              | 60 > | ARGOS communications, sampling on up transit
+              | 61 > | ARGOS communications, sampling on down transit
+              | 62 > | Orbcomm communications, sampling on up transit
+              | 63 > | Orbcomm communications, sampling on down transit
+              | 64 > | Iridium communications, sampling on up transit
+              | 65 > | Iridium communications, sampling on down transit
+              | 70 > | CSIRO Devil-1 XBT acquisition system
+              | 71 > | CSIRO Devil-2 XBT acquisition system
+              | 72 > | TURO/CSIRO Quoll XBT acquisition system
+              | 80 > | Applied Microsystems Ltd., MICRO-SVT&P
+              | 81 > | Sea Mammal Research Unit, Univ. St. Andrews, UK, uncorrected salinity from a sea mammal mounted instrument
+              | 82 > | Sea Mammal Research Unit, Univ. St. Andrews, UK, corrected salinity from a sea mammal mounted instrument
+              | 99   | Unknown
+
+  0-22-120 | AWCK ; CODE
+              | 0 > | Good data
+              | 1 > | Maximum (high) water level limit exceeded
+              | 2 > | Minimum (low) water level limit exceeded
+              | 3 > | Rate of change limit for water level exceeded
+              | 4 > | Flat limit for water level exceeded
+              | 5 > | Observed minus predicted water level value limit exceeded
+              | 6 > | Observed value from primary water level sensor minus backup water level sensor
+              | 7 > | Value exceeded specified tolerance from expected value
+              | 8 > | Water level QA parameter (sigmas and/or outliers) limits exceeded
+              | 9 > | Sea temperature outside of expected range
+              | 10 > | Multiple QC checks (above) failed
+              | 11   | No automated water level checks performed
+
+  0-22-121 | MWCK ; CODE
+              | 0 > | Operational
+              | 1 > | Possible clogging problem or otherwise degraded water level data
+              | 2 > | Possible datum shift
+              | 3 > | Unknown status of water level sensor
+              | 4 > | Suspected or known sea temperature sensor problem
+              | 5 > | Multiple possible problems (above)
+              | 6 > | Bad data   DO NOT DISSEMINATE!
+              | 7   | No manual water level checks performed
+
+  0-22-122 | AMCK ; CODE
+              | 0 > | Good data from all sensors
+              | 1 > | Wind direction outside of allowable range
+              | 2 > | Wind speed outside of expected range
+              | 3 > | Barometric pressure outside of expected range
+              | 4 > | Air temperature outside of expected range
+              | 5 > | Multiple sensors failed QC checks
+              | 6   | No automated meteorological data checks performed
+
+  0-22-123 | MMCK ; CODE
+              | 0 > | Operational
+              | 1 > | Suspected or known problem with wind sensor
+              | 2 > | Suspected or known problem with barometric pressure sensor
+              | 3 > | Suspected or known problem with air temperature sensor
+              | 4 > | Unknown status of all sensors
+              | 5 > | Suspected or known problems with multiple sensors
+              | 6 > | Bad data   DO NOT DISSEMINATE!
+              | 7   | No manual meteorological data checks performed
+
+  0-22-178 | XXLT ; CODE
+              | 0 > | Unknown
+              | 1 > | LM-2A Deck-mounted
+              | 2 > | LM-3A Hand-held
+              | 3 > | LM-4A Thru-hull
+              | 10 > | AL-12 TSK Autolauncher (up to 12 probes)
+              | 20 > | SIO XBT Autolauncher (up to 6 probes)
+              | 30 > | AOML XBT V6 Autolauncher (up to 6 Deep Blue probes)
+              | 31 > | AOML XBT V8.0 Autolauncher (up to 8 Deep Blue probes)
+              | 32 > | AOML XBT V8.1 Autolauncher (up to 8 Deep Blue and Fast Deep probes)
+              | 90 > | CSIRO Devil Autolauncher
+              | 100   | MFSTEP Autolauncher (Mediterranean)
+
+  0-23-001 | AENA ; CODE
+              | 1 > | Articles 1 and 2
+              | 2 > | Article 3
+              | 3   | Article 5.2
+
+  0-23-002 | AFII ; CODE
+              | 1 > | Nuclear reactor on ground
+              | 2 > | Nuclear reactor at sea
+              | 3 > | Nuclear reactor In space
+              | 4 > | Nuclear fuel facility
+              | 5 > | Radioactive waste management facility
+              | 6 > | Transport of nuclear fuel or radioactive waste
+              | 7 > | Storage of nuclear fuel or radioactive waste
+              | 8 > | Manufacture of radio isotopes
+              | 9 > | Use of radio isotopes
+              | 10 > | Storage of radio isotopes
+              | 11 > | Disposal of radio isotopes
+              | 12 > | Transport of radio isotopes
+              | 13   | Use of radio isotopes for power generation
+
+  0-23-003 | TPRE ; CODE
+              | 0 > | No release
+              | 1 > | Release to atmosphere
+              | 2 > | Release to water
+              | 3 > | Release to both atmosphere and water
+              | 4 > | Expected release to atmosphere
+              | 5 > | Expected release to water
+              | 6   | Expected release to both atmosphere and water
+
+  0-23-004 | CTNB ; CODE
+              | 0 > | No countermeasures
+              | 1 > | Evacuation
+              | 2 > | Sheltering
+              | 3 > | Prophylaxis
+              | 4   | Water
+
+  0-23-005 | COIN ; CODE
+              | 0 > | Incident state does not understand what happened
+              | 1   | Incident state knows the cause of the incident
+
+  0-23-006 | INSI ; CODE
+              | 0 > | No improvement
+              | 1 > | Unstable
+              | 2 > | No deterioration
+              | 3 > | Improving
+              | 4 > | Stable
+              | 5   | Deteriorating
+
+  0-23-007 | CHOR ; CODE
+              | 0 > | No release
+              | 1 > | Release has stopped
+              | 2 > | Release
+              | 3   | Release is continuing
+
+  0-23-008 | SOCR ; CODE
+              | 0 > | Gaseous
+              | 1 > | Particulate
+              | 2   | Mixture of gaseous and particulate
+
+  0-23-009 | SOER ; CODE
+              | 0 > | Gaseous
+              | 1 > | Particulate
+              | 2   | Mixture of gaseous and particulate
+
+  0-23-016 | PCTE ; CODE
+              | 0 > | No significant chemical toxic health effect
+              | 1   | Significant chemical toxic health effect possible
+
+  0-23-018 | RBOT ; CODE
+              | 0 > | Release no longer occurring
+              | 1 > | Release still occurring
+              | 2 > | Release expected to increase in next 6 hours
+              | 3 > | Release expected to remain constant in next 6 hours
+              | 4   | Release expected to decrease in next 6 hours
+
+  0-23-031 | PEPS ; CODE
+              | 0 > | Plume will not encounter rain in incident State
+              | 1   | Plume will encounter rain in incident State
+
+  0-23-032 | PECW ; CODE
+              | 0 > | No significant change expected within the next 6 hours
+              | 1   | Anticipated significant change expected within the next 6 hours
+
+  0-24-003 | CORE ; CODE
+              | 0 > | Noble gases
+              | 1 > | Iodides
+              | 2 > | Caesiums
+              | 3   | Transuranics
+
+  0-25-004 | ECHP ; CODE
+              | 0 > | Incoherent
+              | 1   | Coherent (Doppler)
+
+  0-25-005 | ECHI ; CODE
+              | 0 > | Logarithm   2.5dB
+              | 1 > | Linear
+              | 2   | Special
+
+  0-25-006 | Z2RC ; CODE
+              | 0 > | ZH to R conversion
+              | 1 > | (ZH, ZDR) to (NO, DO) to R
+              | 2 > | (Z (Fl), Z (F2)) to attenuation to R
+              | 6   | Other
+
+  0-25-009 | CALM ; FLAG
+              | 1 > | None
+              | 2 > | Calibration target or signal
+              | 3   | Against rain gauges
+
+  0-25-010 | CLTR ; CODE
+              | 0 > | None
+              | 1 > | Map
+              | 2 > | Insertion of higher elevation data and map
+              | 3 > | Analysis of the fluctuating Logarithm signal (clutter detection)
+              | 4 > | Extraction of the fluctuating part of linear signal (clutter suppression)
+              | 5 > | Clutter suppression   Doppler
+              | 6   | Multi parameter analysis
+
+  0-25-011 | GOCO ; CODE
+              | 0 > | None
+              | 1 > | Map of correction factors
+              | 2   | Interpolation (azimuth or elevation)
+
+  0-25-012 | RACO ; CODE
+              | 0 > | Hardware
+              | 1 > | Software
+              | 2   | Hardware and software
+
+  0-25-013 | BBCO ; FLAG
+              | 1   | Brightband correction
+
+  0-25-015 | RDCO ; FLAG
+              | 1   | Radome Attenuation Correction
+
+  0-25-017 | PACO ; FLAG
+              | 1   | Precipitation attenuation correction
+
+  0-25-020 | MSPE ; CODE
+              | 0 > | FFT (fast Fourier transform)
+              | 1 > | PP (pulse pair processing)
+              | 2   | VPC (vector phase change)
+
+  0-25-021 | WICE ; FLAG
+              | 1 > | Simple average
+              | 2 > | Consensus average
+              | 3 > | Median check
+              | 4 > | Vertical consistency check
+              | 5   | Other
+
+  0-25-022 | GRFL ; FLAG
+              | 1 > | Unprocessed
+              | 2 > | Land suspected
+              | 3 > | Wind speed too large
+              | 4 > | Ice detected
+              | 5 > | Rain detected (Microwave retrievals only)
+              | 6 > | Cloudy detected (Infra-red retrievals only)
+              | 7 > | Cosmetic value
+              | 8   | SST out of range
+
+  0-25-023 | GCFL ; FLAG
+              | 1 > | Default confidence value has been used
+              | 2 > | Default bias and standard deviation has been used
+              | 3 > | Sun glint suspected
+              | 4 > | Sea ice retrieval for microwave data
+              | 5 > | High wind speed retrieval
+              | 6 > | Inaccurate SST due to low SST (< 285K) (Only applies to the TMI instrument)
+              | 7 > | Relaxed rain contamination suspected
+              | 8   | Potential side lobe contamination
+
+  0-25-024 | GDQL ; CODE
+              | 0 > | Unprocessed infrared retrieval
+              | 1 > | Cloudy retrievals
+              | 2 > | Bad: Data that are probably contaminated by cloud
+              | 3 > | Suspect data
+              | 4 > | Acceptable data
+              | 5 > | Excellent data
+              | 6 > | Cool skin suspected
+              | 10 > | Unprocessed microwave retrieval
+              | 11 > | Questionable microwave retrieval that may be contaminated
+              | 12 > | Acceptable microwave retrieval
+              | 13   | High probability of diurnal variability
+
+  0-25-029 | CAMT ; FLAG
+              | 2 > | Calibration target or signal
+              | 3 > | Against raingauges
+              | 4   | Against other instruments (distrometer - attenuation)
+
+  0-25-030 | SSTU ; CODE
+              | 0 > | Running mean sea-surface temperature not used because usage criteria not met
+              | 1 > | Running mean sea-surface temperature not used because data not available
+              | 2   | Running mean sea-surface temperature used as predictor
+
+  0-25-031 | NWPT ; CODE
+              | 1 > | No thinning applied (all native model levels are included from base to top of pseudo-sounding)
+              | 2 > | Native model levels are present only if they are significant levels as per regulations B/C 25 for conventional TEMP soundings
+              | 3 > | A predefined subset of native model levels is present
+              | 4   | No native model levels are present. All profile levels are interpolated to a predefined set of pressure coordinate levels
+
+  0-25-032 | NPHL ; CODE
+              | 1 > | Data from low mode
+              | 2   | Data from high mode
+
+  0-25-033 | NPSM ; CODE
+              | 0 > | Wind Profiler operating in Submode A
+              | 1   | Wind Profiler operating in Submode B
+
+  0-25-034 | NPQC ; FLAG
+              | 1 > | Test A performed and failed
+              | 2 > | Test B performed and failed
+              | 3   | Test results inconclusive
+
+  0-25-035 | DMFP ; CODE
+              | 0 > | Not defined
+              | 1 > | Individual voltage deflection
+              | 2 > | Current based, above a threshold
+              | 3 > | Voltage based, above a threshold
+              | 4 > | Consensus of sensors, current above a threshold
+              | 5   | Consensus of sensors, voltage above a threshold
+
+  0-25-036 | ALME ; CODE
+              | 0 > | Network of several direction-finders operating on the same individual atmospherics
+              | 1 > | Network of several arrival-time stations operating on the same individual atmospherics
+              | 6   | Single station range bearing technique
+
+  0-25-040 | CO2W ; CODE
+              | 0 > | Non-specific mode
+              | 1 > | First guess data
+              | 2 > | Cloud data
+              | 3 > | Average vector data
+              | 4 > | Primary data
+              | 5 > | Guess data
+              | 6 > | Vector data
+              | 7 > | Tracer data; this image
+              | 8   | Tracer data to next image
+
+  0-25-041 | MPDR ; CODE
+              | 0 > | Direction originally reported in true degrees
+              | 1   | Direction originally reported using Code Table 0700, FM13
+
+  0-25-042 | MPSR ; CODE
+              | 0 > | Speed originally reported in metres per second
+              | 1   | Speed originally reported using Code Table 4451, FM13
+
+  0-25-045 | HIRC ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3 > | Channel 3 is present
+              | 4 > | Channel 4 is present
+              | 5 > | Channel 5 is present
+              | 6 > | Channel 6 is present
+              | 7 > | Channel 7 is present
+              | 8 > | Channel 8 is present
+              | 9 > | Channel 9 is present
+              | 10 > | Channel 10 is present
+              | 11 > | Channel 11 is present
+              | 12 > | Channel 12 is present
+              | 13 > | Channel 13 is present
+              | 14 > | Channel 14 is present
+              | 15 > | Channel 15 is present
+              | 16 > | Channel 16 is present
+              | 17 > | Channel 17 is present
+              | 18 > | Channel 18 is present
+              | 19 > | Channel 19 is present
+              | 20   | Channel 20 is present
+
+  0-25-046 | MSUC ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3 > | Channel 3 is present
+              | 4   | Channel 4 is present
+
+  0-25-047 | SSUC ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3   | Channel 3 is present
+
+  0-25-048 | AMAC ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3 > | Channel 3 is present
+              | 4 > | Channel 4 is present
+              | 5 > | Channel 5 is present
+              | 6 > | Channel 6 is present
+              | 7 > | Channel 7 is present
+              | 8 > | Channel 8 is present
+              | 9 > | Channel 9 is present
+              | 10 > | Channel 10 is present
+              | 11 > | Channel 11 is present
+              | 12 > | Channel 12 is present
+              | 13 > | Channel 13 is present
+              | 14 > | Channel 14 is present
+              | 15   | Channel 15 is present
+
+  0-25-049 | AMBC ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3 > | Channel 3 is present
+              | 4 > | Channel 4 is present
+              | 5   | Channel 5 is present
+
+  0-25-051 | AVHCST ; FLAG
+              | 1 > | Channel 1 is present
+              | 2 > | Channel 2 is present
+              | 3 > | Channel 3 is present
+              | 4 > | Channel 4 is present
+              | 5 > | Channel 5 is present
+              | 6   | Channel 6 is present
+
+  0-25-053 | OBQL ; FLAG
+              | 1 > | Good
+              | 2 > | Redundant
+              | 3 > | Questionable
+              | 4 > | Bad
+              | 5 > | Experimental
+              | 6   | Precipitating
+
+  0-25-063 | CPSI ; CODE
+              | 0 > | Not defined
+              | 1 > | Main processor
+              | 2   | Backup processor
+
+  0-25-069 | FLPC ; FLAG
+              | 1 > | Smoothed
+              | 2 > | Baseline adjusted
+              | 3 > | Normalized time interval
+              | 4 > | Outlier checked
+              | 5 > | Plausibility checked
+              | 6 > | Consistency checked
+              | 7   | Interpolated
+
+  0-25-086 | QDEP ; CODE
+              | 0 > | Depths are not corrected
+              | 1   | Depths are corrected
+
+  0-25-090 | ORSF ; CODE
+              | 0 > | Orbit computed during a manoeuvre
+              | 1 > | Adjusted mission operations orbit
+              | 2 > | Extrapolated mission operations orbit
+              | 3 > | Adjusted (preliminary/precise) orbit
+              | 4 > | (preliminary/precise) orbit is estimated during a manoeuvre period
+              | 5 > | (preliminary/precise) orbit is interpolated over a tracking data gap
+              | 6 > | (preliminary/precise) orbit is extrapolated for a duration less than 1 day
+              | 7 > | (preliminary/precise) orbit is extrapolated for a duration that ranges from 1 day to 2 days
+              | 8 > | (preliminary/precise) orbit is extrapolated for a duration larger than 2 days, or that the orbit is extrapolated just after a manoeuvre
+              | 9   | DORIS DIODE navigator orbit
+
+  0-25-093 | RACC ; FLAG
+              | 1 > | No correction
+              | 2 > | Vertical velocity correction
+              | 7   | All corrections
+
+  0-25-095 | ASFL ; FLAG
+              | 1   | Altimeter operating (set to 0 if nominal, set to 1 if backup)
+
+  0-25-096 | RSFL ; FLAG
+              | 1 > | Mode indicator (0 if Mode 2, 1 if Mode 1)
+              | 2 > | Mode 1 Calibration sequence indicator (0 if normal data taking either Mode 1 or 2, 1 if Mode 1 Calibration sequence), Bits 3 and 4 indicate active 23.8 GHz channel
+              | 3 > | Channel 2 (0 if on, 1 if off)
+              | 4   | Channel 3 (0 if on, 1 if off)
+
+  0-25-097 | EENO ; CODE
+              | 0 > | Ranges between 0 and 30 cm
+              | 1 > | Ranges between 30 and 60 cm
+              | 2 > | Ranges between 60 and 90 cm
+              | 3 > | Ranges between 90 and 120 cm
+              | 4 > | Ranges between 120 and 150 cm
+              | 5 > | Ranges between 150 and 180 cm
+              | 6 > | Ranges between 180 and 210 cm
+              | 7 > | Ranges between 210 and 240 cm
+              | 8 > | Ranges between 240 and 270 cm
+              | 9   | Ranges larger than 270 cm
+
+  0-25-098 | ADQF ; FLAG
+              | 1 > | Ku band range
+              | 2 > | C band range
+              | 3 > | Ku band significant wave height
+              | 4 > | C band significant wave height
+              | 5 > | Ku band backscatter coefficient
+              | 6 > | C band backscatter coefficient
+              | 7 > | Off nadir angle from Ku band waveform parameters
+              | 8   | Off nadir angle from platform
+
+  0-25-099 | ARQF ; FLAG
+              | 1 > | Ku band range instrumental correction
+              | 2 > | C band range instrumental correction
+              | 3 > | Ku band signficant wave height instrumental correction
+              | 4 > | C band significant wave height instrumental correction
+              | 5 > | Ku band backscatter coefficient instrumental correction
+              | 6   | C band backscatter coefficient instrumental correction
+
+  0-25-110 | IMPS ; FLAG
+              | 1 > | Raw data analysis used for raw data correction.  Correction done using default parameters
+              | 2 > | Raw data analysis used for raw data correction.  Correction done using raw data analysis results
+              | 3 > | Antenna elevation pattern correction applied
+              | 4 > | Nominal chirp replica used
+              | 5 > | Reconstructed chirp used
+              | 6   | Slant range to ground range conversion applied
+
+  0-25-112 | BSADQF ; FLAG
+              | 1 > | Band specific range
+              | 2 > | Band specific significant wave height
+              | 3 > | Band specific backscatter coefficient
+              | 4 > | Off nadir angle from band specific waveform parameters
+              | 5   | Off nadir angle from platform
+
+  0-25-113 | BSACQF ; FLAG
+              | 1 > | Band specific range instrumental correction
+              | 2 > | Band specific significant wave height instrumental correction
+              | 3   | Band specific backscatter coefficient instrumental correction
+
+  0-25-120 | RAPF ; CODE
+              | 0 > | Percentage of data set records free of processing errors during Level 2 processing is greater than the acceptable threshold
+              | 1   | Percentage of data set records free of processing errors during Level 2 processing is less than the acceptable threshold
+
+  0-25-122 | HCRF ; CODE
+              | 0 > | Hardware configuration for RF is A
+              | 1   | Hardware configuration for RF is B
+
+  0-25-123 | HCHA ; CODE
+              | 0 > | Hardware configuration for HPA is A
+              | 1   | Hardware configuration for HPA is B
+
+  0-25-124 | MRPF ; CODE
+              | 0 > | Percentage of data set records free of processing errors during Level 2 processing is greater than the acceptable threshold
+              | 1   | Percentage of data set records free of processing errors during Level 2 processing is less than the acceptable threshold
+
+  0-25-139 | PROCLVL ; CODE
+              | 0 > | L1B
+              | 1   | L2A
+
+  0-25-150 | MTIS ; CODE
+              | 1 > | The Dvorak's VIS (VISual imagery) intensity analysis
+              | 2   | The Dvorak's EIR (Enhanced InfraRed imagery) intensity analysis
+
+  0-25-174 | SMIF ; FLAG
+              | 1 > | Pixel is affected by RFI effects
+              | 2 > | Pixel is located in the hexagonal Alias direction centred on Sun alias
+              | 3 > | Pixel is close to the border delimiting the extended Alias free zone
+              | 4 > | Pixel is inside the extended Alias free zone
+              | 5 > | Pixel is inside the exclusive of Alias free zone
+              | 6 > | Pixel is located in a zone where a moon alias was reconstructed
+              | 7 > | Pixel is located in a zone where Sun reflection has been detected
+              | 8 > | Pixel is located in a zone where Sun Alias was reconstructed
+              | 9 > | Flat target transformation has been performed during image reconstruction of this pixel
+              | 10 > | Scene has been combined with an adjustment scene in opposite polarisation during image reconstruction to account for cross-polarisation leakage
+              | 11 > | Direct Moon correction has been performed during image reconstruction of this pixel
+              | 12 > | Reflected Sun correction has been performed during image reconstruction of this pixel
+              | 13   | Direct Sun correction has been performed during image reconstruction of this image
+
+  0-25-181 | L2PF ; CODE
+              | 0 > | OK
+              | 1   | Percentage of L2b records free of processing errors is less than acceptable threshold
+
+  0-25-182 | L1PF ; CODE
+              | 0 > | OK
+              | 1   | Percentage of L1b records free of processing errors is less than acceptable threshold
+
+  0-25-184 | L2PS ; CODE
+              | 0 > | OK
+              | 1   | Product has a duration shorter than the input product
+
+  0-25-187 | CONFLG ; CODE
+              | 0 > | Valid
+              | 1   | Not valid
+
+  0-25-188 | MRSLP ; CODE
+              | 0 > | Pressure adjusted to mean sea level following WMO 8 for low level (< 50 m) stations
+              | 1 > | Pressure adjusted to mean sea level following WMO 8 for stations below 750 m
+              | 2 > | Pressure adjusted to sea level following national practice
+              | 3 > | Pressure adjusted to local water level following national practice
+              | 4   | Pressure not corrected for height
+
+  0-25-190 | AEPM ; CODE
+              | 0 > | Low Resolution Mode (LRM)
+              | 1 > | Synthetic Aperture Radar (SAR)
+              | 2 > | LRM and SAR (interleaved)
+              | 4 > | Pseudo-LRM (PLRM)
+              | 5   | SAR Interferometric Mode (SARIN)
+
+  0-25-191 | ATRM ; CODE
+              | 0 > | Open loop
+              | 1 > | Closed loop
+              | 2   | Open loop fixed gain
+
+  0-26-010 | HRIN ; FLAG
+              | 1 > | 0100 included
+              | 2 > | 0200 included
+              | 3 > | 0300 included
+              | 4 > | 0400 included
+              | 5 > | 0500 included
+              | 6 > | 0600 included
+              | 7 > | 0700 included
+              | 8 > | 0800 included
+              | 9 > | 0900 included
+              | 10 > | 1000 included
+              | 11 > | 1100 included
+              | 12 > | 1200 included
+              | 13 > | 1300 included
+              | 14 > | 1400 included
+              | 15 > | 1500 included
+              | 16 > | 1600 included
+              | 17 > | 1700 included
+              | 18 > | 1800 included
+              | 19 > | 1900 included
+              | 20 > | 2000 included
+              | 21 > | 2100 included
+              | 22 > | 2200 included
+              | 23 > | 2300 included
+              | 24 > | 2400 included
+              | 25   | Unknown mixture of hours
+
+  0-29-001 | PROT ; CODE
+              | 0 > | Gnomonic projection
+              | 1 > | Polar stereographic projection
+              | 2 > | Lambert's conformal conic projection
+              | 3 > | Mercator's projection
+              | 4 > | Scanning cone (for radar, a Cartesian grid placed directly on the scanning cone defined by the azimuthal sweep of the radar)
+              | 6   | No projection
+
+  0-29-002 | COGT ; CODE
+              | 0 > | Cartesian
+              | 1 > | Polar
+              | 2   | Other
+
+  0-30-031 | PICT ; CODE
+              | 0 > | PPI
+              | 1 > | Composite
+              | 2 > | CAPPl
+              | 3 > | Vertical section
+              | 4 > | Alphanumeric data
+              | 5 > | Map of subject clutter
+              | 6 > | Map
+              | 7 > | Test picture
+              | 8 > | Comments
+              | 9 > | Map of ground occultation
+              | 10 > | Map of radar beam height
+              | 14   | Other
+
+  0-30-032 | CWOD ; FLAG
+              | 1 > | Map
+              | 2 > | Satellite IR
+              | 3 > | Satellite VIS
+              | 4 > | Satellite WV
+              | 5 > | Satellite multispectral
+              | 6 > | Synoptic observations
+              | 7 > | Forecast parameters
+              | 8 > | Lightning data
+              | 15   | Other data
+
+  0-31-021 | AFSI ; CODE
+              | 1 > | 1 bit indicator of quality (0 = good, 1 = suspect or bad)
+              | 2 > | 2 bit indicator of quality (0 = good, 1 = slightly suspect, 2 = highly suspect, 3 = bad)
+              | 5 > | 8-bit indicator of quality control (0 = Data checked and declared good, 1 = Data checked and declared suspect, 2 = Data checked and declared aggregated, 3 = Data checked and declared out of instrument range, 4 = Data checked, declared aggregated, and out of instrument range, 5 = Parameter is not measured at the station, 6 = Daily value not provided, 7 = Data unchecked)
+              | 6 > | 4-bit indicator of quality control class according to GTSPP (0 = unqualified, 1 = correct value (all checks passed), 2 = probably good but value inconsistent with statistics (differ from climatology), 3 = probably bad (spike or gradient, if other tests passed), 4 = bad or impossible value (out of scale, vertical instability or constant profile), 5 = value modified during quality control, 8 = interpolated value)
+              | 7 > | Percentage confidence
+              | 8 > | 2-bit indicator of suspected data (0 = Not suspected, 1 = Suspected, 2 = Reserved, 3 = Information not required)
+              | 9 > | 4-bit status of ancillary data (0 = Data present and good and collocated, 1 = Data available but of degraded quality and not used, 2 = No spatiotemporally collocated data available)
+              | 21   | 1 bit indicator of correction (0 = original value, 1 = substituted/corrected value)
+
+  0-31-031 | DPRI ; FLAG
+              | 1   | 0 = data present, 1 = data not present
+
+  0-33-002 | QMRK ; CODE
+              | 0 > | Data not suspect
+              | 1   | Data suspect
+
+  0-33-003 | QMRKH ; CODE
+              | 0 > | Data not suspect
+              | 1 > | Data slightly suspect
+              | 2 > | Data highly suspect
+              | 3   | Data considered unfit for use
+
+  0-33-005 | QUALI ; FLAG
+              | 1 > | No automated meteorological data checks performed
+              | 2 > | Pressure data suspect
+              | 3 > | Wind data suspect
+              | 4 > | Dry-bulb temperature data suspect
+              | 5 > | Wet-bulb temperature data suspect
+              | 6 > | Humidity data suspect
+              | 7 > | Ground temperature data suspect
+              | 8 > | Soil temperature (depth 1) data suspect
+              | 9 > | Soil temperature (depth 2) data suspect
+              | 10 > | Soil temperature (depth 3) data suspect
+              | 11 > | Soil temperature (depth 4) data suspect
+              | 12 > | Soil temperature (depth 5) data suspect
+              | 13 > | Cloud data suspect
+              | 14 > | Visibility data suspect
+              | 15 > | Present weather data suspect
+              | 16 > | Lightning data suspect
+              | 17 > | Ice deposit data suspect
+              | 18 > | Precipitation data suspect
+              | 19 > | State of ground data suspect
+              | 20 > | Snow data suspect
+              | 21 > | Water content data suspect
+              | 22 > | Evaporation/evapotranspiration data suspect
+              | 23   | Sunshine data suspect
+
+  0-33-006 | IMSI ; CODE
+              | 0 > | Self-check OK
+              | 1 > | At least one Warning active, no Alarms
+              | 2 > | At least one Alarm active
+              | 3   | Sensor failure
+
+  0-33-015 | QCCHEK ; CODE
+              | 0 > | Passed all checks
+              | 1 > | Missing-data check
+              | 2 > | Descending/reascending balloon check
+              | 3 > | Data plausibility check (above limits)
+              | 4 > | Data plausibility check (below limits)
+              | 5 > | Superadiabatic lapse rate check
+              | 6 > | Limiting angles check
+              | 7 > | Ascension rate check
+              | 8 > | Excessive change from previous flight
+              | 9 > | Balloon overhead check
+              | 10 > | Wind speed check
+              | 11 > | Wind direction check
+              | 12 > | Dependency check
+              | 13 > | Data valid but modified
+              | 14   | Data outlier check
+
+  0-33-020 | QCIND ; CODE
+              | 0 > | Good
+              | 1 > | Inconsistent
+              | 2 > | Doubtful
+              | 3 > | Wrong
+              | 4 > | Not checked
+              | 5 > | Has been changed
+              | 6   | Estimated
+
+  0-33-021 | QOFV ; CODE
+              | 0 > | Within limits
+              | 1   | Outside limits
+
+  0-33-022 | QBST ; CODE
+              | 0 > | Good (several identical reports have been received)
+              | 1   | Dubious (no identical reports have been received)
+
+  0-33-023 | QCIL ; CODE
+              | 0 > | Reliable (location was made over two satellite passes)
+              | 1 > | Latest known (no location over the corresponding pass)
+              | 2   | Dubious (location made over one pass only; a second solution is possible in 5 per cent of the cases)
+
+  0-33-024 | QCEVR ; CODE
+              | 1 > | Excellent - within 3 meters
+              | 2 > | Good - within 10 meters
+              | 3 > | Fair - within 20 meters
+              | 4 > | Poor - more than 20 meters
+              | 5 > | Excellent - within 10 feet
+              | 6 > | Good - within 30 feet
+              | 7 > | Fair - within 60 feet
+              | 8   | Poor - more than 60 feet
+
+  0-33-025 | INTV ; CODE
+              | 0 > | Time interpolated, latitude and longitude reported
+              | 1 > | Time reported, latitude and longitude interpolated
+              | 2 > | Time, latitude, and longitude interpolated
+              | 3   | Time, latitude, and longitude reported
+
+  0-33-026 | MSTQ ; CODE
+              | 0 > | Normal operations - measurement mode
+              | 1 > | Normal operations - non-measurement mode
+              | 2 > | Small RH
+              | 3 > | Humidity element is wet
+              | 4 > | Humidity element contaminated
+              | 5 > | Heater fail
+              | 6 > | Heater fail and wet/contaminated humidity element
+              | 7 > | At least one of the input parameters used in the calculation of mixing ratio is invalid
+              | 8 > | Numeric error
+              | 9 > | Sensor not installed
+              | 10 > | Calculated RH > 100%
+              | 11 > | Input laser power too low
+              | 12 > | Probe WV temperature out of range
+              | 13 > | Probe WV pressure out of range
+              | 14 > | Spectral line out of range
+              | 15   | No laser output
+
+  0-33-027 | QCLS ; CODE
+              | 0 > | Radius >= 1500 m
+              | 1 > | 500 m =< Radius <1500 m
+              | 2 > | 250 m =< Radius < 500 m
+              | 3 > | Radius < 250 m
+              | 4   | <= 100m
+
+  0-33-028 | SSOQ ; CODE
+              | 1 > | Nominal
+              | 2 > | Degraded by SW error; any error reported by the algorithms
+              | 3 > | Degraded by instrument error
+              | 4   | Degraded by corrupted /missing ADF
+
+  0-33-030 | SLSF ; FLAG
+              | 1 > | Do not use scan for product generation
+              | 2 > | Time sequence error detected with this scan
+              | 3 > | Data gap precedes this scan
+              | 4 > | No calibration
+              | 5 > | No earth location
+              | 6 > | First good time following a clock update
+              | 7   | Instrument status changed with this scan
+
+  0-33-031 | SLQF ; FLAG
+              | 1 > | Time field is bad but can probably be inferred from the previous good time
+              | 2 > | Time field is bad and can't be inferred from the previous good time
+              | 3 > | This record starts a sequence that is inconsistent with previous times (i.e. there is a time discontinuity). This may or may not be associated with a spacecraft clock update (see scan line status flags for ATOVS)
+              | 4 > | Start of a sequence that apparently repeats scan times that have been previously accepted
+              | 5 > | Scan line was not calibrated because of bad time
+              | 6 > | Scan line was calibrated using fewer than the preferred number of scan lines because of proximaty to start or end of data or to a data gap
+              | 7 > | Scan line was not calibrated because of bad or insufficient PRT data
+              | 8 > | Scan line was calibrated but with marginal PRT data
+              | 9 > | Some uncalibrated channels on this scan
+              | 10 > | Uncalibrated due to instrument mode
+              | 11 > | Questionable calibration because of antenna position error of space view
+              | 12 > | Questionable calibration because of antenna position error of black body
+              | 13 > | Not Earth-located because of bad time
+              | 14 > | Earth location questionable because of questionable time code (see time problem code bits)
+              | 15 > | Earth location questionable   only marginal agreement with reasonableness check
+              | 16 > | Earth location questionable   fails reasonableness check
+              | 17 > | Earth location questionable because of antenna position check
+              | 18 > | Scan line calibration cold black body
+              | 19 > | Scan line calibration warm black body
+              | 20 > | Scan line calibration space view
+              | 21   | Earth view
+
+  0-33-032 | ACQF ; FLAG
+              | 1 > | No good blackbody counts for scan line
+              | 2 > | No good space view counts for this line
+              | 3 > | No good PRTs for this line
+              | 4 > | Some bad blackbody view counts for this line
+              | 5 > | Some bad space view counts for this line
+              | 6 > | Some bad PRT temps on this line
+              | 7   | Quality for this scan is reduced
+
+  0-33-033 | FOVQ ; FLAG
+              | 1 > | Secondary calibration used
+              | 2 > | Brightness temperature in channel 1 is physically unreasonable or has not been calculated due to calibration problems
+              | 3 > | Brightness temperature in channel 2 is physically unreasonable or has not been calculated due to calibration problems
+              | 4 > | Brightness temperature in channel 3 is physically unreasonable or has not been calculated due to calibration problems
+              | 5 > | Brightness temperature in channel 4 is physically unreasonable or has not been calculated due to calibration problems
+              | 6 > | Brightness temperature in channel 5 is physically unreasonable or has not been calculated due to calibration problems
+              | 7 > | Brightness temperature in channel 6 is physically unreasonable or has not been calculated due to calibration problems
+              | 8 > | Brightness temperature in channel 7 is physically unreasonable or has not been calculated due to calibration problems
+              | 9 > | Brightness temperature in channel 8 is physically unreasonable or has not been calculated due to calibration problems
+              | 10 > | Brightness temperature in channel 9 is physically unreasonable or has not been calculated due to calibration problems
+              | 11 > | Brightness temperature in channel 10 is physically unreasonable or has not been calculated due to calibration problems
+              | 12 > | Brightness temperature in channel 11 is physically unreasonable or has not been calculated due to calibration problems
+              | 13 > | Brightness temperature in channel 12 is physically unreasonable or has not been calculated due to calibration problems
+              | 14 > | Brightness temperature in channel 13 is physically unreasonable or has not been calculated due to calibration problems
+              | 15 > | Brightness temperature in channel 14 is physically unreasonable or has not been calculated due to calibration problems
+              | 16 > | Brightness temperature in channel 15 is physically unreasonable or has not been calculated due to calibration problems
+              | 17 > | Brightness temperature in channel 16 is physically unreasonable or has not been calculated due to calibration problems
+              | 18 > | Brightness temperature in channel 17 is physically unreasonable or has not been calculated due to calibration problems
+              | 19 > | Brightness temperature in channel 18 is physically unreasonable or has not been calculated due to calibration problems
+              | 20 > | Brightness temperature in channel 19 is physically unreasonable or has not been calculated due to calibration problems
+              | 21 > | Brightness temperature in channel 20 is physically unreasonable or has not been calculated due to calibration problems
+              | 22 > | All channels are missing
+              | 23   | Suspect
+
+  0-33-035 | MAQC ; CODE
+              | 0 > | Automatic quality control passed and not manually checked
+              | 1 > | Automatic quality control passed and manually checked and passed
+              | 2 > | Automatic quality control passed and manually checked and deleted
+              | 3 > | Automatic quality control failed and manually not checked
+              | 4 > | Automatic quality control failed and manually checked and failed
+              | 5 > | Automatic quality control failed and manually checked and re-inserted
+              | 6 > | Automatic quality control flagged data as questionable and not manually checked
+              | 7 > | Automatic quality control flagged data as questionable and manually checked and failed
+              | 8   | Manually checked and failed
+
+  0-33-037 | WCOE ; FLAG
+              | 1 > | U departure from guess
+              | 2 > | V departure from guess
+              | 3 > | U & V departure from guess
+              | 4 > | U acceleration
+              | 5 > | V acceleration
+              | 6 > | U & V acceleration
+              | 7 > | Possible land feature
+              | 8 > | U acceleration and possible land feature
+              | 9 > | V acceleration and possible land feature
+              | 10 > | U & V acceleration and possible land feature
+              | 11 > | Bad wind guess
+              | 12 > | Correlation failure
+              | 13 > | Search box off edge of area
+              | 14 > | Target box off edge of area
+              | 15 > | Pixel brightness out of bounds (noisy line)
+              | 16 > | Target outside of lat/long box
+              | 17 > | Target outside of pressure min/max
+              | 18 > | Autoeditor flagged slow vector
+              | 19   | Autoeditor flagged vectors
+
+  0-33-038 | QFGN ; FLAG
+              | 1 > | Total Zenith Delay quality is considered poor
+              | 2 > | GALILEO satellites used
+              | 3 > | GLONASS satellites used
+              | 4 > | GPS satellites used
+              | 5 > | Meteorological data applied
+              | 6 > | Atmospheric loading correction applied
+              | 7 > | Ocean tide loading applied
+              | 8 > | Climate quality data processing
+              | 9   | Near-real time data processing
+
+  0-33-039 | QFRO ; FLAG
+              | 1 > | Non-nominal quality
+              | 2 > | Offline product
+              | 3 > | Ascending occultation flag
+              | 4 > | Excess Phase processing non-nominal
+              | 5 > | Bending Angle processing non-nominal
+              | 6 > | Refractivity processing non-nominal
+              | 7 > | Meteorological processing non-nominal
+              | 8 > | Open loop data included
+              | 9 > | Surface reflections detected
+              | 10 > | L2C GNSS signals used
+              | 14 > | Background profile non-nominal
+              | 15   | Background (i.e. not retrieved) profile present
+
+  0-33-041 | AOFV ; CODE
+              | 0 > | The following value is the true value
+              | 1 > | The following value is higher than the true value (the measurement hit the lower limit of the instrument)
+              | 2   | The following value is lower than the true value (the measurement hit the higher limit of the instrument)
+
+  0-33-042 | TLRFV ; CODE
+              | 0 > | Exclusive lower limit (>)
+              | 1 > | Inclusive lower limit (>=)
+              | 2 > | Exclusive upper limit (<)
+              | 3   | Inclusive upper limit (=<)
+
+  0-33-043 | ASTC ; FLAG
+              | 1 > | Sea MDS.  Nadir only SST retrieval used 3.7 Micron channel.  Land MDS reserved
+              | 2 > | Sea MDS.  Dual view SST retrieval used 3.7 Micron channel.  Land MDS reserved.
+              | 3 > | Nadir view contains day time data
+              | 4   | Forward view contains day time data
+
+  0-33-044 | ASARQI ; FLAG
+              | 1 > | Input data mean outside nominal range flag
+              | 2 > | Input data standard deviation outside nominal range flag
+              | 3 > | Number of input data gaps > threshold value
+              | 4 > | Percentage of missing lines > threshold value
+              | 5 > | Doppler centroid uncertain.  Confidence measure < specific value
+              | 6 > | Doppler ambiguity estimate uncertain.  Confidence measure < specific value
+              | 7 > | Output data mean outside nominal range flag
+              | 8 > | Output data standard deviation outside nominal range flag
+              | 9 > | Chirp reconstruction failed or is of low quality flag
+              | 10 > | Data set missing
+              | 11 > | Invalid downlink parameters
+              | 12 > | Azimuth cut-off iteration count.  The azimuth cut-off fit did not converge within a minimum number of iterations
+              | 13 > | Azimuth cut-off fit did not converge within a minimum number of iterations
+              | 14   | Phase information confidence measure.  The imaginary spectral peak is less than a minimum threshold, or the zero lag shift is greater than a minimum threshold
+
+  0-33-047 | MCOD ; FLAG
+              | 1 > | Error detected and attempts to recover made
+              | 2 > | Anomaly in on-board data handling  (OBDH) value detected
+              | 3 > | Anomaly in Ultra Stable Oscillator Processing (USOP) value detected
+              | 4 > | Errors detected by on-board computer
+              | 5 > | Automatic gain control (AGC) out of range
+              | 6 > | Rx delay fault.  Rx distance out of range
+              | 7 > | Wave form samples fault identifier. Error
+              | 8 > | S-band anomaly error detected
+              | 12 > | Brightness temperature (channel 1) out of range
+              | 13 > | Brightness temperature (channel 2) out of range
+              | 15 > | Ku Ocean retracking error
+              | 16 > | S Ocean retracking error
+              | 17 > | Ku Ice 1 retracking error
+              | 18 > | S Ice 1 retracking error
+              | 19 > | Ku Ice 2 retracking error
+              | 20 > | S Ice 2 retracking error
+              | 21 > | Ku Sea Ice retracking error
+              | 22 > | Arithmetic fault error
+              | 23 > | Meteo data state. No map
+              | 24 > | Meteo data state. 1 map
+              | 25 > | Meteo data state 2 maps degraded
+              | 26 > | Meteo data state 2 maps nominal
+              | 27 > | Orbit propagator status for propagation mode, several errors
+              | 28 > | Orbit propagator status for propagation mode, warning detected
+              | 29 > | Orbit propagator status for initialisation mode, several errors
+              | 30   | Orbit propagator status for initialisation mode, warning detected
+
+  0-33-048 | CMSI ; CODE
+              | 0 > | Inversion successful
+              | 1   | Inversion not successful
+
+  0-33-049 | CMWR ; CODE
+              | 0 > | External wind direction used during inversion
+              | 1   | External wind direction not used during inversion
+
+  0-33-050 | GGQF ; CODE
+              | 0 > | Unqualified
+              | 1 > | Correct value (all checks passed)
+              | 2 > | Probably good but value inconsistent with statistics (differ from climatology)
+              | 3 > | Probably bad (spike, gradient, ... if other tests passed)
+              | 4 > | Bad value, Impossible value (out of scale, vertical instability, constant profile)
+              | 5 > | Value modified during quality control
+              | 8 > | Interpolated value
+              | 9   | Good for operational use; Caution; check literature for other uses
+
+  0-33-052 | SORQ ; FLAG
+              | 1 > | Value in data block 1 is invalid
+              | 2 > | Value in data block 2 is invalid
+              | 3 > | Value in data block 3 is invalid
+              | 4 > | Value in data block 4 is invalid
+              | 5 > | Value in data block 5 is invalid
+              | 6 > | Value in data block 6 is invalid
+              | 7 > | Value in data block 7 is invalid
+              | 8 > | Value in data block 8 is invalid
+              | 9 > | Value in data block 9 is invalid
+              | 10 > | Value in data block 10 is invalid
+              | 11 > | Value in data block 11 is invalid
+              | 12 > | Value in data block 12 is invalid
+              | 13 > | Value in data block 13 is invalid
+              | 14 > | Value in data block 14 is invalid
+              | 15 > | Value in data block 15 is invalid
+              | 16 > | Value in data block 16 is invalid
+              | 17 > | Value in data block 17 is invalid
+              | 18 > | Value in data block 18 is invalid
+              | 19 > | Value in data block 19 is invalid
+              | 20   | Value in data block 20 is invalid
+
+  0-33-053 | KORQ ; FLAG
+              | 1 > | Value in data block 1 is invalid
+              | 2 > | Value in data block 2 is invalid
+              | 3 > | Value in data block 3 is invalid
+              | 4 > | Value in data block 4 is invalid
+              | 5 > | Value in data block 5 is invalid
+              | 6 > | Value in data block 6 is invalid
+              | 7 > | Value in data block 7 is invalid
+              | 8 > | Value in data block 8 is invalid
+              | 9 > | Value in data block 9 is invalid
+              | 10 > | Value in data block 10 is invalid
+              | 11 > | Value in data block 11 is invalid
+              | 12 > | Value in data block 12 is invalid
+              | 13 > | Value in data block 13 is invalid
+              | 14 > | Value in data block 14 is invalid
+              | 15 > | Value in data block 15 is invalid
+              | 16 > | Value in data block 16 is invalid
+              | 17 > | Value in data block 17 is invalid
+              | 18 > | Value in data block 18 is invalid
+              | 19 > | Value in data block 19 is invalid
+              | 20   | Value in data block 20 is invalid
+
+  0-33-055 | WVQF ; FLAG
+              | 11 > | Ocean sigma-0 is not available for wind retrievals
+              | 12 > | Background wind is not available
+              | 13 > | Background model detect land
+              | 14 > | Background model detect ice
+              | 15 > | Sigma-0 is not land/ice free
+              | 16 > | Sigma-0 land contamination
+              | 17 > | Sigma-0 ice contamination
+              | 18 > | Not enough azimuthal diversity
+              | 19 > | Inversion is not done
+              | 20 > | Overall WVC flag
+              | 21 > | Inversion is attempted (flag is set)
+              | 22 > | Rain flag is attempted (flag is set)
+              | 23   | Rain is detected
+
+  0-33-056 | SZQF ; FLAG
+              | 8 > | Ascending
+              | 9 > | VV polarisation
+              | 10 > | Fore of spacecraft
+              | 11 > | Land
+              | 12 > | Poor sigma-0 (summary)
+              | 13 > | Invalid sigma-0 (summary)
+              | 14 > | Poor BT
+              | 15 > | Invalid BT
+              | 16 > | Land-sea boundary
+              | 17 > | Negative sigma-0
+              | 21 > | Ice
+              | 22 > | Missing data at a given latitude-longitude for sea-ice flagging process for 2 or more days
+              | 23   | Ice-ocean contamination
+
+  0-33-060 | QGFQ ; CODE
+              | 0 > | Good
+              | 1   | Bad
+
+  0-33-066 | AMVQ ; FLAG
+              | 20 > | Good wind, but an alternative channel used for feature tracking
+              | 21 > | Good wind, but an alternative set of channels used for the determination of cloud-top height/AMV height assignment
+              | 22   | Correlation surface constraint fails
+
+  0-33-070 | SBUVTOQ ; CODE
+              | 0 > | Good retrieval
+              | 1 > | Bad aerosol information flag or NOAA-16 radiance anomaly
+              | 2 > | Solar zenith angle greater than 84 degrees
+              | 3 > | 380nm residue greater than limit
+              | 4 > | Ozone inconsistency
+              | 5 > | Difference between profile ozone and step 3 total ozone exceeds threshold (set to 25 DU)
+              | 6 > | Step 1 ozone iteration did not converge
+              | 7 > | Any channel residue greater than 16 or bad radiance
+              | 8 > | Insufficient pixels - not processed
+              | 9 > | First guess good - ozone forecast data used
+              | 10 > | High cloud in pixel - not processed
+              | 11 > | Successful ozone retrieval
+              | 12   | Unsuccessful ozone retrieval
+
+  0-33-071 | SBUVPOQ ; CODE
+              | 0 > | Good retrieval
+              | 1 > | Solar zenith angle greater than 84 degrees
+              | 2 > | Difference between step 3 and profile total ozone greater than limit (25DU)
+              | 3 > | Average final residue for wavelengths used in retrieval greater than threshold
+              | 4 > | Final residue greater than 3 times a priori error
+              | 5 > | Difference between retrieved and a priori greater than 3 times a priori error
+              | 6 > | Non-convergent solution
+              | 7 > | Upper level profile anomaly or stray light anomaly
+              | 8   | Initial residue greater than 18.0 N-value units
+
+  0-33-072 | GOMEEF ; CODE
+              | 0 > | Good retrieval
+              | 1 > | Reflectivity out of range
+              | 2 > | Larger Pixels (Number of cross-track pixels less than 32) or backward scans error
+              | 3 > | Solar zenith angle greater than 88
+              | 4 > | Latitude/longitude out of range
+              | 5 > | Viewing zenith angle or solar zenith angle out of range
+              | 6 > | Step-one process failed in general
+              | 7 > | First guess ozone out of range
+              | 8 > | Too many iterations (exceed 8)
+              | 9 > | Step-one residue calculation failed
+              | 10 > | Step-two process failed in general
+              | 11 > | First guess ozone profile out of range
+              | 12 > | Step-two ozone value out of range
+              | 13 > | Step-two residue calculation failed
+              | 14 > | Step-three process failed in general
+              | 15 > | Polarization Correction Accuracy Alert
+              | 16   | Radiance or irradiance less or equal to zero
+
+  0-33-075 | NSQF ; FLAG
+              | 1 > | Gap in Raw Data Record (RDR) data detected (i.e., missing scan(s) preceding the current scan)
+              | 2 > | Recorded time is not in sequence (i.e., the scan start time is out of sequence)
+              | 3 > | Lamda monitored calculation cannot be updated
+              | 4 > | The measured temperatures of any instrument components (e.g., beam-splitter, scan mirror, scan baffle, etc.) are outside the allowable ranges
+              | 5   | At least one of the monitored instrument temperatures has drifted more than a specified tolerance value
+
+  0-33-076 | NCQF ; FLAG
+              | 1 > | Lunar intrusion on first deep space view
+              | 2   | Lunar intrusion on second deep space view
+
+  0-33-077 | NFQF ; FLAG
+              | 1 > | Degraded sensor data record quality
+              | 2 > | Invalid sensor data record quality
+              | 3 > | Invalid sensor data record geolocation information
+              | 4 > | Degraded radiometric calibration
+              | 5 > | Invalid radiometric calibration
+              | 6 > | Degraded spectral calibration
+              | 7 > | Invalid spectral calibration
+              | 8 > | Fringe count error detected and corrected
+              | 9 > | Day/night indicator
+              | 10 > | Invalid raw data record data
+              | 11 > | Significant fringe count error detected
+              | 12   | Bit trim failed
+
+  0-33-078 | NGQI ; CODE
+              | 0 > | Nominal - altitude and Ephemeris data available
+              | 1 > | Missing at most a small gap of altitude and Ephemeris data
+              | 2 > | Missing more than a small gap of altitude and Ephemeris data, but no more than a granule boundary
+              | 3   | Missing more than a granule boundary of altitude and Ephemeris data
+
+  0-33-079 | ATMSGQ ; FLAG
+              | 6 > | The #1-#7 health checks failed
+              | 7 > | The #8-#15 health checks failed
+              | 8 > | The #16-#23 health checks failed
+              | 9 > | The #24-#31 health checks failed
+              | 10 > | The #32-#39 health checks failed
+              | 11 > | The #40-#47 health checks failed
+              | 12 > | The #48-#55 health checks failed
+              | 13 > | The #56-#63 health checks failed
+              | 14 > | The #64-#70 health checks failed
+              | 15   | Quadratic correction applied to the radiometric transfer function for non-linearity correction
+
+  0-33-080 | ATMSSQ ; FLAG
+              | 7 > | Divide-by-zero condition or computation loop failed to converge in the K/Ka and V (KAV) band platinum resistance temperature
+              | 8 > | Divide-by-zero condition or computation loop failed to converge in the WG band platinum resistance temperature
+              | 9 > | Divide-by-zero condition or computation loop failed to converge in the K/Ka, V, W, G band receiver shelf platinum resistance temperature K temperature computation
+              | 10 > | Out of range condition for the K/Ka and V band platinum resistance temperature
+              | 11 > | Out of range condition for the WG band platinum resistance temperature
+              | 12 > | KAV platinum resistance temperature inconsistency
+              | 13 > | WG platinum resistance temperature inconsistency
+              | 14 > | Time sequence error
+              | 15 > | Data gap - missing scan(s) preceding the current scan
+              | 16 > | KAV platinum resistance temperature sufficiency - insufficient KAV platinum resistance temperature data are available
+              | 17 > | WG platinum resistance temperature sufficiency - insufficient WG platinum resistance temperature data are available
+              | 18 > | Space view antenna position error
+              | 19   | Blackbody antenna position error
+
+  0-33-081 | ATMSCHQ ; FLAG
+              | 3 > | Moon in space view
+              | 4 > | Gain error - the lowest blackbody count is smaller than or equal to the highest space view count in a scan
+              | 5 > | Calibration with fewer than preferred samples
+              | 6 > | Space view data sufficiency check - insufficient space view samples are available
+              | 7 > | Blackbody view data sufficiency check - insufficient blackbody view samples are available
+              | 8 > | Out of range condition for the space view
+              | 9 > | Out of range condition for the blackbody view
+              | 10 > | Space view inconsistency
+              | 11   | Blackbody view inconsistency
+
+  0-33-082 | VIIRGQ ; FLAG
+              | 6 > | Within South Atlantic anomaly
+              | 7 > | Invalid input data (indicates that any of the spacecraft ephemeris or attitude data is invalid)
+              | 8 > | Bad pointing (indicates that the sensor LOS does not intersect the geoid, is near the limb, has invalid sensor angles or other similar condition)
+              | 9 > | Bad terrain (indicates that the algorithm could not obtain a valid terrain value)
+              | 10 > | Invalid solar angles
+              | 11 > | Missing at most a small gap of altitude and ephemeris data
+              | 12 > | Missing more than a small gap of altitude and ephemeris data, but no more than a granule boundary
+              | 13 > | Missing more than a granule boundary of altitude and ephemeris data
+              | 14 > | The number of encoder pulse values per delta time is not as expected
+              | 15   | Solar eclipse during Earth view scan
+
+  0-33-083 | VIIRSQ ; FLAG
+              | 6 > | Pixel is affected by radio frequency interference
+              | 7 > | Poor calibration quality due to bad space view offsets, on-board calibration view offsets, etc. or use of a previous calibration view
+              | 8 > | Saturated pixel
+              | 9 > | Missing data - data required for calibration processing is not available for processing
+              | 10 > | Calibrated pixel radiance out of range
+              | 11 > | Calibrated pixel reflectance or EBBT out of range
+              | 12 > | The moon has corrupted the space view
+              | 13 > | Scan data is not present (no valid data)
+              | 14 > | Quality for this scan-line is reduced.  The value is determined by the combined number of steps required to find a replacement for thermistor or calibration source data.
+              | 15   | Bad detector
+
+  0-33-084 | SSTPQ ; FLAG
+              | 6 > | Bulk SST outside of validation range
+              | 7 > | Skin SST outside of validation range
+              | 8 > | Sensor zenith angle > 40 degrees (pixel is not within 40 degrees of nadir and therefore is not of high quality)
+              | 9 > | Degradation - Horizontal Cell Size (HCS) > 1.3 km, swath width > 1700 km, sensor zenith angle > 50.3 degrees
+              | 10 > | Exclusion - no ocean in pixel
+              | 11 > | Degradation - Aerosol Optical Thickness (AOT) > 0.6 (AOT in horizontal cell > 0.6 on the slant path (AOT @ 550 nm))
+              | 12 > | Exclusion - Aerosol Optical Thickness (AOT) > 1.0 (AOT in horizontal cell > 1.0 on the slant path (AOT @ 550 nm))
+              | 13 > | Sun glint present in pixel
+              | 14 > | Ice concentration threshold exceeded (SST not retrieved due to ice concentration exceeding threshold in system spec)
+              | 15   | Thin cirrus detected in pixel
+
+  0-33-085 | AOTQ ; FLAG
+              | 4 > | Angstrom exponent is outside of the system specification range
+              | 5 > | Excluded, Angstrom exponent for AOT at 550 nm < 0.15
+              | 6 > | Bright surface in cell (if over land), or shallow or turbid water in cell (if over ocean)
+              | 7 > | Low sun, excluded, Solar Zenith Angle > 80 degrees
+              | 8 > | Low sun, degraded, 65 degrees < Solar Zenith Angle <= 80 degrees
+              | 9 > | Fire detected in cell
+              | 10 > | Snow/Ice in cell
+              | 11 > | Cloud shadow in cell
+              | 12 > | Sun glint in cell
+              | 13 > | Bad SDR data present in horizontal cell (quality of AOT/APSP degraded or AOT/APSP not retrieved due to bad SDR data in horizontal cell)
+              | 14 > | Cirrus contamination in cell
+              | 15 > | Cloud adjacent to cell
+              | 16 > | Cloud contamination in cell
+              | 17   | AOT is outside of the system specification range
+
+  0-33-086 | RETRQ ; CODE
+              | 0 > | Not retrieved
+              | 1 > | Excluded
+              | 2 > | Degraded
+              | 3   | High quality
+
+  0-33-087 | XSAA ; CODE
+              | 0 > | Less than or equal to 10%
+              | 1 > | Greater than 10% but less than or equal to 20%
+              | 2 > | Greater than 20% but less than or equal to 30%
+              | 3 > | Greater than 30% but less than or equal to 40%
+              | 4 > | Greater than 40% but less than or equal to 50%
+              | 5 > | Greater than 50% but less than or equal to 60%
+              | 6 > | Greater than 60% but less than or equal to 70%
+              | 7 > | Greater than 70% but less than or equal to 80%
+              | 8   | Greater than 80%
+
+  0-33-088 | OTCQ ; FLAG
+              | 6 > | Surface reflectivity out of range
+              | 7 > | Residual too large
+              | 8 > | Aerosol index limit exceeded
+              | 9 > | Solar eclipse present (All or part of the instantaneous field-of-view is affected by a solar eclipse, umbra or penumbra viewing)
+              | 10 > | Sun glint present within instantaneous field-of-view
+              | 11 > | Snow or ice surface is within the instantaneous field-of-view
+              | 12 > | Solar zenith angle in excluded (night) condition (solar zenith angle >= 88 degrees)
+              | 13 > | Solar zenith angle in degraded condition (80 degrees <= solar zenith angle < 88 degrees)
+              | 14 > | SO2 index > 6 DU (degraded condition)
+              | 15 > | Residues are not consistent (indicates whether the residues from the 22 wavelengths
+              | 16 > | Ozone triplet selection is not consistent within retrieval (ozone triplet consistency)
+              | 17   | Input data quality is not good
+
+  0-33-092 | BSOQ ; FLAG
+              | 1 > | Altimeter operating
+              | 2   | MicroWave Radiometer (MWR) operating
+
+  0-33-093 | QFGNX ; FLAG
+              | 1 > | Path delay quality is considered poor
+              | 2 > | GALILEO satellites used
+              | 3 > | GLONASS satellites used
+              | 4 > | GPS satellites used
+              | 5 > | BeiDou satellites used
+              | 9 > | Meteorological data applied
+              | 10 > | Atmospheric loading correction applied
+              | 11 > | Ocean tide loading applied
+              | 12 > | Second order ionosphere corrections applied
+              | 13 > | Third order ionosphere corrections applied
+              | 14 > | PPP solution
+              | 15 > | Gradients applied to path delay
+              | 16 > | Multipath corrections applied to path delay
+              | 17 > | Residual applied to path delay
+              | 18 > | Climate quality data processing
+              | 19 > | Re-processing
+              | 20 > | Post-processing
+              | 21 > | Near-real time data processing
+              | 22   | Real time data processing
+
+  0-33-094 | NCQCF ; FLAG
+              | 16 > | Non-ocean
+              | 17 > | Lunar or solar intrusion
+              | 18 > | Spacecraft maneuver
+              | 19 > | Cold calibration consistency
+              | 20 > | Warm calibration consistency
+              | 21 > | Descending
+              | 22 > | Night
+              | 23   | Payload rear orientation
+
+  0-35-001 | TFFM ; CODE
+              | 0 > | Real time
+              | 1 > | Near-real time
+              | 2   | Non-real time
+
+  0-35-030 | DAED ; CODE
+              | 0 > | No discrepancies
+              | 1 > | Non-compliance with standard and recommended practices and procedures including those of monitoring
+              | 2 > | Catalogues of meteorological bulletins not updated in a timely manner
+              | 3 > | Incorrect routeing directories
+              | 4 > | Lack of flexibility in the routeing arrangements
+              | 5 > | Deficiencies in the operation of GTS centres and circuits
+              | 6 > | Loss of data or delays in relaying data on the GTS
+              | 7 > | Routeing of data different from the routeing provided in the plan
+              | 8   | Various malpractices
+
+  0-35-031 | QOMR ; CODE
+              | 1 > | Sufficient and all of acceptable quality
+              | 2 > | Sufficient but partly of acceptable quality
+              | 3 > | Insufficient but all of acceptable quality
+              | 4 > | Insufficient and of unacceptable quality
+              | 5 > | Some messages not complete
+              | 6 > | Suspect or wrongly coded groups could not be interpreted confidently
+              | 7 > | Gross coding errors
+              | 8 > | Transmission sequential order not observed
+              | 9 > | Report completely garbled and thus discarded
+              | 10 > | Deficiencies identified and rectified
+              | 11 > | Deficiencies identified but not rectified
+              | 12 > | Deficiencies not identified
+              | 13 > | Measuring errors
+              | 14 > | Mutual inconsistency
+              | 15 > | Temporal inconsistency
+              | 16 > | Forecast error
+              | 17 > | Bias
+              | 18 > | Improve system of quality control
+              | 19   | Expand training programmes
+
+  0-35-032 | COMD ; CODE
+              | 1 > | Data groups missing due to radio fading
+              | 2 > | Data groups missing due to outage of centre
+              | 3 > | Data groups missing due to outage of circuit
+              | 4 > | Non-implementation or maintenance of required RBSN density
+              | 5 > | Shortage of qualified staff to man stations
+              | 6 > | Lack of consumables
+              | 7 > | Instrument failure
+              | 8 > | Non-adherence to telecommunication procedures
+              | 9   | Some observing programmes ceased
+
+  0-35-033 | OACD ; CODE
+              | 1 > | No deficiency
+              | 2 > | Observations not made regularly
+              | 3 > | Observations not made at right time
+              | 4 > | Observations made but not disseminated
+              | 5 > | Observations made and sent to incorrect users
+              | 6 > | Collection not received
+              | 7 > | Collection transmitted late
+              | 8 > | Collection not transmitted
+              | 9 > | Difficulties in HF propagation and selection of suitable frequency
+              | 10 > | Difficulties in maintenance of communication equipment at remote stations
+              | 11   | No alternative arrangement for routeing meteorological observation
+
+  0-35-034 | STAD ; CODE
+              | 1 > | Slight improvement
+              | 2 > | Significant improvement
+              | 3 > | Most significant improvement
+              | 4 > | Steady
+              | 5 > | Decreasing
+              | 6   | Efforts required to improve night-time observations
+
+  0-35-035 | RTERM ; CODE
+              | 1 > | Balloon burst
+              | 2 > | Balloon forced down by icing
+              | 3 > | Leaking or floating balloon
+              | 4 > | Weak or fading signal
+              | 5 > | Battery failure
+              | 6 > | Ground equipment failure
+              | 7 > | Signal interference
+              | 8 > | Radiosonde failure
+              | 9 > | Excessive missing data frames
+              | 11 > | Excessive missing temperature
+              | 12 > | Excessive missing pressure
+              | 13 > | User terminated
+              | 14 > | Sudden loss of signal
+              | 15 > | Tracking lost
+              | 16 > | Increasing pressure
+              | 17 > | Invalid and/or missed data time limits exceeded
+              | 30   | Other
+
+  0-40-005 | SMCF ; FLAG
+              | 1 > | Soil moisture between -20% and 0%
+              | 2 > | Soil moisture between 100% and 120%
+              | 3 > | Correction of wet backscatter reference
+              | 4 > | Correction of dry backscatter reference
+              | 5   | Correction of volume scattering in sand
+
+  0-40-006 | SMPF ; FLAG
+              | 1 > | Not soil
+              | 2 > | Sensitivity to soil moisture below limit
+              | 3 > | Azimuthal noise above limit
+              | 4 > | Backscatter Fore-Aft beam out of range
+              | 5 > | Slope Mid-Fore beam out of range
+              | 6 > | Slope Mid-Aft beam out of range
+              | 7 > | Soil moisture below -20%
+              | 8   | Soil moisture above 120%
+
+  0-40-011 | INTF ; FLAG
+              | 1 > | Mean sea surface (MSS) interpolation flag
+              | 2 > | Ocean tide solution 1 interpolation flag (0=4 points over ocean, 1=less than 4 points)
+              | 3 > | Ocean tide solution 2 interpolation flag (0=4 points over ocean, 1=less than 4 points)
+              | 4   | Meteorological data interpolation flag (0=4 points over ocean, 1=less than 4 points)
+
+  0-40-012 | RDQF ; FLAG
+              | 1 > | 18.7 GHz brightness temperature is bad
+              | 2 > | 23.8 GHz brightness temperature is bad
+              | 3   | 34 GHz brightness temperature is bad
+
+  0-40-013 | RBIF ; CODE
+              | 0 > | Interpolation with no gap between JASON-1 Microwave Radiometer data
+              | 1 > | Interpolation with gaps between JASON-1 Microwave Radiometer data
+              | 2 > | Extrapolation of JASON-1 Microwave Radiometer data
+              | 3   | Failure of extrapolation and interpolation
+
+  0-40-020 | QFFS ; FLAG
+              | 1 > | NZPD and complex calibration error
+              | 2 > | Band 3 affected by spike
+              | 3 > | Band 3 affected by saturation
+              | 4 > | Band 2 affected by spike
+              | 5 > | Band 1 affected by spike
+              | 6 > | Overflow/underflow
+              | 7 > | On-board processing error
+              | 8 > | Spectral calibration error
+              | 9 > | Radiometric calibration error
+              | 10 > | Missing AVHRR data
+              | 11 > | Missing IIS data
+              | 12 > | Missing sounder data
+              | 13 > | GqisFlagQual summary flag for all bands
+              | 14 > | On-ground processing error
+              | 15   | Inter-calibration error IASI/AVHRR
+
+  0-40-023 | AASF ; FLAG
+              | 1 > | Band sequence (0 = 3Ku_1C_3Ku, 1 = 2Ku_1C_2Ku)
+              | 2 > | C band frequency (0 = 320 MHz, 1 = 100 MHz)
+              | 3 > | C band status (0 = On, 1 = Off)
+              | 4   | Ku band status (0 = On, 1 = Off)
+
+  0-40-024 | MMAC ; CODE
+              | 0 > | 2 maps available (6 hours apart)
+              | 1 > | 2 maps available (greater than 6 hours apart)
+              | 2 > | 1 map available, data extrapolated
+              | 3   | No maps used
+
+  0-40-025 | IFDT ; CODE
+              | 0 > | Good
+              | 1   | Bad
+
+  0-40-028 | GMIQ ; CODE
+              | 0 > | Good data
+              | 1 > | Possible sun glint
+              | 2 > | Possible radio frequency interference
+              | 3 > | Degraded geolocation data
+              | 4 > | Data corrected for warm load intrusion
+              | 5 > | Scan blanking on
+              | 6 > | Data is missing from file or unreadable
+              | 7 > | Unphysical brightness temperature
+              | 8 > | Error in geolocation data
+              | 9 > | Data missing in one channel
+              | 10 > | Data missing in multiple channels
+              | 11 > | Lat/long values are out of range
+              | 12 > | Non-normal status modes
+              | 13   | Distance to corresponding low frequency pixel > 7 km
+
+  0-40-036 | LL2BCT ; CODE
+              | 0 > | Clear
+              | 1   | Cloud
+
+  0-40-043 | SMNI ; CODE
+              | 0 > | The platform is not undergoing a manoeuvre
+              | 1 > | The platform is undergoing a manoeuvre, nominal processing
+              | 2   | The platform is undergoing a manoeuvre, no processing
+
+  0-40-045 | CFHA ; FLAG
+              | 1 > | Cloud products retrieved with the chi-squared method
+              | 2 > | Cloud products retrieved with the CO2 slicing
+              | 3 > | Height assignment performed with statistical first guess retrieval
+              | 4   | Height assignment performed with NWP forecasts
+
+  0-40-046 | CLDSM ; CODE
+              | 0 > | The IASI IFOV is clear
+              | 1 > | Small cloud contamination possible
+              | 2 > | The IASI IFOV is partially covered by clouds
+              | 3   | High or full cloud coverage
+
+  0-40-047 | VIL1P ; CODE
+              | 0 > | The measurements and side information are available and of good quality for L2 processing
+              | 1 > | The L1c products are of degraded quality according to L1c flags, no L2 processing
+              | 2   | Quality control indicates that the L1c data are of degraded quality (not indicated by the IASI L1c flags), no L2 processing
+
+  0-40-048 | VAL1F ; CODE
+              | 0 > | The expected AMSU measurements are available, of good quality and collocated with IASI for processing
+              | 1 > | AMSU-A data are available but of degraded quality (according to AMSU L1 flags or QC tests) and not used for processing
+              | 2   | No coincident (time and space) AMSU measurements available for processing
+
+  0-40-049 | CTXR ; FLAG
+              | 4 > | IASI cloud optical thickness indicates a cloud
+              | 5 > | IASI cloud optical thickness computed
+              | 6 > | AVHRR heterogeneity test indicates a cloud
+              | 7 > | AVHRR heterogeneity test executed
+              | 8 > | IASI-AVHRR ANN cloud test indicates a cloud
+              | 9 > | IASI-AVHRR ANN cloud test executed
+              | 10 > | AVHRR integrated cloud fraction indicates a cloud
+              | 11 > | AVHRR integrated cloud fraction assessed
+              | 12 > | AMSU cloud test indicates a cloud
+              | 13 > | AMSU cloud test executed
+              | 14 > | IASI window cloud test indicates a cloud
+              | 15   | IASI window cloud test executed
+
+  0-40-050 | RTRIN ; FLAG
+              | 5 > | MHS included
+              | 6 > | AMSU included
+              | 7   | IASI included
+
+  0-40-051 | CVIR ; CODE
+              | 0 > | OEM not attempted
+              | 1 > | OEM aborted because first guess residuals too high
+              | 2 > | The minimisation did not converge, sounding rejected
+              | 3 > | The minimisation did not converge, sounding accepted
+              | 4 > | The minimisation converged, sounding rejected
+              | 5   | The minimisation converged, sounding accepted
+
+  0-40-052 | ISFRTR ; FLAG
+              | 4 > | Supersaturation conditions in the OEM retrieval
+              | 5 > | Superadiabatic conditions in the OEM retrieval
+              | 6 > | Supersaturation conditions in the first guess
+              | 7   | Superadiabatic conditions in the first guess
+
+  0-40-054 | PPIE ; FLAG
+              | 1 > | An error has been detected
+              | 2 > | Message from L1
+              | 3 > | Message from L2
+              | 4 > | Message from ancillary data
+              | 5 > | Message from fitting procedure
+              | 6 > | File opening
+              | 7 > | File reading
+              | 8 > | Quality flag
+              | 9 > | Level 2 "from linear regression" (F_Qual) report a pixel where L2 are not fully trusted
+              | 10 > | Empty field or data
+              | 11 > | Missing surface pressure value
+              | 12   | Radiance filtering
+
+  0-40-055 | DRTR ; FLAG
+              | 1 > | Radiance filtering
+              | 2 > | Polar regions
+              | 3 > | Location in the night
+              | 4 > | Negative altitude surface below MSL
+              | 5 > | Cloud-covered scene
+              | 6 > | Scene above the sea
+              | 7 > | Scene above desert
+              | 8 > | Skin temperature
+              | 9 > | Skin temperature differential
+              | 10 > | Spectral line contrast too weak
+              | 11 > | Maximum number of iterations exceeded
+              | 12 > | Negative partial columns
+              | 13 > | Matrix ill-conditioned
+              | 14 > | Fit diverged
+              | 15 > | Error in GSL usage
+              | 16 > | Residuals biased
+              | 17 > | Residuals sloped
+              | 18 > | Residuals RMS large
+              | 19 > | Weird averaging kernels
+              | 20   | Ice presence detected
+
+  0-40-056 | GRTRQ ; CODE
+              | 0 > | Use not recommended
+              | 1 > | Use with caution
+              | 2   | Best quality
+
+  0-40-057 | IL2RTR ; FLAG
+              | 1 > | An error has been detected
+              | 2 > | Message from L1
+              | 3 > | Message from L2
+              | 4 > | Message from ancillary data
+              | 5 > | Message from fitting procedure
+              | 7 > | Bad L1 or L2 flag raised
+              | 8 > | Level 2 not fully trusted
+              | 9 > | Missing temperature or humidity levels in the vertical profile
+              | 10 > | Missing surface pressure value
+              | 11 > | Radiance filtering
+              | 12 > | Polar regions
+              | 13 > | Location in the night
+              | 14 > | Negative altitude
+              | 15 > | Cloud-covered scene
+              | 16 > | Scene above the sea
+              | 17 > | Scene above desert
+              | 18 > | Missing skin temperature
+              | 19 > | Retrieved skin temperature too different from model
+              | 20 > | Spectral line contrast too weak
+              | 21 > | Maximum number of iterations exceeded
+              | 22 > | Negative partial columns
+              | 23 > | Matrix ill-conditioned
+              | 24 > | Fit diverged
+              | 25 > | Error in GSL usage
+              | 26 > | Residuals biased
+              | 27 > | Residuals sloped
+              | 28 > | Residuals RMS large
+              | 29 > | Weird averaging kernels
+              | 30   | Ice presence detected
+
+  0-40-068 | GRTRQSO2 ; CODE
+              | 0 > | Values calculated with IASI L2
+              | 1 > | Pressure and temperature profiles missing in IASI L2 data; model/forecast data used instead
+              | 2   | Best quality
+
+  0-40-074 | GIQF ; FLAG
+              | 1 > | Incompatibility of a scan angle for electroencephalogram
+              | 2 > | Calibration failure (limit of black body temperature reached, not enough sources for interferometry, etc.)
+              | 3 > | Geolocation executed taking into account the orientation of the spacecraft and using the star catalogue
+              | 4 > | High level of cryogenic sediment reached, requiring outgassing of the radiation cooler. Set when NESR level of the ice cover threshold crossed
+              | 5 > | Interferometry package flag
+              | 6 > | General accuracy flag
+              | 7 > | Noise present during the interferometry
+              | 8 > | Outgassing of the radiation cooler
+              | 9 > | Flag preceding the first 24 hours/day mark (set to on as a rule)
+              | 10   | Telemetry package flag
+
+  0-42-004 | CIPSWV ; CODE
+              | 0 > | Wave direction resolved
+              | 1   | 180-degree ambiguity not resolved
+END

--- a/tables/bufrtab.TableB_LOC_0_7_1
+++ b/tables/bufrtab.TableB_LOC_0_7_1
@@ -1,7 +1,7 @@
 Table B LOC |  0 | 7 |  1
 #
 # Local BUFR Table B, Master Table 0, Originating Center 7, Version 1
-# This file was generated: 2021/05/04 16:54:47
+# This file was generated: 2022/11/08 16:34:17
 #
 #========================================================================================================
 # F-XX-YYY |SCALE| REFERENCE   | BIT |      UNIT         | MNEMONIC ;DESC ;  ELEMENT NAME

--- a/tables/bufrtab.TableB_STD_0_39
+++ b/tables/bufrtab.TableB_STD_0_39
@@ -1,0 +1,1756 @@
+Table B STD |  0 | 39
+#
+# Standard BUFR Table B, Master Table 0, Version 39
+# This file was generated: 2022/11/08 16:34:15
+#
+#========================================================================================================
+# F-XX-YYY |SCALE| REFERENCE   | BIT |      UNIT         | MNEMONIC ;DESC ;  ELEMENT NAME
+#          |     |   VALUE     |WIDTH|                   |          ;CODE ;
+#========================================================================================================
+  0-00-001 |   0 |           0 |  24 | CCITT IA5         | TABLAE   ;     ; Table A: entry
+  0-00-002 |   0 |           0 | 256 | CCITT IA5         | TABLAD1  ;     ; Table A: data category description, line 1
+  0-00-003 |   0 |           0 | 256 | CCITT IA5         | TABLAD2  ;     ; Table A: data category description, line 2
+  0-00-004 |   0 |           0 |  16 | CCITT IA5         | MTABL    ;     ; BUFR/CREX Master table
+  0-00-005 |   0 |           0 |  24 | CCITT IA5         | BUFREDN  ;     ; BUFR/CREX edition number
+  0-00-006 |   0 |           0 |  16 | CCITT IA5         | BMTVN    ;     ; BUFR Master table version number
+  0-00-007 |   0 |           0 |  16 | CCITT IA5         | CMTVN    ;     ; CREX Master table version number
+  0-00-008 |   0 |           0 |  16 | CCITT IA5         | BLTVN    ;     ; BUFR Local table version number
+  0-00-010 |   0 |           0 |   8 | CCITT IA5         | FDESC    ;     ; F descriptor to be added or defined
+  0-00-011 |   0 |           0 |  16 | CCITT IA5         | XDESC    ;     ; X descriptor to be added or defined
+  0-00-012 |   0 |           0 |  24 | CCITT IA5         | YDESC    ;     ; Y descriptor to be added or defined
+  0-00-013 |   0 |           0 | 256 | CCITT IA5         | ELEMNA1  ;     ; Element name, line 1
+  0-00-014 |   0 |           0 | 256 | CCITT IA5         | ELEMNA2  ;     ; Element name, line 2
+  0-00-015 |   0 |           0 | 192 | CCITT IA5         | UNITSNA  ;     ; Units name
+  0-00-016 |   0 |           0 |   8 | CCITT IA5         | SCALESG  ;     ; Units scale sign
+  0-00-017 |   0 |           0 |  24 | CCITT IA5         | SCALEU   ;     ; Units scale
+  0-00-018 |   0 |           0 |   8 | CCITT IA5         | REFERSG  ;     ; Units reference sign
+  0-00-019 |   0 |           0 |  80 | CCITT IA5         | REFERVA  ;     ; Units reference value
+  0-00-020 |   0 |           0 |  24 | CCITT IA5         | ELEMDWD  ;     ; Element data width
+  0-00-024 |   0 |           0 |  64 | CCITT IA5         | CODFIG   ;     ; Code figure
+  0-00-025 |   0 |           0 | 496 | CCITT IA5         | CODFIGM  ;     ; Code figure meaning
+  0-00-026 |   0 |           0 |  48 | CCITT IA5         | BITNUM   ;     ; Bit number
+  0-00-027 |   0 |           0 | 496 | CCITT IA5         | BITNUMM  ;     ; Bit number meaning
+  0-00-030 |   0 |           0 |  48 | CCITT IA5         | DDSEQ    ;     ; Descriptor defining sequence
+  0-01-001 |   0 |           0 |   7 | Numeric           | WMOB     ;     ; WMO block number
+  0-01-002 |   0 |           0 |  10 | Numeric           | WMOS     ;     ; WMO station number
+  0-01-003 |   0 |           0 |   3 | Code table        | WMOR     ;     ; WMO Region number/geographical area
+  0-01-004 |   0 |           0 |   3 | Numeric           | WMORS    ;     ; WMO Region sub-area
+  0-01-005 |   0 |           0 |  17 | Numeric           | BPID     ;     ; Buoy/platform identifier
+  0-01-006 |   0 |           0 |  64 | CCITT IA5         | ACID     ;     ; Aircraft flight number
+  0-01-007 |   0 |           0 |  10 | Code table        | SAID     ;     ; Satellite identifier
+  0-01-008 |   0 |           0 |  64 | CCITT IA5         | ACRN     ;     ; Aircraft registration number or other identification
+  0-01-009 |   0 |           0 |  64 | CCITT IA5         | ACTP     ;     ; Type of commercial aircraft
+  0-01-010 |   0 |           0 |  64 | CCITT IA5         | SBPI     ;     ; Stationary buoy platform identifier; e.g. C-MAN buoys
+  0-01-011 |   0 |           0 |  72 | CCITT IA5         | SMID     ;     ; Ship or mobile land station identifier
+  0-01-012 |   0 |           0 |   9 | Degree true       | DOMO     ;     ; Direction of motion of moving observing platform
+  0-01-013 |   0 |           0 |  10 | m s**-1           | SMMO     ;     ; Speed of motion of moving observing platform
+  0-01-014 |   2 |           0 |  10 | m s**-1           | PLDS     ;     ; Platform drift speed (high precision)
+  0-01-015 |   0 |           0 | 160 | CCITT IA5         | STSN     ;     ; Station or site name
+  0-01-016 |   0 |           0 |  16 | Numeric           | SASBID   ;     ; Satellite sub-identifier
+  0-01-018 |   0 |           0 |  40 | CCITT IA5         | SSTN     ;     ; Short station or site name
+  0-01-019 |   0 |           0 | 256 | CCITT IA5         | LSTN     ;     ; Long station or site name
+  0-01-020 |   0 |           0 |   4 | Numeric           | WMORS4   ;     ; WMO Region sub-area
+  0-01-021 |   0 |           0 |  14 | Numeric           | SFID     ;     ; Synoptic feature identifier
+  0-01-022 |   0 |           0 | 224 | CCITT IA5         | NAOF     ;     ; Name of feature
+  0-01-023 |   0 |           0 |   9 | Numeric           | OSQN     ;     ; Observation sequence number
+  0-01-024 |   0 |           0 |   5 | Code table        | WSPDS    ;     ; Wind speed source
+  0-01-025 |   0 |           0 |  24 | CCITT IA5         | STMID    ;     ; Storm identifier
+  0-01-026 |   0 |           0 |  64 | CCITT IA5         | STMNAM   ;     ; WMO storm name
+  0-01-027 |   0 |           0 |  80 | CCITT IA5         | STMNAL   ;     ; WMO long storm name
+  0-01-028 |   0 |           0 |   5 | Code table        | AODS     ;     ; Aerosol optical depth (AOD) source
+  0-01-029 |   0 |           0 |   5 | Code table        | SSIS     ;     ; SSI source
+  0-01-030 |   0 |           0 | 128 | CCITT IA5         | NUMID    ;     ; Numerical model identifier
+  0-01-031 |   0 |           0 |  16 | Code table        | GCLONG   ;     ; Identification of originating/generating centre
+  0-01-032 |   0 |           0 |   8 | Code table        | GNAP     ;     ; Generating application
+  0-01-033 |   0 |           0 |   8 | Code table        | OGCE     ;     ; Identification of originating/generating centre
+  0-01-034 |   0 |           0 |   8 | Code table        | GSES     ;     ; Identification of originating/generating sub-centre
+  0-01-035 |   0 |           0 |  16 | Code table        | ORIGC    ;     ; Originating centre
+  0-01-036 |   0 |           0 |  20 | Code table        | AOOP     ;     ; Agency in charge of operating the observing platform
+  0-01-037 |   0 |           0 |  24 | CCITT IA5         | SIGSI    ;     ; SIGMET sequence identifier
+  0-01-038 |   0 |           0 |   5 | Code table        | SSIF     ;     ; Source of sea ice fraction
+  0-01-039 |   0 |           0 |  40 | CCITT IA5         | GFSI     ;     ; Graphical Area Forecast (GFA) sequence identifier
+  0-01-040 |   0 |           0 |  48 | CCITT IA5         | PCID     ;     ; Processing centre ID code
+  0-01-041 |   5 | -1073741824 |  31 | m s**-1           | PS00     ;     ; Absolute platform velocity - first component
+  0-01-042 |   5 | -1073741824 |  31 | m s**-1           | PS90     ;     ; Absolute platform velocity - second component
+  0-01-043 |   5 | -1073741824 |  31 | m s**-1           | PSNP     ;     ; Absolute platform velocity - third component
+  0-01-044 |   0 |           0 |   8 | Code table        | GNAPS    ;     ; Standard generating application
+  0-01-050 |   0 |           0 |  17 | Numeric           | PTID     ;     ; Platform transmitter ID number
+  0-01-051 |   0 |           0 |  96 | CCITT IA5         | PTIDC    ;     ; Platform transmitter ID number
+  0-01-052 |   0 |           0 |   3 | Code table        | PTIDT    ;     ; Platform transmitter ID
+  0-01-053 |   0 |           0 |   7 | Numeric           | TRSN     ;     ; Tsunameter report sequence number triggered by a tsunami event
+  0-01-060 |   0 |           0 |  64 | CCITT IA5         | ACRP     ;     ; Aircraft reporting point (Beacon identifier)
+  0-01-062 |   0 |           0 |  32 | CCITT IA5         | ICLX     ;     ; Short ICAO location indicator
+  0-01-063 |   0 |           0 |  64 | CCITT IA5         | ICLI     ;     ; ICAO location indicator
+  0-01-064 |   0 |           0 |  32 | CCITT IA5         | RWID     ;     ; Runway designator
+  0-01-065 |   0 |           0 | 256 | CCITT IA5         | ICRI     ;     ; ICAO region identifier
+  0-01-075 |   0 |           0 |  40 | CCITT IA5         | TSTI     ;     ; Tide station identification
+  0-01-079 |   0 |           0 |  64 | CCITT IA5         | IDPF     ;     ; Unique identifier for the profile
+  0-01-080 |   0 |           0 |  32 | CCITT IA5         | SLNO     ;     ; Ship line number according to SOOP
+  0-01-081 |   0 |           0 | 160 | CCITT IA5         | RSERL    ;     ; Radiosonde serial number
+  0-01-082 |   0 |           0 |  14 | Numeric           | RASCN    ;     ; Radiosonde ascension number
+  0-01-083 |   0 |           0 |   3 | Numeric           | RRLSE    ;     ; Radiosonde release number
+  0-01-085 |   0 |           0 | 160 | CCITT IA5         | OPMM     ;     ; Observing platform manufacturer's model
+  0-01-086 |   0 |           0 | 256 | CCITT IA5         | OPMS     ;     ; Observing platform manufacturer's serial number
+  0-01-087 |   0 |           0 |  23 | Numeric           | WMOP     ;     ; WMO marine observing platform extended identifier
+  0-01-090 |   0 |           0 |   8 | Code table        | TMIP     ;     ; Technique for making up initial perturbations
+  0-01-091 |   0 |           0 |  10 | Numeric           | EMNO     ;     ; Ensemble member number
+  0-01-092 |   0 |           0 |   8 | Code table        | TOEF     ;     ; Type of ensemble forecast
+  0-01-093 |   0 |           0 |  96 | CCITT IA5         | BLOTN    ;     ; Balloon lot number
+  0-01-094 |   0 |           0 |  17 | Numeric           | WBAN     ;     ; WBAN number
+  0-01-095 |   0 |           0 |  32 | CCITT IA5         | OBSVR    ;     ; Observer identification
+  0-01-096 |   0 |           0 | 160 | CCITT IA5         | STAQ     ;     ; Station acquisition
+  0-01-099 |   0 |           0 | 248 | CCITT IA5         | UPRD     ;     ; Unique product definition
+  0-01-101 |   0 |           0 |  10 | Code table        | STID     ;     ; State identifier
+  0-01-102 |   0 |           0 |  30 | Numeric           | NSID     ;     ; National station number
+  0-01-103 |   0 |           0 |  24 | Numeric           | IMON     ;     ; IMO Number. Unique Lloyd's register
+  0-01-104 |   0 |           0 |  32 | CCITT IA5         | SFSID    ;     ; State/federal state identifier
+  0-01-105 |   0 |           0 |  40 | CCITT IA5         | HWYID    ;     ; Highway designator
+  0-01-106 |  -2 |           0 |  14 | m                 | LHWYPM   ;     ; Location along highway as indicated by position markers
+  0-01-110 |   0 |           0 |  48 | CCITT IA5         | ACTN     ;     ; Aircraft tail number
+  0-01-111 |   0 |           0 |  24 | CCITT IA5         | OAPT     ;     ; Origination airport
+  0-01-112 |   0 |           0 |  24 | CCITT IA5         | DAPT     ;     ; Destination airport
+  0-01-113 |   1 |           0 |   9 | Numeric           | TVNO     ;     ; Template version number defined by originating centre
+  0-01-114 |   0 |           0 | 352 | CCITT IA5         | ENCSMID  ;     ; Encrypted ship or mobile land station identifier (base64 encoding)
+  0-01-115 |   0 |           0 | 160 | CCITT IA5         | ICMDC    ;     ; Identifier of the cruise or mission under which the data were collected
+  0-01-124 |   0 |           0 |  24 | Numeric           | GPTI     ;     ; Grid point identifier
+  0-01-125 |   0 |           0 |   4 | Numeric           | WGOSIDS  ;     ; WIGOS identifier series
+  0-01-126 |   0 |           0 |  16 | Numeric           | WGOSISID ;     ; WIGOS issuer of identifier
+  0-01-127 |   0 |           0 |  16 | Numeric           | WGOSISNM ;     ; WIGOS issue number
+  0-01-128 |   0 |           0 | 128 | CCITT IA5         | WGOSLID  ;     ; WIGOS local identifier (character)
+  0-01-144 |   0 |           0 |  31 | Numeric           | SNSI     ;     ; Snapshot identifier
+  0-01-145 |   0 |          -8 |  20 | Numeric           | LSID     ;     ; Light source identifier
+  0-01-150 |   0 |           0 |  16 | Code table        | CRFS     ;     ; Coordinate reference system
+  0-01-151 |   0 |           0 |  12 | Code table        | FMSLRD   ;     ; Fixed mean sea-level reference datum
+  0-01-152 |   2 |           0 |  31 | m                 | SMAJARE  ;     ; Semi-major axis of rotation ellipsoid
+  0-01-153 |   2 |           0 |  31 | m                 | SMINARE  ;     ; Semi-minor axis of rotation ellipsoid
+  0-01-154 |   0 |           0 |  12 | Numeric           | SSRI     ;     ; Sensor identifier
+  0-01-155 |   0 |           0 |   8 | Code table        | RTRID    ;     ; Retrieval identifier
+  0-02-001 |   0 |           0 |   2 | Code table        | TOST     ;     ; Type of station
+  0-02-002 |   0 |           0 |   4 | Flag table        | TIWM     ;     ; Type of instrumentation for wind measurement
+  0-02-003 |   0 |           0 |   4 | Code table        | A4ME     ;     ; Type of measuring equipment used
+  0-02-004 |   0 |           0 |   4 | Code table        | TIEM     ;     ; Type of instrumentation for evaporation measurement or type of crop for which evapotranspiration is reported
+  0-02-005 |   2 |           0 |   7 | K                 | PCAT     ;     ; Precision of temperature observation
+  0-02-006 |   0 |           0 |   6 | Code table        | UARSI    ;     ; Upper air remote sensing instrument type
+  0-02-007 |   0 |           0 |   6 | Code table        | TGIT     ;     ; Type of sensor for water level measuring instrument
+  0-02-008 |   0 |           0 |   4 | Code table        | TOFSP    ;     ; Type of offshore platform
+  0-02-011 |   0 |           0 |   8 | Code table        | RATP     ;     ; Radiosonde type
+  0-02-012 |   0 |           0 |   4 | Code table        | RACM     ;     ; Radiosonde computational method
+  0-02-013 |   0 |           0 |   4 | Code table        | SIRC     ;     ; Solar and infrared radiation correction
+  0-02-014 |   0 |           0 |   7 | Code table        | TTSS     ;     ; Tracking technique/status of system used
+  0-02-015 |   0 |           0 |   4 | Code table        | RACP     ;     ; Radiosonde completeness
+  0-02-016 |   0 |           0 |   5 | Flag table        | RCONF    ;     ; Radiosonde configuration
+  0-02-017 |   0 |           0 |   5 | Code table        | CAHM     ;     ; Correction algorithms for humidity measurements
+  0-02-019 |   0 |           0 |  11 | Code table        | SIID     ;     ; Satellite instruments
+  0-02-020 |   0 |           0 |   9 | Code table        | SCLF     ;     ; Satellite classification
+  0-02-021 |   0 |           0 |   9 | Flag table        | SIDU     ;     ; Satellite instrument data used in processing
+  0-02-022 |   0 |           0 |   8 | Flag table        | SDPT     ;     ; Satellite data-processing technique used
+  0-02-023 |   0 |           0 |   4 | Code table        | SWCM     ;     ; Satellite-derived wind computation method
+  0-02-024 |   0 |           0 |   4 | Code table        | IMHC     ;     ; Integrated mean humidity computational method
+  0-02-025 |   0 |           0 |  25 | Flag table        | SCUC     ;     ; Satellite channel(s) used in computation
+  0-02-026 |   2 |           0 |  12 | m                 | CTRE     ;     ; Cross-track resolution
+  0-02-027 |   2 |           0 |  12 | m                 | ATRE     ;     ; Along-track resolution
+  0-02-028 |   0 |           0 |  18 | m                 | SSNX     ;     ; Segment size at nadir in x-direction
+  0-02-029 |   0 |           0 |  18 | m                 | SSNY     ;     ; Segment size at nadir in y-direction
+  0-02-030 |   0 |           0 |   3 | Code table        | MCMS     ;     ; Method of current measurement
+  0-02-031 |   0 |           0 |   5 | Code table        | DTCC     ;     ; Duration and time of current measurement
+  0-02-032 |   0 |           0 |   2 | Code table        | IDGT     ;     ; Indicator for digitization
+  0-02-033 |   0 |           0 |   3 | Code table        | MSDM     ;     ; Method of salinity/depth measurement
+  0-02-034 |   0 |           0 |   5 | Code table        | DROT     ;     ; Drogue type
+  0-02-035 |   0 |           0 |   9 | m                 | CALT     ;     ; Cable length
+  0-02-036 |   0 |           0 |   2 | Code table        | BUYTS    ;     ; Buoy type
+  0-02-037 |   0 |           0 |   3 | Code table        | MOTO     ;     ; Method of tidal observation
+  0-02-038 |   0 |           0 |   4 | Code table        | MSST     ;     ; Method of water temperature and/or salinity measurement
+  0-02-039 |   0 |           0 |   3 | Code table        | MWBT     ;     ; Method of wet-bulb temperature measurement
+  0-02-040 |   0 |           0 |   4 | Code table        | MRMV     ;     ; Method of removing velocity and motion of platform from current
+  0-02-041 |   0 |           0 |   6 | Code table        | MESF     ;     ; Method for estimating reports related to synoptic features
+  0-02-042 |   0 |           0 |   2 | Code table        | ISCS     ;     ; Indicator for sea-surface current speed
+  0-02-044 |   0 |           0 |   4 | Code table        | IMCW     ;     ; Indicator for method of calculating spectral wave data
+  0-02-045 |   0 |           0 |   4 | Code table        | ITOP     ;     ; Indicator for type of platform
+  0-02-046 |   0 |           0 |   4 | Code table        | WMIN     ;     ; Wave measurement instrumentation
+  0-02-047 |   0 |           0 |   7 | Code table        | DOTT     ;     ; Deep-ocean tsunameter type
+  0-02-048 |   0 |           0 |   4 | Code table        | SSIN     ;     ; Satellite sensor indicator
+  0-02-049 |   0 |           0 |   8 | Flag table        | GSDP     ;     ; Geostationary satellite data-processing technique used
+  0-02-050 |   0 |           0 |  20 | Flag table        | GSCU     ;     ; Geostationary sounder satellite channels used
+  0-02-051 |   0 |           0 |   4 | Code table        | IOET     ;     ; Indicator to specify observing method for extreme temperatures
+  0-02-052 |   0 |           0 |   6 | Flag table        | GICU     ;     ; Geostationary imager satellite channels used
+  0-02-053 |   0 |           0 |   4 | Code table        | GBTCST   ;     ; GOES-I/M brightness temperature characteristics
+  0-02-054 |   0 |           0 |   4 | Code table        | GSPCST   ;     ; GOES-I/M soundings parameter characteristics
+  0-02-055 |   0 |           0 |   4 | Code table        | GSSP     ;     ; Geostationary soundings statistical parameters
+  0-02-056 |   0 |           0 |   4 | Code table        | GSAS     ;     ; Geostationary soundings accuracy statistics
+  0-02-057 |   0 |           0 |   4 | Code table        | OFGI     ;     ; Origin of first-guess information for GOES-I/M soundings
+  0-02-058 |   0 |           0 |   4 | Code table        | VTGG     ;     ; Valid times of first-guess information for GOES-I/M soundings
+  0-02-059 |   0 |           0 |   4 | Code table        | OANI     ;     ; Origin of analysis information for GOES-I/M soundings
+  0-02-060 |   0 |           0 |   4 | Code table        | OSFI     ;     ; Origin of surface information for GOES-I/M soundings
+  0-02-061 |   0 |           0 |   3 | Code table        | ACNS     ;     ; Aircraft navigational system
+  0-02-062 |   0 |           0 |   4 | Code table        | TADR     ;     ; Type of aircraft data relay system
+  0-02-063 |   2 |      -18000 |  16 | Degree            | ROLL     ;     ; Aircraft roll angle
+  0-02-064 |   0 |           0 |   2 | Code table        | ROLQ     ;     ; Aircraft roll angle quality
+  0-02-065 |   0 |           0 |  40 | CCITT IA5         | ARST     ;     ; ACARS ground-receiving station
+  0-02-066 |   0 |           0 |   6 | Code table        | RGRSY    ;     ; Radiosonde ground receiving system
+  0-02-067 |  -5 |           0 |  15 | Hz                | RFREQ    ;     ; Radiosonde operating frequency
+  0-02-070 |   0 |           0 |   4 | Code table        | OSLL     ;     ; Original specification of latitude/longitude
+  0-02-071 |  13 |           0 |  30 | m                 | WAVL     ;     ; Spectrographic wavelength
+  0-02-072 |  13 |           0 |  30 | m                 | WIDT     ;     ; Spectrographic width
+  0-02-080 |   0 |           0 |   6 | Code table        | BMFGR    ;     ; Balloon manufacturer
+  0-02-081 |   0 |           0 |   5 | Code table        | BTYPE    ;     ; Type of balloon
+  0-02-082 |   3 |           0 |  12 | kg                | BWGHT    ;     ; Weight of balloon
+  0-02-083 |   0 |           0 |   4 | Code table        | BSHEL    ;     ; Type of balloon shelter
+  0-02-084 |   0 |           0 |   4 | Code table        | BGTYP    ;     ; Type of gas used in balloon
+  0-02-085 |   3 |           0 |  13 | kg                | BGAMT    ;     ; Amount of gas used in balloon
+  0-02-086 |   1 |           0 |  10 | m                 | BFTLN    ;     ; Balloon flight train length
+  0-02-087 |   4 |           0 |  15 | m**2              | PRSA     ;     ; Parachute surface area
+  0-02-088 |   3 |           0 |  13 | m**3              | BGVOL    ;     ; Volume of gas used in balloon
+  0-02-090 |   9 |           0 |  16 | m                 | INWL     ;     ; Instrument wavelength
+  0-02-091 |   4 |           0 |  10 | A                 | ETYS     ;     ; Entry sensor 4/20 mA
+  0-02-092 |   0 |           0 |   3 | Code table        | OPCM     ;     ; Ozone profile computation method
+  0-02-095 |   0 |           0 |   5 | Code table        | PSENS    ;     ; Type of pressure sensor
+  0-02-096 |   0 |           0 |   5 | Code table        | TSENS    ;     ; Type of temperature sensor
+  0-02-097 |   0 |           0 |   5 | Code table        | RHSENS   ;     ; Type of humidity sensor
+  0-02-099 |   0 |           0 |   3 | Code table        | POLA     ;     ; Polarization
+  0-02-100 |   1 |           0 |  12 | dB                | RADARC   ;     ; Radar constant
+  0-02-101 |   0 |           0 |   4 | Code table        | ANTYP    ;     ; Type of antenna
+  0-02-102 |   0 |           0 |   8 | m                 | ANHAT    ;     ; Antenna height above tower base
+  0-02-103 |   0 |           0 |   2 | Flag table        | RADO     ;     ; Radome
+  0-02-104 |   0 |           0 |   4 | Code table        | ANPO     ;     ; Antenna polarization
+  0-02-105 |   0 |           0 |   6 | dB                | MANG     ;     ; Maximum antenna gain
+  0-02-106 |   1 |           0 |   6 | Degree            | BEAMW    ;     ; 3-dB beamwidth
+  0-02-107 |   0 |           0 |   6 | dB                | SLSU     ;     ; Sidelobe suppression
+  0-02-108 |   0 |           0 |   6 | dB                | CPDS     ;     ; Crosspol discrimination (on axis)
+  0-02-109 |   2 |           0 |  12 | Degree s**-1      | ANSA     ;     ; Antenna speed (azimuth)
+  0-02-110 |   2 |           0 |  12 | Degree s**-1      | ANSE     ;     ; Antenna speed (elevation)
+  0-02-111 |   1 |           0 |  10 | Degree            | RAIA     ;     ; Radar incidence angle
+  0-02-112 |   1 |           0 |  12 | Degree            | RALA     ;     ; Radar look angle
+  0-02-113 |   0 |           0 |   4 | Numeric           | NOAL     ;     ; Number of azimuth looks
+  0-02-114 |   0 |           0 |  15 | m**2              | ANES     ;     ; Antenna effective surface area
+  0-02-115 |   0 |           0 |   5 | Code table        | SFEQP    ;     ; Type of surface observing equipment
+  0-02-116 |   0 |           0 |   7 | %                 | P320     ;     ; Percentage of 320 MHz band processed
+  0-02-117 |   0 |           0 |   7 | %                 | P080     ;     ; Percentage of 80 MHz band processed
+  0-02-118 |   0 |           0 |   7 | %                 | P020     ;     ; Percentage of 20 MHz band processed
+  0-02-119 |   0 |           0 |   3 | Code table        | RA2IO    ;     ; RA-2 instrument operations
+  0-02-120 |   3 |           0 |  10 | Hz                | OWFR     ;     ; Ocean wave frequency
+  0-02-121 |  -8 |           0 |   7 | Hz                | MEFR     ;     ; Mean frequency
+  0-02-122 |  -6 |        -128 |   8 | Hz                | FRAR     ;     ; Frequency agility range
+  0-02-123 |  -4 |           0 |   7 | W                 | PKPW     ;     ; Peak power
+  0-02-124 |  -1 |           0 |   7 | W                 | AVPW     ;     ; Average power
+  0-02-125 |  -1 |           0 |   8 | Hz                | PRFR     ;     ; Pulse repetition frequency
+  0-02-126 |   7 |           0 |   6 | s                 | PWID     ;     ; Pulse width
+  0-02-127 |  -6 |           0 |   7 | Hz                | RIFR     ;     ; Receiver intermediate frequency
+  0-02-128 |  -5 |           0 |   6 | Hz                | IFRB     ;     ; Intermediate frequency bandwidth
+  0-02-129 |   0 |        -150 |   5 | dB                | MNDS     ;     ; Minimum detectable signal
+  0-02-130 |   0 |           0 |   7 | dB                | DYRG     ;     ; Dynamic range
+  0-02-131 |   0 |           0 |   2 | Flag table        | STCL     ;     ; Sensitivity time control (STC)
+  0-02-132 |   2 |           0 |   6 | Degree            | AZPA     ;     ; Azimuth pointing accuracy
+  0-02-133 |   2 |           0 |   6 | Degree            | ELPA     ;     ; Elevation pointing accuracy
+  0-02-134 |   2 |           0 |  16 | Degree            | ANAZ     ;     ; Antenna beam azimuth
+  0-02-135 |   2 |       -9000 |  15 | Degree            | ANEL     ;     ; Antenna elevation
+  0-02-136 |  -3 |           0 |  16 | m                 | RPAC     ;     ; Range processed by range attenuation correction
+  0-02-137 |   0 |           0 |   4 | Code table        | RDPR     ;     ; Radar dual PRF ratio
+  0-02-138 |   0 |           0 |   2 | Code table        | ANRD     ;     ; Antenna rotation direction
+  0-02-139 |   0 |           0 |   2 | Code table        | SIIC     ;     ; SIRAL instrument configuration
+  0-02-140 |   0 |           0 |   9 | Degree            | SRBA     ;     ; Satellite radar beam azimuth angle
+  0-02-141 |   0 |           0 |  24 | CCITT IA5         | MTYP     ;     ; Measurement type
+  0-02-142 |   0 |           0 |  32 | CCITT IA5         | OISN     ;     ; Ozone instrument serial number/identification
+  0-02-143 |   0 |           0 |   7 | Code table        | OITP     ;     ; Ozone instrument type
+  0-02-144 |   0 |           0 |   4 | Code table        | LSTB     ;     ; Light source type for Brewer spectrophotometer
+  0-02-145 |   0 |           0 |   4 | Code table        | WSDI     ;     ; Wavelength setting for Dobson instruments
+  0-02-146 |   0 |           0 |   4 | Code table        | SCDI     ;     ; Source conditions for Dobson instruments
+  0-02-147 |   0 |           0 |   6 | Code table        | MTCC     ;     ; Method of transmission to collection centre
+  0-02-148 |   0 |           0 |   5 | Code table        | DCLS     ;     ; Data collection and/or location system
+  0-02-149 |   0 |           0 |   6 | Code table        | BUYT     ;     ; Type of data buoy
+  0-02-150 |   0 |           0 |   6 | Code table        | INCN     ;     ; TOVS/ATOVS/AVHRR instrumentation channel number
+  0-02-151 |   0 |           0 |  11 | Code table        | RAID     ;     ; Radiometer identifier
+  0-02-152 |   0 |           0 |  31 | Flag table        | SIDP     ;     ; Satellite instrument used in data processing
+  0-02-153 |  -8 |           0 |  26 | Hz                | SCCF     ;     ; Satellite channel centre frequency
+  0-02-154 |  -8 |           0 |  26 | Hz                | SCBW     ;     ; Satellite channel band width
+  0-02-155 |   9 |           0 |  16 | m                 | CHWL     ;     ; Satellite channel wavelength
+  0-02-156 |   0 |           0 |   7 | %                 | PVKORM   ;     ; Percentage of valid KU ocean retracker measurements
+  0-02-157 |   0 |           0 |   7 | %                 | PVSORM   ;     ; Percentage of valid S ocean retracker measurements
+  0-02-158 |   0 |           0 |   9 | Flag table        | RA2M     ;     ; RA-2 instrument
+  0-02-159 |   0 |           0 |   8 | Flag table        | MWRI     ;     ; MWR instrument
+  0-02-160 |   0 |           0 |   4 | Code table        | WLOR     ;     ; Wavelength of the radar
+  0-02-161 |   0 |           0 |  16 | Flag table        | WDPF     ;     ; Wind processing method
+  0-02-162 |   0 |           0 |   6 | Code table        | EHAM     ;     ; Extended height assignment method
+  0-02-163 |   0 |           0 |   4 | Code table        | HAMD     ;     ; Height assignment method
+  0-02-164 |   0 |           0 |   3 | Code table        | TCMD     ;     ; Tracer correlation method
+  0-02-165 |   0 |           0 |  15 | Flag table        | RDTF     ;     ; Radiance type flags
+  0-02-166 |   0 |           0 |   4 | Code table        | RDTP     ;     ; Radiance type
+  0-02-167 |   0 |           0 |   4 | Code table        | RDCM     ;     ; Radiance computational method
+  0-02-168 |  -3 |           0 |  16 | Pa                | HPLE     ;     ; Hydrostatic pressure of lower end of cable (thermistor string)
+  0-02-169 |   0 |           0 |   4 | Code table        | ANTP     ;     ; Anemometer type
+  0-02-170 |   0 |           0 |   6 | Code table        | ACHS     ;     ; Aircraft humidity sensors
+  0-02-171 |   0 |           0 |  64 | CCITT IA5         | ISNW     ;     ; Instrument serial number for water temperature profile measurement
+  0-02-172 |   0 |           0 |   8 | Code table        | PTAG     ;     ; Product type for retrieved atmospheric gases
+  0-02-173 |   4 |           0 |  10 | Degree**2         | SONA     ;     ; Square of the off-nadir angle
+  0-02-174 |   0 |           0 |   9 | Numeric           | MACP     ;     ; Mean across track pixel number
+  0-02-175 |   0 |           0 |   4 | Code table        | MOPM     ;     ; Method of precipitation measurement
+  0-02-176 |   0 |           0 |   4 | Code table        | MSGM     ;     ; Method of state of ground measurement
+  0-02-177 |   0 |           0 |   4 | Code table        | MODM     ;     ; Method of snow depth measurement
+  0-02-178 |   0 |           0 |   4 | Code table        | MLMP     ;     ; Method of liquid content measurement of precipitation
+  0-02-179 |   0 |           0 |   4 | Code table        | TSCA     ;     ; Type of sky condition algorithm
+  0-02-180 |   0 |           0 |   4 | Code table        | MPRW     ;     ; Main present weather detecting system
+  0-02-181 |   0 |           0 |  21 | Flag table        | SPRW     ;     ; Supplementary present weather sensor
+  0-02-182 |   0 |           0 |   4 | Code table        | VZMS     ;     ; Visibility measurement system
+  0-02-183 |   0 |           0 |   4 | Code table        | CLDS     ;     ; Cloud detection system
+  0-02-184 |   0 |           0 |   4 | Code table        | TLDS     ;     ; Type of lightning detection sensor
+  0-02-185 |   0 |           0 |   4 | Code table        | MEVM     ;     ; Method of evaporation measurement
+  0-02-186 |   0 |           0 |  30 | Flag table        | CDPP     ;     ; Capability to detect precipitation phenomena
+  0-02-187 |   0 |           0 |  18 | Flag table        | CDWP     ;     ; Capability to detect other weather phenomena
+  0-02-188 |   0 |           0 |  21 | Flag table        | CDOB     ;     ; Capability to detect obscuration
+  0-02-189 |   0 |           0 |  12 | Flag table        | CDLS     ;     ; Capability to discriminate lightning strikes
+  0-02-190 |   0 |           0 |   7 | %                 | LDRS     ;     ; Lagrangian drifter submergence (% time submerged)
+  0-02-191 |   0 |           0 |   4 | Code table        | GHTC     ;     ; Geopotential height calculation
+  0-03-001 |   0 |           0 |   5 | Code table        | SFSTP    ;     ; Surface station type
+  0-03-003 |   0 |           0 |   4 | Code table        | THHS     ;     ; Thermometer/hygrometer housing
+  0-03-004 |   0 |           0 |   4 | Code table        | TPSCSH   ;     ; Type of screen/shelter/radiation shield
+  0-03-005 |   3 |           0 |  16 | m                 | HWSCSH   ;     ; Horizontal width of screen or shield (x)
+  0-03-006 |   3 |           0 |  16 | m                 | HDSCSH   ;     ; Horizontal depth of screen or shield (y)
+  0-03-007 |   3 |           0 |  16 | m                 | VHSCSH   ;     ; Vertical height of screen or shield (z)
+  0-03-008 |   0 |           0 |   3 | Code table        | AVSCSH   ;     ; Artificially ventilated screen or shield
+  0-03-009 |   1 |           0 |   9 | m s**-1           | AFVTR    ;     ; Amount of forced ventilation at time of reading
+  0-03-010 |   0 |           0 |   4 | Code table        | MSCM     ;     ; Method of sea/water current measurement
+  0-03-011 |   0 |           0 |   2 | Code table        | MDCL     ;     ; Method of depth calculation
+  0-03-012 |   0 |           0 |   4 | Code table        | SDOM     ;     ; Instrument type/sensor for dissolved oxygen measurement
+  0-03-016 |   0 |           0 |   4 | Code table        | POSRS    ;     ; Position of road sensors
+  0-03-017 |   0 |           0 |   6 | Flag table        | TOSTX    ;     ; Extended type of station
+  0-03-018 |   0 |           0 |   5 | Code table        | TPROAD   ;     ; Type of road
+  0-03-019 |   0 |           0 |   4 | Code table        | TPCONS   ;     ; Type of construction
+  0-03-020 |   0 |           0 |   3 | Code table        | MTHHS    ;     ; Material for thermometer/hygrometer housing
+  0-03-021 |   0 |           0 |   2 | Code table        | HYGH     ;     ; Hygrometer heating
+  0-03-022 |   0 |           0 |   3 | Code table        | INSTO    ;     ; Instrument owner
+  0-03-023 |   0 |           0 |   3 | Code table        | CLTHS    ;     ; Configuration of louvers for thermometer/hygrometer screen
+  0-03-024 |   6 |           0 |  10 | K**-1             | PRCF     ;     ; Psychrometric coefficient
+  0-03-025 |   0 |        5000 |  16 | m                 | CTEAS    ;     ; Cross-track estimation area size
+  0-03-026 |   0 |        5000 |  16 | m                 | ATEAS    ;     ; Along-track estimation area size
+  0-03-027 |   0 |           0 |   4 | Code table        | TPFR     ;     ; Type of flight rig
+  0-03-028 |   0 |           0 |   6 | Code table        | MSWEM    ;     ; Method of snow water equivalent measurement
+  0-04-001 |   0 |           0 |  12 | Year              | YEAR     ;     ; Year
+  0-04-002 |   0 |           0 |   4 | Month             | MNTH     ;     ; Month
+  0-04-003 |   0 |           0 |   6 | Day               | DAYS     ;     ; Day
+  0-04-004 |   0 |           0 |   5 | Hour              | HOUR     ;     ; Hour
+  0-04-005 |   0 |           0 |   6 | Minute            | MINU     ;     ; Minute
+  0-04-006 |   0 |           0 |   6 | s                 | SECO     ;     ; Second
+  0-04-007 |   6 |           0 |  26 | s                 | SECW     ;     ; Seconds within a minute (microsecond accuracy)
+  0-04-011 |   0 |       -1024 |  11 | Year              | TIYR     ;     ; Time increment
+  0-04-012 |   0 |       -1024 |  11 | Month             | TIMO     ;     ; Time increment
+  0-04-013 |   0 |       -1024 |  11 | Day               | TIDY     ;     ; Time increment
+  0-04-014 |   0 |       -1024 |  11 | Hour              | TIHR     ;     ; Time increment
+  0-04-015 |   0 |       -2048 |  12 | Minute            | TIMI     ;     ; Time increment
+  0-04-016 |   0 |       -4096 |  13 | s                 | TISE     ;     ; Time increment
+  0-04-017 |   0 |       -1440 |  12 | Minute            | RTAE     ;     ; Reference time period for accumulated or extreme data
+  0-04-021 |   0 |       -1024 |  11 | Year              | TPYR     ;     ; Time period or displacement
+  0-04-022 |   0 |       -1024 |  11 | Month             | TPMO     ;     ; Time period or displacement
+  0-04-023 |   0 |       -1024 |  11 | Day               | TPDY     ;     ; Time period or displacement
+  0-04-024 |   0 |       -2048 |  12 | Hour              | TPHR     ;     ; Time period or displacement
+  0-04-025 |   0 |       -2048 |  12 | Minute            | TPMI     ;     ; Time period or displacement
+  0-04-026 |   0 |       -4096 |  13 | s                 | TPSE     ;     ; Time period or displacement
+  0-04-031 |   0 |           0 |   8 | Hour              | .DTH.... ;     ; Duration of time relating to following value
+  0-04-032 |   0 |           0 |   6 | Minute            | .DTM.... ;     ; Duration of time relating to following value
+  0-04-041 |   0 |       -1440 |  12 | Minute            | TIDF     ;     ; Time difference, UTC - LMT
+  0-04-043 |   0 |           0 |   9 | Day               | DOYR     ;     ; Day of the year
+  0-04-051 |   0 |           0 |   5 | Hour              | PTMX     ;     ; Principal time of daily reading of maximum temperature
+  0-04-052 |   0 |           0 |   5 | Hour              | PTMN     ;     ; Principal time of daily reading of minimum temperature
+  0-04-053 |   0 |           0 |   6 | Numeric           | NDP1     ;     ; Number of days with precipitation equal to or more than 1 mm
+  0-04-059 |   0 |           0 |   6 | Flag table        | TOMV     ;     ; Times of observation used to compute the reported mean values
+  0-04-065 |   0 |        -128 |   8 | Minute            | TIMIX    ;     ; Short time increment
+  0-04-066 |   0 |        -128 |   8 | s                 | STIS     ;     ; Short time increment
+  0-04-073 |   0 |        -128 |   8 | Day               | STDD     ;     ; Short time period or displacement
+  0-04-074 |   0 |        -128 |   8 | Hour              | STDH     ;     ; Short time period or displacement
+  0-04-075 |   0 |        -128 |   8 | Minute            | STDM     ;     ; Short time period or displacement
+  0-04-080 |   0 |           0 |   4 | Code table        | .AVP.... ;     ; Averaging period for following value
+  0-04-086 |   0 |       -8192 |  15 | s                 | LTDS     ;     ; Long time period or displacement
+  0-05-001 |   5 |    -9000000 |  25 | Degree            | CLATH    ;     ; Latitude (high accuracy)
+  0-05-002 |   2 |       -9000 |  15 | Degree            | CLAT     ;     ; Latitude (coarse accuracy)
+  0-05-011 |   5 |    -9000000 |  25 | Degree            | LATIH    ;     ; Latitude increment (high accuracy)
+  0-05-012 |   2 |       -9000 |  15 | Degree            | LATI     ;     ; Latitude increment (coarse accuracy)
+  0-05-015 |   5 |    -9000000 |  25 | Degree            | LATDH    ;     ; Latitude displacement (high accuracy)
+  0-05-016 |   2 |       -9000 |  15 | Degree            | LATD     ;     ; Latitude displacement (coarse accuracy)
+  0-05-021 |   2 |           0 |  16 | Degree true       | BEARAZ   ;     ; Bearing or azimuth
+  0-05-022 |   2 |           0 |  16 | Degree true       | SOLAZI   ;     ; Solar azimuth
+  0-05-023 |   1 |       -1800 |  12 | Degree            | SSAD     ;     ; Sun to satellite azimuth difference
+  0-05-030 |   0 |           0 |  12 | Degree            | DRSP     ;     ; Direction (spectral)
+  0-05-031 |   0 |           0 |  12 | Numeric           | ROWN     ;     ; Row number
+  0-05-032 |   2 | -1073741824 |  31 | m                 | YOFF     ;     ; Y offset
+  0-05-033 |  -1 |           0 |  16 | m                 | PSH1     ;     ; Pixel size on horizontal - 1
+  0-05-034 |   0 |           0 |  11 | Numeric           | ATRN     ;     ; Along track row number
+  0-05-035 |   0 |           0 |  12 | Numeric           | MSXD     ;     ; Maximum size of x-dimension
+  0-05-036 |   0 |           0 |   7 | Numeric           | STNO     ;     ; Ship transect number according to SOOP
+  0-05-040 |   0 |           0 |  24 | Numeric           | ORBN     ;     ; Orbit number
+  0-05-041 |   0 |           0 |   8 | Numeric           | SLNM     ;     ; Scan line number
+  0-05-042 |   0 |           0 |   6 | Numeric           | CHNM     ;     ; Channel number
+  0-05-043 |   0 |           0 |   8 | Numeric           | FOVN     ;     ; Field of view number
+  0-05-044 |   0 |           0 |  11 | Numeric           | SACYLN   ;     ; Satellite cycle number
+  0-05-045 |   0 |           0 |   8 | Numeric           | FORN     ;     ; Field of regard number
+  0-05-052 |   0 |           0 |   5 | Numeric           | CHNI     ;     ; Channel number increment
+  0-05-053 |   0 |           0 |   5 | Numeric           | FOVNI    ;     ; Field of view number increment
+  0-05-060 |   6 |    -8000000 |  24 | Degree            | YAPCG    ;     ; Y angular position from centre of gravity
+  0-05-061 |   6 |    -8000000 |  24 | Degree            | ZAPCG    ;     ; Z angular position from centre of gravity
+  0-05-063 |   2 |           0 |  16 | Degree            | SCROLL   ;     ; Spacecraft roll
+  0-05-064 |   2 |           0 |  16 | Degree            | SCPITCH  ;     ; Spacecraft pitch
+  0-05-066 |   2 |           0 |  16 | Degree            | SCYAW    ;     ; Spacecraft yaw
+  0-05-067 |   0 |           0 |   8 | Numeric           | NMSL     ;     ; Number of scan lines
+  0-05-068 |   0 |           0 |  16 | Numeric           | PFNUM    ;     ; Profile number
+  0-05-069 |   0 |           0 |   2 | Code table        | RCVCH    ;     ; Receiver channel
+  0-05-070 |   0 |           0 |  30 | Numeric           | OBSID    ;     ; Observation identifier
+  0-05-071 |   0 |           0 |  16 | Numeric           | STRMPID  ;     ; Stripmap identifier
+  0-05-072 |   0 |           0 |   8 | Numeric           | NSRA     ;     ; Number of spectra in range direction
+  0-05-073 |   0 |           0 |   8 | Numeric           | NSAZ     ;     ; Number of spectra in azimuthal direction
+  0-05-074 |   0 |           0 |   8 | Numeric           | IXRA     ;     ; Index in range direction
+  0-05-075 |   0 |           0 |   8 | Numeric           | IXAZ     ;     ; Index in azimuthal direction
+  0-06-001 |   5 |   -18000000 |  26 | Degree            | CLONH    ;     ; Longitude (high accuracy)
+  0-06-002 |   2 |      -18000 |  16 | Degree            | CLON     ;     ; Longitude (coarse accuracy)
+  0-06-011 |   5 |   -18000000 |  26 | Degree            | LONIH    ;     ; Longitude increment (high accuracy)
+  0-06-012 |   2 |      -18000 |  16 | Degree            | LONI     ;     ; Longitude increment (coarse accuracy)
+  0-06-015 |   5 |   -18000000 |  26 | Degree            | LONDH    ;     ; Longitude displacement (high accuracy)
+  0-06-016 |   2 |      -18000 |  16 | Degree            | LOND     ;     ; Longitude displacement (coarse accuracy)
+  0-06-021 |  -1 |           0 |  13 | m                 | DIST     ;     ; Distance
+  0-06-029 |   1 |           0 |  22 | m**-1             | WVNM     ;     ; Wave number
+  0-06-030 |   5 |           0 |  13 | rad m**-1         | WNSP     ;     ; Wave number (spectral)
+  0-06-031 |   0 |           0 |  12 | Numeric           | COLN     ;     ; Column number
+  0-06-032 |   2 | -1073741824 |  31 | m                 | XOFF     ;     ; X offset
+  0-06-033 |  -1 |           0 |  16 | m                 | PSH2     ;     ; Pixel size on horizontal - 2
+  0-06-034 |   0 |           0 |   7 | Numeric           | CTCN     ;     ; Cross-track cell number
+  0-06-035 |   0 |           0 |  12 | Numeric           | MSYD     ;     ; Maximum size of y-dimension
+  0-06-040 |   0 |           0 |  13 | m                 | RAOC     ;     ; Radius of confidence
+  0-07-001 |   0 |        -400 |  15 | m                 | SELV     ;     ; Height of station
+  0-07-002 |  -1 |         -40 |  16 | m                 | HMSL     ;     ; Height or altitude
+  0-07-003 |  -1 |        -400 |  17 | m**2 s**-2        | GP07C    ;     ; Geopotential
+  0-07-004 |  -1 |           0 |  14 | Pa                | PRLC     ;     ; Pressure
+  0-07-005 |   0 |        -400 |  12 | m                 | HINC     ;     ; Height increment
+  0-07-006 |   0 |           0 |  15 | m                 | HAST     ;     ; Height above station
+  0-07-007 |   0 |       -1000 |  17 | m                 | HEIT     ;     ; Height
+  0-07-008 |   0 |      -10000 |  20 | m**2 s**-2        | GP07     ;     ; Geopotential
+  0-07-009 |   0 |       -1000 |  17 | gpm               | GPHTST   ;     ; Geopotential height
+  0-07-010 |   0 |       -1024 |  16 | m                 | FLVLST   ;     ; Flight level
+  0-07-012 |   2 |      -50000 |  20 | m                 | GPAL     ;     ; Grid point altitude
+  0-07-021 |   2 |       -9000 |  15 | Degree            | ELEV     ;     ; Elevation
+  0-07-022 |   2 |       -9000 |  15 | Degree            | SOEL     ;     ; Solar elevation
+  0-07-024 |   2 |       -9000 |  15 | Degree            | SAZA     ;     ; Satellite zenith angle
+  0-07-025 |   2 |       -9000 |  15 | Degree            | SOZA     ;     ; Solar zenith angle
+  0-07-026 |   4 |     -900000 |  21 | Degree            | SAZAH    ;     ; Satellite zenith angle
+  0-07-030 |   1 |       -4000 |  17 | m                 | HSMSL    ;     ; Height of station ground above mean sea level
+  0-07-031 |   1 |       -4000 |  17 | m                 | HBMSL    ;     ; Height of barometer above mean sea level
+  0-07-032 |   2 |           0 |  16 | m                 | HSALG    ;     ; Height of sensor above local ground (or deck of marine platform)
+  0-07-033 |   1 |           0 |  12 | m                 | HSAWS    ;     ; Height of sensor above water surface
+  0-07-035 |   0 |           0 |  12 | Numeric           | MSZD     ;     ; Maximum size of z-dimension
+  0-07-036 |   0 |           0 |  12 | Numeric           | LINZ     ;     ; Level index of z
+  0-07-040 |   1 |    62000000 |  22 | m                 | IMPP     ;     ; Impact parameter
+  0-07-061 |   2 |           0 |  14 | m                 | DBLS     ;     ; Depth below land surface
+  0-07-062 |   1 |           0 |  17 | m                 | DBSS     ;     ; Depth below sea/water surface
+  0-07-063 |   2 |           0 |  20 | m                 | DBSSX    ;     ; Depth below sea/water surface (cm)
+  0-07-064 |   0 |           0 |   4 | m                 | AHAC     ;     ; Representative height of sensor above station
+  0-07-065 |  -3 |           0 |  17 | Pa                | WPRES    ;     ; Water pressure
+  0-07-070 |   0 |           0 |  10 | m                 | DROD     ;     ; Drogue depth
+  0-07-071 |   3 |   -10000000 |  26 | m                 | HEITH    ;     ; Height (high resolution)
+  0-07-072 |   2 |       -9000 |  15 | Degree            | SANGST   ;     ; Scan angle
+  0-08-001 |   0 |           0 |   7 | Flag table        | VSIG     ;     ; Vertical sounding significance
+  0-08-002 |   0 |           0 |   6 | Code table        | VSSO     ;     ; Vertical significance (surface observations)
+  0-08-003 |   0 |           0 |   6 | Code table        | VSAT     ;     ; Vertical significance (satellite observations)
+  0-08-004 |   0 |           0 |   3 | Code table        | POAF     ;     ; Phase of aircraft flight
+  0-08-005 |   0 |           0 |   4 | Code table        | SSFO     ;     ; Meteorological attribute significance
+  0-08-006 |   0 |           0 |   9 | Flag table        | OVSS     ;     ; Ozone vertical sounding significance
+  0-08-007 |   0 |           0 |   4 | Code table        | DIMS     ;     ; Dimensional significance
+  0-08-008 |   0 |           0 |   9 | Flag table        | RVSS     ;     ; Radiation vertical sounding significance
+  0-08-009 |   0 |           0 |   4 | Code table        | DPOF     ;     ; Detailed phase of flight
+  0-08-010 |   0 |           0 |   5 | Code table        | SFCQ     ;     ; Surface qualifier (temperature data)
+  0-08-011 |   0 |           0 |   6 | Code table        | METFET   ;     ; Meteorological feature
+  0-08-012 |   0 |           0 |   2 | Code table        | LSQL     ;     ; Land/sea qualifier
+  0-08-013 |   0 |           0 |   2 | Code table        | DNQL     ;     ; Day/night qualifier
+  0-08-014 |   0 |           0 |   4 | Code table        | RVRQ     ;     ; Qualifier for runway visual range
+  0-08-015 |   0 |           0 |   3 | Code table        | SIGS     ;     ; Significant qualifier for sensor
+  0-08-016 |   0 |           0 |   3 | Code table        | CHQL     ;     ; Change qualifier of a trend-type forecast or an aerodrome forecast
+  0-08-017 |   0 |           0 |   2 | Code table        | FCQL     ;     ; Qualifier of the time when the forecast change is expected
+  0-08-018 |   0 |           0 |  17 | Flag table        | SLIT     ;     ; SEAWINDS land/ice surface type
+  0-08-019 |   0 |           0 |   4 | Code table        | CIQL     ;     ; Qualifier for following centre identifier
+  0-08-020 |   0 |           0 |  16 | Numeric           | ACAM     ;     ; Total number of missing entities (with respect to accumulation or average)
+  0-08-021 |   0 |           0 |   5 | Code table        | TSIG     ;     ; Time significance
+  0-08-022 |   0 |           0 |  16 | Numeric           | ACAV     ;     ; Total number (with respect to accumulation or average)
+  0-08-023 |   0 |           0 |   6 | Code table        | FOST     ;     ; First-order statistics
+  0-08-024 |   0 |           0 |   6 | Code table        | DFST     ;     ; Difference statistics
+  0-08-025 |   0 |           0 |   4 | Code table        | TDQL     ;     ; Time difference qualifier
+  0-08-026 |   0 |           0 |   6 | Code table        | MTXSIG   ;     ; Matrix significance
+  0-08-029 |   0 |           0 |   8 | Code table        | RSST     ;     ; Surface type
+  0-08-030 |   0 |           0 |  13 | Numeric           | CTDD     ;     ; Manual on Codes (Volume I.1, Section C) Code table from which data are derived
+  0-08-031 |   0 |           0 |   8 | Numeric           | DCAT     ;     ; Data category - CREX table A
+  0-08-032 |   0 |           0 |   4 | Code table        | SOOP     ;     ; Status of operation
+  0-08-033 |   0 |           0 |   7 | Code table        | MDPC     ;     ; Method of derivation of percentage confidence
+  0-08-034 |   0 |           0 |   4 | Code table        | TSQL     ;     ; Temperature/salinity measurement qualifier
+  0-08-035 |   0 |           0 |   3 | Code table        | TOME     ;     ; Type of monitoring exercise
+  0-08-036 |   0 |           0 |   3 | Code table        | TSPM     ;     ; Type of centre or station performing monitoring
+  0-08-037 |   0 |           0 |   5 | Code table        | BLCSIG   ;     ; Baseline check significance
+  0-08-038 |   0 |           0 |   8 | Code table        | INDSIG   ;     ; Instrument data significance
+  0-08-039 |   0 |           0 |   6 | Code table        | TSIGAF   ;     ; Time significance (Aviation forecast)
+  0-08-040 |   0 |           0 |   6 | Code table        | LEVSIG   ;     ; Flight level significance
+  0-08-041 |   0 |           0 |   5 | Code table        | DATSIG   ;     ; Data significance
+  0-08-042 |   0 |           0 |  18 | Flag table        | VSIGX    ;     ; Extended vertical sounding significance
+  0-08-043 |   0 |           0 |   8 | Code table        | ATCT     ;     ; Atmospheric chemical or physical constituent type
+  0-08-044 |   0 |           0 |  88 | CCITT IA5         | CASRN    ;     ; CAS registry number
+  0-08-046 |   0 |           0 |  16 | Code table        | ACCT     ;     ; Atmospheric chemical or physical constituent type
+  0-08-049 |   0 |           0 |   8 | Numeric           | NOBS     ;     ; Number of observations
+  0-08-050 |   0 |           0 |   4 | Code table        | QNMV     ;     ; Qualifier for number of missing values in calculation of statistic
+  0-08-051 |   0 |           0 |   3 | Code table        | QNMVX    ;     ; Qualifier for number of missing values in calculation of statistic
+  0-08-052 |   0 |           0 |   5 | Code table        | CNDO     ;     ; Condition for which number of days of occurrence follows
+  0-08-053 |   0 |           0 |   2 | Code table        | DOQL     ;     ; Day of occurrence qualifier
+  0-08-054 |   0 |           0 |   3 | Code table        | QWSG     ;     ; Qualifier for wind speed or wind gusts
+  0-08-060 |   0 |           0 |   4 | Code table        | SSMS     ;     ; Sample scanning mode significance
+  0-08-065 |   0 |           0 |   2 | Code table        | SGIN     ;     ; Sun-glint indicator
+  0-08-066 |   0 |           0 |   2 | Code table        | STIN     ;     ; Semi-transparency indicator
+  0-08-070 |   0 |           0 |   4 | Code table        | TAPQ     ;     ; Vertical sounding product qualifier
+  0-08-072 |   0 |           0 |   3 | Code table        | PIXT     ;     ; Pixel(s) type
+  0-08-074 |   0 |           0 |   2 | Code table        | AETP     ;     ; Altimeter echo type
+  0-08-075 |   0 |           0 |   2 | Code table        | STKO     ;     ; Ascending/descending orbit qualifier
+  0-08-076 |   0 |           0 |   6 | Code table        | TOBD     ;     ; Type of band
+  0-08-077 |   0 |           0 |   7 | Code table        | DSST     ;     ; Radiometer sensed surface type
+  0-08-079 |   0 |           0 |   4 | Code table        | CSFP     ;     ; Product status
+  0-08-080 |   0 |           0 |   6 | Code table        | QFQF     ;     ; Qualifier for GTSPP quality flag
+  0-08-081 |   0 |           0 |   6 | Code table        | TOEQ     ;     ; Type of equipment
+  0-08-082 |   0 |           0 |   3 | Code table        | ACSH     ;     ; Modification of sensor height to another value
+  0-08-083 |   0 |           0 |  15 | Flag table        | NOVI     ;     ; Nominal value indicator
+  0-08-085 |   0 |           0 |   3 | Code table        | BEAMI    ;     ; Beam identifier
+  0-08-086 |   0 |           0 |  12 | Flag table        | VSNWP    ;     ; Vertical significance for NWP
+  0-08-087 |   0 |           0 |   3 | Code table        | CPOS     ;     ; Corner position of observation
+  0-08-088 |   0 |           0 |   6 | Code table        | MAPSIG   ;     ; Map significance
+  0-08-090 |   0 |        -127 |   8 | Numeric           | DSFTV    ;     ; Decimal scale of following significands
+  0-08-091 |   0 |           0 |   8 | Code table        | CRDSIG   ;     ; Coordinates significance
+  0-08-092 |   0 |           0 |   5 | Code table        | MUNCEX   ;     ; Measurement uncertainty expression
+  0-08-093 |   0 |           0 |   5 | Code table        | MUNCSG   ;     ; Measurement uncertainty significance
+  0-08-094 |   0 |           0 |   8 | Code table        | MCAVGDTM ;     ; Method used to calculate the average daily temperature
+  0-08-095 |   0 |           0 |   8 | Code table        | SMQCTM   ;     ; Siting and measurement quality classification for temperature
+  0-08-096 |   0 |           0 |   8 | Code table        | SMQCPC   ;     ; Siting and measurement quality classification for precipitation
+  0-08-097 |   0 |           0 |   7 | Code table        | MCAVGITM ;     ; Method used to calculate the average instrument temperature
+  0-10-001 |   0 |        -400 |  15 | m                 | HOLS     ;     ; Height of land surface
+  0-10-002 |  -1 |         -40 |  16 | m                 | HITE     ;     ; Height
+  0-10-003 |  -1 |        -400 |  17 | m**2 s**-2        | GEOP     ;     ; Geopotential
+  0-10-004 |  -1 |           0 |  14 | Pa                | PRES     ;     ; Pressure
+  0-10-007 |   0 |       -1000 |  17 | m                 | HGHT     ;     ; Height
+  0-10-008 |   0 |      -10000 |  20 | m**2 s**-2        | GP10     ;     ; Geopotential
+  0-10-009 |   0 |       -1000 |  17 | gpm               | GPH10    ;     ; Geopotential height
+  0-10-010 |  -1 |           0 |  14 | Pa                | PMSLMN   ;     ; Minimum pressure reduced to mean sea level
+  0-10-011 |  -1 |           0 |  14 | Pa                | PMSLMX   ;     ; Maximum pressure reduced to mean sea level
+  0-10-031 |   2 | -1073741824 |  31 | m                 | PDNP     ;     ; In direction of the North Pole, distance from the Earth's centre
+  0-10-032 |   1 |           0 |  27 | m                 | SDEC     ;     ; Satellite distance to Earth's centre
+  0-10-033 |   1 |           0 |  27 | m                 | ALTPE    ;     ; Altitude (platform to ellipsoid)
+  0-10-034 |   1 |           0 |  27 | m                 | ERAD     ;     ; Earth's radius
+  0-10-035 |   1 |    62000000 |  22 | m                 | ELRC     ;     ; Earth's local radius of curvature
+  0-10-036 |   2 |      -15000 |  15 | m                 | GEODU    ;     ; Geoid undulation
+  0-10-038 |   0 |           0 |   6 | m                 | MHCASL   ;     ; Maximum height of deck cargo above summer load line
+  0-10-039 |   0 |         -32 |   6 | m                 | DRLASL   ;     ; Departure of reference level (summer maximum load line) from actual sea level
+  0-10-040 |   0 |           0 |  10 | Numeric           | NRLY     ;     ; Number of retrieved layers
+  0-10-050 |   2 |           0 |  16 | m                 | SDAL     ;     ; Standard deviation altitude
+  0-10-051 |  -1 |           0 |  14 | Pa                | PMSL     ;     ; Pressure reduced to mean sea level
+  0-10-052 |  -1 |           0 |  14 | Pa                | ALSE     ;     ; Altimeter setting (QNH)
+  0-10-053 |   0 |       -1000 |  17 | m                 | GNSA     ;     ; Global navigation satellite system altitude
+  0-10-060 |  -1 |       -1024 |  11 | Pa                | PCHG     ;     ; Pressure change
+  0-10-061 |  -1 |        -500 |  10 | Pa                | 3HPC     ;     ; 3-hour pressure change
+  0-10-062 |  -1 |       -1000 |  11 | Pa                | 24PC     ;     ; 24-hour pressure change
+  0-10-063 |   0 |           0 |   4 | Code table        | CHPT     ;     ; Characteristic of pressure tendency
+  0-10-064 |   0 |           0 |   3 | Code table        | SIGCL    ;     ; SIGMET cruising level
+  0-10-070 |   0 |        -400 |  16 | m                 | IALT     ;     ; Indicated aircraft altitude
+  0-10-071 |   0 |           0 |  14 | m                 | VRES     ;     ; Vertical resolution
+  0-10-079 |   4 |           0 |  16 | Degree            | ONAS     ;     ; Off-nadir angle of the satellite from platform data
+  0-10-080 |   2 |       -9000 |  15 | Degree            | VZAN     ;     ; Viewing zenith angle
+  0-10-081 |   3 |           0 |  31 | m                 | ALRE     ;     ; Altitude of COG above reference ellipsoid
+  0-10-082 |   3 |      -65536 |  17 | m s**-1           | IALR     ;     ; Instantaneous altitude rate
+  0-10-083 |   2 |           0 |  16 | Degree**2         | ONAP     ;     ; Squared off-nadir angle of the satellite from platform data
+  0-10-084 |   2 |           0 |  16 | Degree**2         | ONAW     ;     ; Squared off-nadir angle of the satellite from waveform data
+  0-10-085 |   3 |     -131072 |  18 | m                 | MSSH     ;     ; Mean sea-surface height
+  0-10-086 |   3 |     -131072 |  18 | m                 | GEODH    ;     ; Geoid's height
+  0-10-087 |   1 |     -131072 |  18 | m                 | ODLE     ;     ; Ocean depth/land elevation
+  0-10-088 |   3 |      -32768 |  16 | m                 | TGOTH1   ;     ; Total geocentric ocean tide height (solution 1)
+  0-10-089 |   3 |      -32768 |  16 | m                 | TGOTH2   ;     ; Total geocentric ocean tide height (solution 2)
+  0-10-090 |   3 |      -32768 |  16 | m                 | LPTH     ;     ; Long period tide height
+  0-10-091 |   3 |      -32768 |  16 | m                 | TILH     ;     ; Tidal loading height
+  0-10-092 |   3 |      -32768 |  16 | m                 | SETH     ;     ; Solid Earth tide height
+  0-10-093 |   3 |      -32768 |  16 | m                 | GPTH     ;     ; Geocentric pole tide height
+  0-10-095 |   0 |           0 |  16 | m                 | HOAU     ;     ; Height of atmosphere used
+  0-10-096 |   3 |     -131072 |  18 | m                 | MDYT     ;     ; Mean dynamic topography
+  0-10-097 |   3 |     -131072 |  18 | m                 | MSHA     ;     ; Mean sea-surface height from altimeter only
+  0-10-098 |   4 |       -2000 |  12 | m                 | LTHS1    ;     ; Loading tide height geocentric ocean tide solution 1
+  0-10-099 |   4 |       -2000 |  12 | m                 | LTHS2    ;     ; Loading tide height geocentric ocean tide solution 2
+  0-10-100 |   4 |       -2000 |  12 | m                 | NLTH     ;     ; Non-equilibrium long period tide height
+  0-10-101 |   2 |      -32768 |  16 | Degree**2         | SONAW    ;     ; Squared off-nadir angle of the satellite from waveform data
+  0-10-102 |   3 |      -32768 |  16 | m                 | SSHA     ;     ; Sea-surface height anomaly
+  0-10-103 |   3 |     -131072 |  18 | m                 | MDTA     ;     ; Mean dynamic topography accuracy
+  0-11-001 |   0 |           0 |   9 | Degree true       | WDIR     ;     ; Wind direction
+  0-11-002 |   1 |           0 |  12 | m s**-1           | WSPD     ;     ; Wind speed
+  0-11-003 |   1 |       -4096 |  13 | m s**-1           | UWND     ;     ; u-component
+  0-11-004 |   1 |       -4096 |  13 | m s**-1           | VWND     ;     ; v-component
+  0-11-005 |   1 |        -512 |  10 | Pa s**-1          | OMEGA    ;     ; w-component
+  0-11-006 |   2 |       -4096 |  13 | m s**-1           | WCMP     ;     ; w-component
+  0-11-007 |   0 |           0 |   9 | Degree            | RWDIR    ;     ; Relative wind direction (in degrees off bow)
+  0-11-008 |   1 |           0 |  12 | m s**-1           | RWSPD    ;     ; Relative wind speed
+  0-11-010 |   0 |           0 |   9 | Degree true       | WDAS     ;     ; Wind direction associated with wind speed which follows
+  0-11-011 |   0 |           0 |   9 | Degree true       | WD10     ;     ; Wind direction at 10 m
+  0-11-012 |   1 |           0 |  12 | m s**-1           | WS10     ;     ; Wind speed at 10 m
+  0-11-013 |   0 |           0 |   9 | Degree true       | WD05     ;     ; Wind direction at 5 m
+  0-11-014 |   1 |           0 |  12 | m s**-1           | WS05     ;     ; Wind speed at 5 m
+  0-11-016 |   0 |           0 |   9 | Degree true       | DRC1     ;     ; Extreme counterclockwise wind direction of a variable wind
+  0-11-017 |   0 |           0 |   9 | Degree true       | DRC2     ;     ; Extreme clockwise wind direction of a variable wind
+  0-11-019 |   0 |           0 |   7 | %                 | STOW     ;     ; Steadiness of wind
+  0-11-021 |   9 |      -65536 |  17 | s**-1             | RVORT    ;     ; Relative vorticity
+  0-11-022 |   9 |      -65536 |  17 | s**-1             | DIVG     ;     ; Divergence
+  0-11-023 |  -2 |      -65536 |  17 | m**2 s**-1        | VPOT     ;     ; Velocity potential
+  0-11-030 |   0 |           0 |   6 | Code table        | DGOTX    ;     ; Extended degree of turbulence
+  0-11-031 |   0 |           0 |   4 | Code table        | DGOT     ;     ; Degree of turbulence
+  0-11-032 |  -1 |         -40 |  16 | m                 | HBOT     ;     ; Height of base of turbulence
+  0-11-033 |  -1 |         -40 |  16 | m                 | HTOT     ;     ; Height of top of turbulence
+  0-11-034 |   1 |       -1024 |  11 | m s**-1           | VGVL     ;     ; Vertical gust velocity
+  0-11-035 |   2 |       -8192 |  14 | m s**-2           | VGAC     ;     ; Vertical gust acceleration
+  0-11-036 |   1 |           0 |  10 | m s**-1           | MDEVG    ;     ; Maximum derived equivalent vertical gust speed
+  0-11-037 |   0 |           0 |   6 | Code table        | TRBXST   ;     ; Turbulence index
+  0-11-038 |   0 |           0 |   5 | Code table        | TOPEDR   ;     ; Time of occurrence of peak eddy dissipation rate
+  0-11-039 |   0 |           0 |   6 | Code table        | XTOPEDR  ;     ; Extended time of occurrence of peak eddy dissipation rate
+  0-11-040 |   1 |           0 |  12 | m s**-1           | MXWS     ;     ; Maximum wind speed (mean wind)
+  0-11-041 |   1 |           0 |  12 | m s**-1           | MXGS     ;     ; Maximum wind gust speed
+  0-11-042 |   1 |           0 |  12 | m s**-1           | MXWS10   ;     ; Maximum wind speed (10-minute mean wind)
+  0-11-043 |   0 |           0 |   9 | Degree true       | MXGD     ;     ; Maximum wind gust direction
+  0-11-044 |   0 |           0 |   9 | Degree true       | MWDL     ;     ; Mean wind direction for surface - 1 500 m (5 000 feet)
+  0-11-045 |   1 |           0 |  12 | m s**-1           | MWSL     ;     ; Mean wind speed for surface - 1 500 m (5 000 feet)
+  0-11-046 |   1 |           0 |  12 | m s**-1           | MIWS     ;     ; Maximum instantaneous wind speed
+  0-11-047 |   1 |           0 |  12 | m s**-1           | MIWS10   ;     ; Maximum instantaneous wind speed over 10 minutes
+  0-11-049 |   0 |           0 |   9 | Degree true       | SDWD     ;     ; Standard deviation of wind direction
+  0-11-050 |   1 |           0 |  12 | m s**-1           | SDHS     ;     ; Standard deviation of horizontal wind speed
+  0-11-051 |   1 |           0 |   8 | m s**-1           | SDVS     ;     ; Standard deviation of vertical wind speed
+  0-11-052 |   2 |           0 |  13 | m s**-1           | FUWS     ;     ; Formal uncertainty in wind speed
+  0-11-053 |   2 |           0 |  15 | Degree true       | FUWD     ;     ; Formal uncertainty in wind direction
+  0-11-054 |   0 |           0 |   9 | Degree true       | MWDIRL   ;     ; Mean wind direction for 1 500 - 3 000 m
+  0-11-055 |   1 |           0 |  12 | m s**-1           | MWSPDL   ;     ; Mean wind speed for 1 500 - 3 000 m
+  0-11-061 |   1 |           0 |  12 | m s**-1           | AWSB     ;     ; Absolute wind shear in 1 km layer below
+  0-11-062 |   1 |           0 |  12 | m s**-1           | AWSA     ;     ; Absolute wind shear in 1 km layer above
+  0-11-070 |   0 |           0 |  32 | CCITT IA5         | DRAS     ;     ; Designator of the runway affected by wind shear (including ALL)
+  0-11-071 |   3 |        -128 |  14 | m**2 s**-2        | TVMF     ;     ; Turbulent vertical momentum flux
+  0-11-072 |   3 |        -128 |  11 | K m s**-1         | TVBF     ;     ; Turbulent vertical buoyancy flux
+  0-11-073 |   2 |       -1024 |  13 | m**2 s**-2        | TKEN     ;     ; Turbulent kinetic energy
+  0-11-074 |   2 |       -1024 |  10 | m**2 s**-2        | DPEN     ;     ; Dissipation energy
+  0-11-075 |   2 |           0 |   8 | m**(2/3) s**-1    | MTRB     ;     ; Mean turbulence intensity (eddy dissipation rate)
+  0-11-076 |   2 |           0 |   8 | m**(2/3) s**-1    | PTRB     ;     ; Peak turbulence intensity (eddy dissipation rate)
+  0-11-077 |   0 |           0 |  12 | s                 | RIEDR    ;     ; Reporting interval or averaging time for eddy dissipation rate
+  0-11-081 |   2 |           0 |  16 | Degree true       | MWD10    ;     ; Model wind direction at 10 m
+  0-11-082 |   2 |           0 |  14 | m s**-1           | MWS10    ;     ; Model wind speed at 10 m
+  0-11-083 |   0 |           0 |   9 | km h**-1          | WSPD2    ;     ; Wind speed
+  0-11-084 |   0 |           0 |   8 | kt                | WSPD3    ;     ; Wind speed
+  0-11-085 |   0 |           0 |   9 | km h**-1          | MXGSP1   ;     ; Maximum wind gust speed
+  0-11-086 |   0 |           0 |   8 | kt                | MXGSP2   ;     ; Maximum wind gust speed
+  0-11-095 |   1 |       -4096 |  13 | m s**-1           | UMWV     ;     ; u-component of the model wind vector
+  0-11-096 |   1 |       -4096 |  13 | m s**-1           | VWMV     ;     ; v-component of the model wind vector
+  0-11-097 |   2 |           0 |  12 | m s**-1           | WSPA     ;     ; Wind speed from altimeter
+  0-11-098 |   2 |           0 |  12 | m s**-1           | WSPR     ;     ; Wind speed from radiometer
+  0-11-100 |   1 |           0 |  12 | m s**-1           | TASP     ;     ; Aircraft true airspeed
+  0-11-101 |   1 |       -4096 |  13 | m s**-1           | AVLU     ;     ; Aircraft ground speed u-component
+  0-11-102 |   1 |       -4096 |  13 | m s**-1           | AVLV     ;     ; Aircraft ground speed v-component
+  0-11-103 |   1 |        -512 |  10 | m s**-1           | AVLW     ;     ; Aircraft ground speed w-component
+  0-11-104 |   0 |           0 |   9 | Degree true       | ACTH     ;     ; True heading of aircraft, ship or other mobile platform
+  0-11-105 |   0 |           0 |   6 | Numeric           | EDRV     ;     ; EDR algorithm version
+  0-11-106 |   1 |           0 |   4 | Numeric           | RMCF     ;     ; Running minimum confidence
+  0-11-107 |   0 |           0 |   5 | Numeric           | MNBI     ;     ; Maximum number bad inputs
+  0-11-108 |   1 |           0 |   4 | Numeric           | PKLN     ;     ; Peak location
+  0-11-109 |   0 |           0 |   4 | Numeric           | GEDR     ;     ; Number of good EDR
+  0-11-110 |   1 |       -4096 |  13 | m s**-1           | UNCUWND  ;     ; Uncertainty in u-component
+  0-11-111 |   1 |       -4096 |  13 | m s**-1           | UNCVWND  ;     ; Uncertainty in v-component
+  0-11-112 |   2 |       -4096 |  13 | m s**-1           | UNCWCMP  ;     ; Uncertainty in w-component
+  0-11-113 |   3 |       -1000 |  12 | Numeric           | TCOV     ;     ; Tracking correlation of vector
+  0-12-001 |   1 |           0 |  12 | K                 | TMDBST   ;     ; Temperature/air temperature
+  0-12-002 |   1 |           0 |  12 | K                 | TMWBST   ;     ; Wet-bulb temperature
+  0-12-003 |   1 |           0 |  12 | K                 | TMDPST   ;     ; Dewpoint temperature
+  0-12-004 |   1 |           0 |  12 | K                 | T2MS     ;     ; Air temperature at 2 m
+  0-12-005 |   1 |           0 |  12 | K                 | T2MW     ;     ; Wet-bulb temperature at 2 m
+  0-12-006 |   1 |           0 |  12 | K                 | T2MD     ;     ; Dewpoint temperature at 2 m
+  0-12-007 |   1 |           0 |  12 | K                 | TMVRST   ;     ; Virtual temperature
+  0-12-008 |   1 |           0 |  12 | K                 | UNCTMVR  ;     ; Uncertainty in virtual temperature
+  0-12-011 |   1 |           0 |  12 | K                 | MXTMST   ;     ; Maximum temperature, at height and over period specified
+  0-12-012 |   1 |           0 |  12 | K                 | MITMST   ;     ; Minimum temperature, at height and over period specified
+  0-12-013 |   1 |           0 |  12 | K                 | GMIT     ;     ; Ground minimum temperature, past 12 hours
+  0-12-014 |   1 |           0 |  12 | K                 | MXT2M12  ;     ; Maximum temperature at 2 m, past 12 hours
+  0-12-015 |   1 |           0 |  12 | K                 | MIT2M12  ;     ; Minimum temperature at 2 m, past 12 hours
+  0-12-016 |   1 |           0 |  12 | K                 | MXT2M24  ;     ; Maximum temperature at 2 m, past 24 hours
+  0-12-017 |   1 |           0 |  12 | K                 | MIT2M24  ;     ; Minimum temperature at 2 m, past 24 hours
+  0-12-021 |   2 |           0 |  16 | K                 | MXT2M    ;     ; Maximum temperature at 2 m
+  0-12-022 |   2 |           0 |  16 | K                 | MIT2M    ;     ; Minimum temperature at 2 m
+  0-12-023 |   0 |         -99 |   8 | C                 | TMDBC    ;     ; Temperature
+  0-12-024 |   0 |         -99 |   8 | C                 | TMDPC    ;     ; Dewpoint temperature
+  0-12-030 |   1 |           0 |  12 | K                 | STEM     ;     ; Soil temperature
+  0-12-049 |   0 |         -30 |   6 | K                 | TCPS     ;     ; Temperature change over specified period
+  0-12-051 |   1 |           0 |  10 | K                 | STDT     ;     ; Standard deviation temperature
+  0-12-052 |   1 |           0 |  12 | K                 | HDMT     ;     ; Highest daily mean temperature
+  0-12-053 |   1 |           0 |  12 | K                 | LDMT     ;     ; Lowest daily mean temperature
+  0-12-060 |   1 |           0 |  12 | K                 | AWST     ;     ; AWS enclosure internal temperature
+  0-12-061 |   1 |           0 |  12 | K                 | TMSKST   ;     ; Skin temperature
+  0-12-062 |   1 |           0 |  12 | K                 | EBBT     ;     ; Equivalent black body temperature
+  0-12-063 |   1 |           0 |  12 | K                 | TMBRST   ;     ; Brightness temperature
+  0-12-064 |   1 |           0 |  12 | K                 | TMINST   ;     ; Instrument temperature
+  0-12-065 |   1 |           0 |  12 | K                 | SDTB     ;     ; Standard deviation brightness temperature
+  0-12-066 |   2 |           0 |  16 | K                 | TMANT    ;     ; Antenna temperature
+  0-12-070 |   2 |           0 |  16 | K                 | WLTM     ;     ; Warm load temperature
+  0-12-071 |   1 |           0 |  12 | K                 | CCST     ;     ; Coldest cluster temperature
+  0-12-072 |   6 |           0 |  31 | W m**-2 sr**-1    | RDNEH    ;     ; Radiance
+  0-12-075 |  -3 |           0 |  16 | W m**-3 sr**-1    | SPRD     ;     ; Spectral radiance
+  0-12-076 |   3 |           0 |  16 | W m**-2 sr**-1    | RDNE     ;     ; Radiance
+  0-12-080 |   2 |      -10000 |  16 | K                 | TMBRR    ;     ; Brightness temperature real part
+  0-12-081 |   2 |      -10000 |  16 | K                 | TMBRI    ;     ; Brightness temperature imaginary part
+  0-12-082 |   2 |           0 |  12 | K                 | PXRA     ;     ; Pixel radiometric accuracy
+  0-12-101 |   2 |           0 |  16 | K                 | TMDB     ;     ; Temperature/air temperature
+  0-12-102 |   2 |           0 |  16 | K                 | TMWB     ;     ; Wet-bulb temperature
+  0-12-103 |   2 |           0 |  16 | K                 | TMDP     ;     ; Dewpoint temperature
+  0-12-104 |   2 |           0 |  16 | K                 | T2MSH    ;     ; Air temperature at 2 m
+  0-12-105 |   2 |           0 |  16 | K                 | T2MWH    ;     ; Web-bulb temperature at 2 m
+  0-12-106 |   2 |           0 |  16 | K                 | T2MDH    ;     ; Dewpoint temperature at 2 m
+  0-12-107 |   2 |           0 |  16 | K                 | TMVR     ;     ; Virtual temperature
+  0-12-111 |   2 |           0 |  16 | K                 | MXTM     ;     ; Maximum temperature, at height and over period specified
+  0-12-112 |   2 |           0 |  16 | K                 | MITM     ;     ; Minimum temperature, at height and over period specified
+  0-12-113 |   2 |           0 |  16 | K                 | GMITH    ;     ; Ground minimum temperature, past 12 hours
+  0-12-114 |   2 |           0 |  16 | K                 | MXT2M12H ;     ; Maximum temperature at 2 m, past 12 hours
+  0-12-115 |   2 |           0 |  16 | K                 | MIT2M12H ;     ; Minimum temperature at 2 m, past 12 hours
+  0-12-116 |   2 |           0 |  16 | K                 | MXT2M24H ;     ; Maximum temperature at 2 m, past 24 hours
+  0-12-117 |   2 |           0 |  16 | K                 | MIT2M24H ;     ; Minimum temperature at 2 m, past 24 hours
+  0-12-118 |   2 |           0 |  16 | K                 | MXTM24   ;     ; Maximum temperature at height specified, past 24 hours
+  0-12-119 |   2 |           0 |  16 | K                 | MITM24   ;     ; Minimum temperature at height specified, past 24 hours
+  0-12-120 |   2 |           0 |  16 | K                 | GTEM     ;     ; Ground temperature
+  0-12-121 |   2 |           0 |  16 | K                 | GMINT    ;     ; Ground minimum temperature
+  0-12-122 |   2 |           0 |  16 | K                 | GMINTP   ;     ; Ground minimum temperature of the preceding night
+  0-12-128 |   2 |           0 |  16 | K                 | ROADST   ;     ; Road surface temperature
+  0-12-129 |   2 |           0 |  16 | K                 | ROADSST  ;     ; Road subsurface temperature
+  0-12-130 |   2 |           0 |  16 | K                 | STEMH    ;     ; Soil temperature
+  0-12-131 |   2 |           0 |  16 | K                 | NTEM     ;     ; Snow temperature
+  0-12-132 |   2 |           0 |  16 | K                 | ITEM     ;     ; Ice surface temperature
+  0-12-151 |   2 |           0 |  12 | K                 | STDMT    ;     ; Standard deviation of daily mean temperature
+  0-12-152 |   2 |           0 |  16 | K                 | HDMTH    ;     ; Highest daily mean temperature
+  0-12-153 |   2 |           0 |  16 | K                 | LDMTH    ;     ; Lowest daily mean temperature
+  0-12-158 |   2 |           0 |  12 | K                 | NEDTCO   ;     ; Noise-equivalent delta temperature while viewing cold target
+  0-12-159 |   2 |           0 |  12 | K                 | NEDTWA   ;     ; Noise-equivalent delta temperature while viewing warm target
+  0-12-161 |   2 |           0 |  16 | K                 | TMSK     ;     ; Skin temperature
+  0-12-162 |   2 |           0 |  16 | K                 | EBBTH    ;     ; Equivalent black body temperature
+  0-12-163 |   2 |           0 |  16 | K                 | TMBR     ;     ; Brightness temperature
+  0-12-164 |   2 |           0 |  16 | K                 | TMINSTH  ;     ; Instrument temperature
+  0-12-165 |   0 |           0 |  23 | K                 | DSBT     ;     ; Direct sun brightness temperature
+  0-12-166 |   1 |       -4000 |  13 | K                 | SSAC     ;     ; Snapshot accuracy
+  0-12-167 |   1 |           0 |   9 | K                 | RACPP    ;     ; Radiometric accuracy (pure polarization)
+  0-12-168 |   1 |           0 |   9 | K                 | RACCP    ;     ; Radiometric accuracy (cross polarization)
+  0-12-171 |   2 |           0 |  16 | K                 | CCSTH    ;     ; Coldest cluster temperature
+  0-12-180 |   2 |           0 |  16 | K                 | A12BN    ;     ; Averaged 12 micron BT for all clear pixels at nadir
+  0-12-181 |   2 |           0 |  16 | K                 | A11BN    ;     ; Averaged 11 micron BT for all clear pixels at nadir
+  0-12-182 |   2 |           0 |  16 | K                 | A37BN    ;     ; Averaged 3.7 micron BT for all clear pixels at nadir
+  0-12-183 |   2 |           0 |  16 | K                 | A12BF    ;     ; Averaged 12 micron BT for all clear pixels, forward view
+  0-12-184 |   2 |           0 |  16 | K                 | A11BF    ;     ; Averaged 11 micron BT for all clear pixels, forward view
+  0-12-185 |   2 |           0 |  16 | K                 | A37BF    ;     ; Averaged 3.7 micron BT for all clear pixels, forward view
+  0-12-186 |   2 |           0 |  16 | K                 | MNASST   ;     ; Mean nadir sea-surface temperature
+  0-12-187 |   2 |           0 |  16 | K                 | MDVSST   ;     ; Mean dual view sea-surface temperature
+  0-12-188 |   2 |           0 |  16 | K                 | I23P8B   ;     ; Interpolated 23.8 GHz brightness T from MWR
+  0-12-189 |   2 |           0 |  16 | K                 | I36P5B   ;     ; Interpolated 36.5 GHz brightness T from MWR
+  0-13-001 |   5 |           0 |  14 | kg kg**-1         | SPFH     ;     ; Specific humidity
+  0-13-002 |   5 |           0 |  14 | kg kg**-1         | MIXR     ;     ; Mixing ratio
+  0-13-003 |   0 |           0 |   7 | %                 | REHU     ;     ; Relative humidity
+  0-13-004 |  -1 |           0 |  10 | Pa                | VAPR     ;     ; Vapour pressure
+  0-13-005 |   3 |           0 |   7 | kg m**-3          | VADN     ;     ; Vapour density
+  0-13-006 |  -1 |         -40 |  16 | m                 | MIXH     ;     ; Mixing heights
+  0-13-007 |   0 |           0 |   7 | %                 | MIRH     ;     ; Minimum relative humidity
+  0-13-008 |   0 |           0 |   7 | %                 | MXRH     ;     ; Maximum relative humidity
+  0-13-009 |   1 |       -1000 |  12 | %                 | RAWHU    ;     ; Relative humidity
+  0-13-011 |   1 |          -1 |  14 | kg m**-2          | TOPC     ;     ; Total precipitation/total water equivalent
+  0-13-012 |   2 |          -2 |  12 | m                 | DOFS     ;     ; Depth of fresh snow
+  0-13-013 |   2 |          -2 |  16 | m                 | TOSD     ;     ; Total snow depth
+  0-13-014 |   4 |           0 |  12 | kg m**-2 s**-1    | REQV     ;     ; Rainfall/water equivalent of snow (averaged rate)
+  0-13-015 |   7 |           0 |  12 | m s**-1           | SNFLA    ;     ; Snowfall (averaged rate)
+  0-13-016 |   0 |           0 |   7 | kg m**-2          | TPWT     ;     ; Precipitable water
+  0-13-019 |   1 |          -1 |  14 | kg m**-2          | TP01     ;     ; Total precipitation past 1 hour
+  0-13-020 |   1 |          -1 |  14 | kg m**-2          | TP03     ;     ; Total precipitation past 3 hours
+  0-13-021 |   1 |          -1 |  14 | kg m**-2          | TP06     ;     ; Total precipitation past 6 hours
+  0-13-022 |   1 |          -1 |  14 | kg m**-2          | TP12     ;     ; Total precipitation past 12 hours
+  0-13-023 |   1 |          -1 |  14 | kg m**-2          | TP24     ;     ; Total precipitation past 24 hours
+  0-13-031 |   0 |           0 |   7 | kg m**-2          | EVTR     ;     ; Evapotranspiration
+  0-13-032 |   1 |           0 |   8 | kg m**-2          | EVAP     ;     ; Evaporation/evapotranspiration
+  0-13-033 |   1 |           0 |  10 | kg m**-2          | EVAP1    ;     ; Evaporation/evapotranspiration
+  0-13-038 |   0 |           0 |   2 | Code table        | SADF     ;     ; Superadiabatic indicator
+  0-13-039 |   0 |           0 |   3 | Code table        | TERN     ;     ; Terrain type (ice/snow)
+  0-13-040 |   0 |           0 |   4 | Code table        | SFLG     ;     ; Surface flag
+  0-13-041 |   0 |           0 |   4 | Code table        | PGSC     ;     ; Pasquill-Gifford stability category
+  0-13-042 |   0 |         -20 |   6 | K                 | PLFTI    ;     ; Parcel lifted index (to 500 hPa)
+  0-13-043 |   0 |         -20 |   6 | K                 | BLFTI    ;     ; Best lifted index (to 500 hPa)
+  0-13-044 |   0 |         -30 |   8 | K                 | KIND     ;     ; K index
+  0-13-045 |   0 |         -30 |   8 | K                 | KOIND    ;     ; KO index
+  0-13-046 |   0 |         -30 |   8 | K                 | MAXB     ;     ; Maximum buoyancy
+  0-13-047 |   0 |         -60 |   6 | K                 | STBS     ;     ; Modified Showalter stability index
+  0-13-048 |   1 |           0 |  10 | %                 | WFCN     ;     ; Water fraction
+  0-13-051 |   0 |           0 |   4 | Code table        | FRGP     ;     ; Frequency group, precipitation
+  0-13-052 |   1 |          -1 |  14 | kg m**-2          | HIDP     ;     ; Highest daily amount of precipitation
+  0-13-055 |   4 |           0 |   8 | kg m**-2 s**-1    | PRAT     ;     ; Intensity of precipitation
+  0-13-056 |   0 |           0 |   4 | Code table        | CIPR     ;     ; Character and intensity of precipitation
+  0-13-057 |   0 |           0 |   4 | Code table        | TBEPR    ;     ; Time of beginning or end of precipitation
+  0-13-058 |   4 |           0 |   7 | m                 | SOPE     ;     ; Size of precipitating element
+  0-13-059 |   0 |           0 |   7 | Numeric           | NOFL     ;     ; Number of flashes (thunderstorm)
+  0-13-060 |   1 |          -1 |  17 | kg m**-2          | TOAP     ;     ; Total accumulated precipitation
+  0-13-071 |   2 |           0 |  14 | m                 | UPWL     ;     ; Upstream water level
+  0-13-072 |   2 |           0 |  14 | m                 | DNWL     ;     ; Downstream water level
+  0-13-073 |   2 |           0 |  14 | m                 | MXWL     ;     ; Maximum water level
+  0-13-074 |   2 |           0 |  18 | m                 | GWLV     ;     ; Ground water level
+  0-13-080 |   1 |           0 |  10 | pH unit           | WAPH     ;     ; Water pH
+  0-13-081 |   3 |           0 |  14 | S m**-1           | WACN     ;     ; Water conductivity
+  0-13-082 |   1 |           0 |  12 | K                 | WATM     ;     ; Water temperature
+  0-13-083 |   6 |           0 |  15 | kg m**-3          | DOXY     ;     ; Dissolved oxygen
+  0-13-084 |   0 |           0 |  14 | lm                | TURBD    ;     ; Turbidity
+  0-13-085 |   3 |           0 |  14 | V                 | OXYRP    ;     ; Oxidation Reduction Potential (ORP)
+  0-13-090 |   1 |           0 |  10 | kg m**-2          | RWVC     ;     ; Radiometer water vapour content
+  0-13-091 |   2 |           0 |   8 | kg m**-2          | RLQC     ;     ; Radiometer liquid content
+  0-13-093 |   0 |           0 |   8 | Numeric           | COPT     ;     ; Cloud optical thickness
+  0-13-095 |   4 |           0 |  19 | kg m**-2          | TCWV     ;     ; Total column water vapour
+  0-13-096 |   2 |           0 |  14 | kg m**-2          | MRWVC    ;     ; MWR water vapour content
+  0-13-097 |   2 |           0 |  14 | kg m**-2          | MRLWC    ;     ; MWR liquid water content
+  0-13-098 |   8 |           0 |  30 | kg m**-2          | IWVD     ;     ; Integrated water vapour density
+  0-13-099 |   1 |           0 |   7 | log (m**-2)       | LTICPD   ;     ; Log10 of integrated cloud particle density
+  0-13-100 |   1 |         -70 |   7 | log (m**2 m**-2)  | LTICPA   ;     ; Log10 of integrated cloud particle area
+  0-13-101 |   1 |        -140 |   7 | log (m**3 m**-2)  | LTICPV   ;     ; Log10 of integrated cloud particle volume
+  0-13-109 |   3 |           0 |  10 | kg m**-2          | ILWP     ;     ; Ice/liquid water path
+  0-13-110 |   0 |           0 |   7 | %                 | MMXR     ;     ; Mass mixing ratio
+  0-13-111 |   0 |           0 |  10 | g kg**-1          | SMST     ;     ; Soil moisture
+  0-13-112 |   0 |           0 |  17 | s                 | OWDU     ;     ; Object wetness duration
+  0-13-114 |   1 |           0 |  11 | kg m**-2 h**-1    | ROIAV    ;     ; Rate of ice accretion
+  0-13-115 |   2 |           0 |  19 | m                 | ITHK     ;     ; Ice thickness
+  0-13-116 |   4 |           0 |  10 | m                 | WFTHK    ;     ; Water film thickness
+  0-13-117 |   0 |           0 |  10 | kg m**-3          | SDEN     ;     ; Snow density (liquid water content)
+  0-13-118 |   3 |          -2 |  14 | m                 | DOFSH    ;     ; Depth of fresh snow (high accuracy)
+  0-13-155 |   5 |          -1 |  16 | kg m**-2 s**-1    | PRATH    ;     ; Intensity of precipitation (high accuracy)
+  0-13-160 |   2 |        -350 |  10 | kg m**-2          | RDLC     ;     ; Radiometer liquid content
+  0-13-162 |   2 |           0 |   8 | kg m**-2          | CLWA     ;     ; Cloud liquid water
+  0-13-163 |   0 |           0 |  16 | kg m**-2          | SWEMS    ;     ; Snow water equivalent
+  0-13-164 |   3 |     -131072 |  18 | m                 | SIFB     ;     ; Sea ice freeboard
+  0-14-001 |  -3 |      -65536 |  17 | J m**-2           | LWR24    ;     ; Long-wave radiation, integrated over 24 hours
+  0-14-002 |  -3 |      -65536 |  17 | J m**-2           | LWRAD    ;     ; Long-wave radiation, integrated over period specified
+  0-14-003 |  -3 |      -65536 |  17 | J m**-2           | SWR24    ;     ; Short-wave radiation, integrated over 24 hours
+  0-14-004 |  -3 |      -65536 |  17 | J m**-2           | SWRAD    ;     ; Short-wave radiation, integrated over period specified
+  0-14-011 |  -3 |      -65536 |  17 | J m**-2           | NLWR24   ;     ; Net long-wave radiation, integrated over 24 hours
+  0-14-012 |  -3 |      -65536 |  17 | J m**-2           | NLWRAD   ;     ; Net long-wave radiation, integrated over period specified
+  0-14-013 |  -3 |      -65536 |  17 | J m**-2           | NSWR24   ;     ; Net short-wave radiation, integrated over 24 hours
+  0-14-014 |  -3 |      -65536 |  17 | J m**-2           | NSWRAD   ;     ; Net short-wave radiation, integrated over period specified
+  0-14-015 |  -4 |      -16384 |  15 | J m**-2           | NR24     ;     ; Net radiation, integrated over 24 hours
+  0-14-016 |  -4 |      -16384 |  15 | J m**-2           | NRAD     ;     ; Net radiation, integrated over period specified
+  0-14-017 |   0 |        -512 |  10 | W m**-2           | ILWRDP   ;     ; Instantaneous long-wave radiation
+  0-14-018 |   0 |       -2048 |  12 | W m**-2           | ISWRDP   ;     ; Instantaneous short-wave radiation
+  0-14-019 |   0 |           0 |   7 | %                 | SALB     ;     ; Surface albedo
+  0-14-020 |  -4 |           0 |  15 | J m**-2           | GSO24    ;     ; Global solar radiation, integrated over 24 hours
+  0-14-021 |  -4 |           0 |  15 | J m**-2           | GSORD    ;     ; Global solar radiation, integrated over period specified
+  0-14-022 |  -4 |           0 |  15 | J m**-2           | DFSO24   ;     ; Diffuse solar radiation, integrated over 24 hours
+  0-14-023 |  -4 |           0 |  15 | J m**-2           | DFSORDX  ;     ; Diffuse solar radiation, integrated over period specified
+  0-14-024 |  -4 |           0 |  15 | J m**-2           | DRSO24   ;     ; Direct solar radiation, integrated over 24 hours
+  0-14-025 |  -4 |           0 |  15 | J m**-2           | DRSORDX  ;     ; Direct solar radiation, integrated over period specified
+  0-14-026 |   0 |           0 |   7 | %                 | CLAL     ;     ; Albedo at the top of clouds
+  0-14-027 |   0 |           0 |   7 | %                 | ALBD     ;     ; Albedo
+  0-14-028 |  -2 |           0 |  20 | J m**-2           | GSORDH   ;     ; Global solar radiation (high accuracy), integrated over period specified
+  0-14-029 |  -2 |           0 |  20 | J m**-2           | DFSORD   ;     ; Diffuse solar radiation (high accuracy), integrated over period specified
+  0-14-030 |  -2 |           0 |  20 | J m**-2           | DRSORD   ;     ; Direct solar radiation (high accuracy), integrated over period specified
+  0-14-031 |   0 |           0 |  11 | Minute            | TOSS     ;     ; Total sunshine
+  0-14-032 |   0 |           0 |  10 | Hour              | TOSH     ;     ; Total sunshine
+  0-14-033 |   0 |           0 |   9 | %                 | TOSP     ;     ; Total sunshine
+  0-14-034 |   0 |           0 |  11 | Minute            | SOPS     ;     ; Sunshine over period specified
+  0-14-035 |   1 |           0 |  14 | W m**-2           | SRADF    ;     ; Solar radiation flux
+  0-14-042 |   0 |           0 |   7 | %                 | BDRF     ;     ; Bidirectional reflectance
+  0-14-043 |   4 |           0 |  23 | W m**-2 sr**-1 um**-1 | SCHRAD   ;     ; Channel radiance
+  0-14-044 |   7 |     -100000 |  22 | W m**-2 sr**-1 cm | SRAD     ;     ; Channel radiance
+  0-14-045 |   0 |           0 |  11 | W m**-2 sr**-1 cm | CHRAD    ;     ; Channel radiance
+  0-14-046 |   0 |       -5000 |  16 | W m**-2 sr**-1 m  | SCRA     ;     ; Scaled radiance
+  0-14-047 |   0 |           0 |  31 | W m**-2 sr**-1 m  | SMRA     ;     ; Scaled mean AVHRR radiance
+  0-14-048 |   0 |           0 |  31 | W m**-2 sr**-1 m  | SSDR     ;     ; Scaled standard deviation AVHRR radiance
+  0-14-049 |   7 |           0 |  22 | W m**-2 sr**-1 cm | NEDR     ;     ; Noise equivalent delta radiance
+  0-14-050 |   1 |           0 |  10 | %                 | EMMI     ;     ; Emissivity
+  0-14-051 |  -3 |           0 |  14 | J m**-2           | DRSOLH   ;     ; Direct solar radiation integrated over last hour
+  0-14-052 |  -2 |    -1048574 |  20 | J m**-2           | GUSR     ;     ; Global upward solar radiation, integrated over period specified
+  0-14-053 |  -2 |    -1048574 |  21 | J m**-2           | NETR     ;     ; Net radiation (high accuracy), integrated over period specified
+  0-14-054 |  -3 |           0 |  16 | J m**-2           | PSAR     ;     ; Photosynthetically active radiation, integrated over period specified
+  0-14-055 |   0 |      -32768 |  16 | Numeric           | SOAI     ;     ; Solar activity index
+  0-14-056 |   0 |           0 |  18 | Cd m**-2          | BKLU     ;     ; Background luminance
+  0-14-057 |  -2 |    -1048574 |  21 | J m**-2           | SHFX     ;     ; Soil heat flux
+  0-14-072 |   0 |    -4000000 |  23 | J m**-2           | GUVI     ;     ; Global UV irradiation
+  0-15-001 |   0 |           0 |  10 | DU                | OZON     ;     ; Total ozone
+  0-15-002 |   2 |           0 |  10 | Numeric           | AIRM     ;     ; Air mass (slant path at 22 km)
+  0-15-003 |   4 |           0 |   9 | Pa                | MOPP     ;     ; Measured ozone partial pressure (sounding)
+  0-15-004 |   3 |           0 |  11 | Numeric           | OSCF     ;     ; Ozone sounding correction factor (CF)
+  0-15-005 |   0 |           0 |  10 | DU                | OZOP     ;     ; Ozone p
+  0-15-006 |   5 |     1800000 |  20 | log (m**-3)       | LTNDA    ;     ; Log10 of number density of atmosphere
+  0-15-008 |   0 |           0 |  10 | Numeric           | MIXRV    ;     ; Significand of volumetric mixing ratio
+  0-15-009 |   5 |     1200000 |  20 | log (m**-3)       | LTNDO    ;     ; Log10 of number density of ozone
+  0-15-011 |   3 |       14000 |  13 | log (m**-2)       | LIED     ;     ; Log10 of integrated electron density
+  0-15-012 | -16 |           0 |   6 | m**-2             | TECP     ;     ; Total electron count per square metre
+  0-15-015 |   0 |           0 |  31 | Numeric           | MSCN     ;     ; Maximum image spectral component before normalization
+  0-15-020 |   8 |           0 |  21 | kg m**-2          | IOZD     ;     ; Integrated ozone density
+  0-15-021 |  11 |           0 |  31 | kg m**-2          | IMDENS   ;     ; Integrated mass density
+  0-15-022 |   1 |  -100000000 |  31 | kg m**-2          | NMDENS   ;     ; Extended integrated mass density
+  0-15-024 |   4 |           0 |  24 | Numeric           | OPTD     ;     ; Optical depth
+  0-15-025 |   0 |           0 |   4 | Code table        | TYPO     ;     ; Type of pollutant
+  0-15-026 |   9 |           0 |   9 | mol mol**-1       | COPO     ;     ; Concentration of pollutant
+  0-15-027 |   9 |           0 |  10 | kg m**-3          | COPOPM   ;     ; Concentration of pollutant
+  0-15-028 |   5 |           0 |  16 | Part per thousand | MFACDA   ;     ; Mole fraction of atmospheric constituent/pollutant in dry air
+  0-15-029 |   9 |           0 |  30 | m**-1             | EXCF     ;     ; Extinction coefficient
+  0-15-030 |   2 |       -1000 |  12 | Numeric           | ACIDX    ;     ; Aerosol contamination index
+  0-15-031 |   4 |       10000 |  15 | m                 | APDS     ;     ; Atmospheric path delay in satellite signal
+  0-15-032 |   4 |           0 |  10 | m                 | APDE     ;     ; Estimated error in atmospheric path delay
+  0-15-033 |   5 |      -10000 |  15 | m                 | PDDX     ;     ; Difference in path delays for limb views at extremes of scan
+  0-15-034 |   5 |           0 |  14 | m                 | PDDE     ;     ; Estimated error in path delay difference
+  0-15-035 |   4 |           0 |  14 | m                 | ZPDW     ;     ; Component of zenith path delay due to water vapour
+  0-15-036 |   3 |           0 |  19 | N units           | ARFR     ;     ; Atmospheric refractivity
+  0-15-037 |   8 |     -100000 |  23 | rad               | BNDA     ;     ; Bending angle
+  0-15-038 |   4 |           0 |  20 | m                 | PDNA     ;     ; Path delay due to neutral atmosphere
+  0-15-039 |   4 |           0 |  14 | m                 | SIMDENS  ;     ; Estimated error in neutral atmosphere path delay
+  0-15-041 |   2 |       -1200 |  14 | Numeric           | SDIN     ;     ; Sulphur dioxide index
+  0-15-042 |   2 |           0 |  14 | %                 | RELF     ;     ; Reflectance
+  0-15-045 |   2 |       -2000 |  15 | DU                | SDOX     ;     ; Sulphur dioxide
+  0-15-046 |   2 |       -1000 |  11 | Numeric           | VOLI     ;     ; Volcano contamination index
+  0-15-049 |   3 |       -2000 |  14 | Numeric           | AAWE     ;     ; Aerosol Angstrom wavelength exponent
+  0-15-051 |   0 |           0 |  18 | m                 | MOPR     ;     ; Meteorological optical range
+  0-15-052 |   1 |          60 |   6 | log (m**-3)       | LTNDAP1  ;     ; Log10 of number density of aerosol particles with diameter greater than 5 nm
+  0-15-053 |   2 |         600 |   9 | log (m**-3)       | LTNDAP2  ;     ; Log10 of number density of aerosol particles with diameter greater than 14 nm
+  0-15-054 |   2 |         550 |   9 | log (m**-3)       | LTNDAP3  ;     ; Log10 of number density of aerosol particles with diameter between 0.25 and 2.5 um
+  0-15-055 |   2 |           0 |   7 | Numeric           | NVAR     ;     ; Non volatile aerosol ratio
+  0-15-062 |   3 |       -1000 |  14 | Numeric           | AOTH     ;     ; Aerosol optical thickness
+  0-15-063 |   8 |           0 |  20 | m**-1 sr**-1      | ATBS     ;     ; Attenuated backscatter
+  0-15-064 |   8 |           0 |  20 | m**-1 sr**-1      | UNCATBS  ;     ; Uncertainty in attenuated backscatter
+  0-15-065 |   8 |           0 |  20 | m**-1 sr**-1      | PBSC     ;     ; Particle backscatter coefficient
+  0-15-066 |   8 |           0 |  20 | m**-1 sr**-1      | UNCPBSC  ;     ; Uncertainty in particle backscatter coefficient
+  0-15-067 |   8 |           0 |  20 | m**-1             | PEXC     ;     ; Particle extinction coefficient
+  0-15-068 |   8 |           0 |  20 | m**-1             | UNCPEXC  ;     ; Uncertainty in particle extinction coefficient
+  0-15-069 |   2 |           0 |  14 | sr                | PLIR     ;     ; Particle lidar ratio
+  0-15-070 |   2 |           0 |  14 | sr                | UNXPLIR  ;     ; Uncertainty in lidar ratio
+  0-15-071 |   2 |           0 |  14 | %                 | PDPR     ;     ; Particle depolarization ratio
+  0-15-072 |   2 |           0 |  14 | %                 | UNCPDPR  ;     ; Uncertainty in depolarization ratio
+  0-15-073 |   8 |     -524288 |  20 | m**-1 sr**-1      | ATBS2    ;     ; Attenuated backscatter
+  0-15-074 |   8 |     -524288 |  20 | m**-1 sr**-1      | PBSC2    ;     ; Particle backscatter coefficient
+  0-15-075 |   8 |     -524288 |  20 | m                 | PEXC2    ;     ; Particle extinction coefficient
+  0-15-076 |   1 |       -2048 |  13 | sr                | PLIR2    ;     ; Particle lidar ratio
+  0-15-077 |   1 |           0 |  12 | sr                | UNXPLIR2 ;     ; Uncertainty in lidar ratio
+  0-15-078 |   2 |       -8192 |  15 | %                 | PDPR2    ;     ; Particle depolarization ratio
+  0-15-079 |   4 |           0 |  15 | m                 | ZPDNA    ;     ; Zenith path delay due to neutral atmosphere
+  0-15-080 |   4 |           0 |  12 | m                 | ZPDNAE   ;     ; Estimated error in neutral atmosphere zenith path delay
+  0-15-081 |   4 |           0 |  18 | m                 | WPDNA    ;     ; Wet path delay due to neutral atmosphere
+  0-15-082 |   1 |           0 |  16 | kg m**-2          | PIWV     ;     ; Path integrated water vapour
+  0-15-083 |   5 |       -8192 |  14 | m                 | GNNAG    ;     ; GNSS derived neutral atmosphere gradient
+  0-15-084 |   4 |           0 |  14 | m                 | GNLSR    ;     ; GNSS least squares residual
+  0-15-085 |   4 |           0 |  14 | m                 | GNMPD    ;     ; GNSS multi-path delay
+  0-15-086 |   3 |           0 |  16 | Numeric           | GNHMF    ;     ; GNSS hydrostatic mapping function
+  0-15-087 |   3 |           0 |  16 | Numeric           | GNWMF    ;     ; GNSS wet mapping function
+  0-15-088 |   3 |           0 |  16 | Numeric           | GNGMF    ;     ; GNSS gradient mapping function
+  0-15-089 |   4 |           0 |  15 | m                 | ZPDNHA   ;     ; Zenith path delay due to neutral hydrostatic atmosphere
+  0-15-090 |   4 |           0 |  20 | m                 | PDNHA    ;     ; Path delay due to neutral hydrostatic atmosphere
+  0-19-001 |   0 |           0 |   6 | Code table        | STMFE1   ;     ; Type of synoptic feature
+  0-19-002 |  -2 |           0 |  12 | m                 | STMFE2   ;     ; Effective radius of feature
+  0-19-003 |   0 |           0 |   8 | m s**-1           | STMFE3   ;     ; Wind speed threshold
+  0-19-004 |  -2 |           0 |  12 | m                 | STMFE4   ;     ; Effective radius with respect to wind speeds above threshold
+  0-19-005 |   0 |           0 |   9 | Degree true       | STMFE5   ;     ; Direction of motion of feature
+  0-19-006 |   2 |           0 |  14 | m s**-1           | STMFE6   ;     ; Speed of motion of feature
+  0-19-007 |  -3 |           0 |  12 | m                 | STMFE7   ;     ; Effective radius of feature
+  0-19-008 |   0 |           0 |   3 | Code table        | STMFE8   ;     ; Vertical extent of circulation
+  0-19-009 |  -3 |           0 |  12 | m                 | STMFE9   ;     ; Effective radius with respect to wind speeds above threshold (large storms)
+  0-19-010 |   0 |           0 |   4 | Code table        | STMFE10  ;     ; Method for tracking the centre of synoptic feature
+  0-19-100 |   0 |           0 |   4 | Code table        | TIEC     ;     ; Time interval to calculate the movement of the tropical cyclone
+  0-19-101 |   0 |           0 |   4 | Code table        | APCE     ;     ; Accuracy of the position of the centre of the tropical cyclone
+  0-19-102 |   0 |           0 |   3 | Code table        | SDOE     ;     ; Shape and definition of the eye of the tropical cyclone
+  0-19-103 |   0 |           0 |   4 | Code table        | DMAE     ;     ; Diameter of major axis of the eye of the tropical cyclone
+  0-19-104 |   0 |           0 |   4 | Code table        | CE30     ;     ; Change in character of the eye during the 30 minutes
+  0-19-105 |   0 |           0 |   4 | Code table        | DOBC     ;     ; Distance between the end of spiral band and the centre
+  0-19-106 |   0 |           0 |   7 | Numeric           | INTC     ;     ; Identification number of tropical cyclone
+  0-19-107 |   0 |           0 |   4 | Code table        | TIMC     ;     ; Time interval over which the movement of the tropical cyclone has been calculated
+  0-19-108 |   0 |           0 |   3 | Code table        | AGPC     ;     ; Accuracy of geographical position of the tropical cyclone
+  0-19-109 |   0 |           0 |   4 | Code table        | MWFC     ;     ; Mean diameter of the overcast cloud of the tropical cyclone
+  0-19-110 |   0 |           0 |   4 | Code table        | A24C     ;     ; Apparent 24-hour change in intensity of the tropical cyclone
+  0-19-111 |   1 |           0 |   7 | Numeric           | IOTC     ;     ; Current Intensity (CI) number of the tropical cyclone
+  0-19-112 |   1 |           0 |   7 | Numeric           | DTNC     ;     ; Data Tropical (DT) number of the tropical cyclone
+  0-19-113 |   0 |           0 |   4 | Code table        | CPDT     ;     ; Cloud pattern type of the DT-number
+  0-19-114 |   1 |           0 |   7 | Numeric           | METN     ;     ; Model Expected Tropical (MET) number of the tropical cyclone
+  0-19-115 |   1 |         -30 |   6 | Numeric           | T24C     ;     ; Trend of the past 24-hour change (+: Developed, -: Weakened)
+  0-19-116 |   1 |           0 |   7 | Numeric           | PTNC     ;     ; Pattern Tropical (PT) number of the tropical cyclone
+  0-19-117 |   0 |           0 |   3 | Code table        | CPPT     ;     ; Cloud picture type of the PT-number
+  0-19-118 |   1 |           0 |   7 | Numeric           | FTNC     ;     ; Final Tropical (T) number of the tropical cyclone
+  0-19-119 |   0 |           0 |   3 | Code table        | TFTN     ;     ; Type of the final T-number
+  0-19-150 |   0 |           0 |  32 | CCITT IA5         | TICN     ;     ; Typhoon International Common Number (Typhoon Committee)
+  0-20-001 |  -1 |           0 |  13 | m                 | HOVI     ;     ; Horizontal visibility
+  0-20-002 |  -1 |           0 |   7 | m                 | VTVI     ;     ; Vertical visibility
+  0-20-003 |   0 |           0 |   9 | Code table        | PRWE     ;     ; Present weather
+  0-20-004 |   0 |           0 |   5 | Code table        | PSW1     ;     ; Past weather (1)
+  0-20-005 |   0 |           0 |   5 | Code table        | PSW2     ;     ; Past weather (2)
+  0-20-006 |   0 |           0 |   3 | Code table        | FLTR     ;     ; Flight rules
+  0-20-008 |   0 |           0 |   5 | Code table        | CDFA     ;     ; Cloud distribution for aviation
+  0-20-009 |   0 |           0 |   4 | Code table        | GWEI     ;     ; General weather indicator (TAF/METAR)
+  0-20-010 |   0 |           0 |   7 | %                 | TOCC     ;     ; Cloud cover (total)
+  0-20-011 |   0 |           0 |   4 | Code table        | CLAM     ;     ; Cloud amount
+  0-20-012 |   0 |           0 |   6 | Code table        | CLTP     ;     ; Cloud type
+  0-20-013 |  -1 |         -40 |  11 | m                 | HOCB     ;     ; Height of base of cloud
+  0-20-014 |  -1 |         -40 |  11 | m                 | HOCT     ;     ; Height of top of cloud
+  0-20-015 |  -1 |           0 |  14 | Pa                | CDBP     ;     ; Pressure at base of cloud
+  0-20-016 |  -1 |           0 |  14 | Pa                | CDTP     ;     ; Pressure at top of cloud
+  0-20-017 |   0 |           0 |   4 | Code table        | CTDS     ;     ; Cloud top description
+  0-20-018 |   0 |           0 |   2 | Code table        | RWYT     ;     ; Tendency of runway visual range
+  0-20-019 |   0 |           0 |  72 | CCITT IA5         | SPRWE    ;     ; Significant present or forecast weather
+  0-20-020 |   0 |           0 |  32 | CCITT IA5         | SREWE    ;     ; Significant recent weather phenomena
+  0-20-021 |   0 |           0 |  30 | Flag table        | PRTP     ;     ; Type of precipitation
+  0-20-022 |   0 |           0 |   4 | Code table        | PRCH     ;     ; Character of precipitation
+  0-20-023 |   0 |           0 |  18 | Flag table        | OWEP     ;     ; Other weather phenomena
+  0-20-024 |   0 |           0 |   3 | Code table        | INTP     ;     ; Intensity of phenomena
+  0-20-025 |   0 |           0 |  21 | Flag table        | OBSC     ;     ; Obscuration
+  0-20-026 |   0 |           0 |   4 | Code table        | OBCH     ;     ; Character of obscuration
+  0-20-027 |   0 |           0 |   9 | Flag table        | PHEO     ;     ; Phenomena occurrence
+  0-20-028 |   0 |           0 |   3 | Code table        | ECIN     ;     ; Expected change in intensity
+  0-20-029 |   0 |           0 |   2 | Code table        | RFLAG    ;     ; Rain flag
+  0-20-031 |   2 |           0 |   7 | m                 | IDTH     ;     ; Ice deposit (thickness)
+  0-20-032 |   0 |           0 |   3 | Code table        | ROIA     ;     ; Rate of ice accretion (estimated)
+  0-20-033 |   0 |           0 |   4 | Flag table        | COIA     ;     ; Cause of ice accretion
+  0-20-034 |   0 |           0 |   5 | Code table        | SICE     ;     ; Sea ice concentration
+  0-20-035 |   0 |           0 |   4 | Code table        | AICE     ;     ; Amount and type of ice
+  0-20-036 |   0 |           0 |   5 | Code table        | ICESI    ;     ; Ice situation
+  0-20-037 |   0 |           0 |   5 | Code table        | ICEDV    ;     ; Ice development
+  0-20-038 |   0 |           0 |  12 | Degree true       | BOIE     ;     ; Bearing of ice edge
+  0-20-039 |  -1 |           0 |  13 | m                 | ICEDS    ;     ; Ice distance
+  0-20-040 |   0 |           0 |   4 | Code table        | EDRS     ;     ; Evolution of drift snow
+  0-20-041 |   0 |           0 |   4 | Code table        | AFIC     ;     ; Airframe icing
+  0-20-042 |   0 |           0 |   2 | Code table        | AFICP    ;     ; Airframe icing present
+  0-20-043 |   4 |           0 |   7 | kg m**-3          | PLWC     ;     ; Peak liquid water content
+  0-20-044 |   4 |           0 |   7 | kg m**-3          | ALWC     ;     ; Average liquid water content
+  0-20-045 |   0 |           0 |   2 | Code table        | SCLD     ;     ; Supercooled large droplet (SLD) conditions
+  0-20-048 |   0 |           0 |   4 | Code table        | EVFE     ;     ; Evolution of feature
+  0-20-050 |   0 |           0 |   8 | Code table        | CLDI     ;     ; Cloud index
+  0-20-051 |   0 |           0 |   7 | %                 | LCLD     ;     ; Amount of low clouds
+  0-20-052 |   0 |           0 |   7 | %                 | MCLD     ;     ; Amount of middle clouds
+  0-20-053 |   0 |           0 |   7 | %                 | HCLD     ;     ; Amount of high clouds
+  0-20-054 |   0 |           0 |   9 | Degree true       | TDCM     ;     ; True direction from which a phenomenon or clouds are moving or in which they are observed
+  0-20-055 |   0 |           0 |   4 | Code table        | STST     ;     ; State of sky in the tropics
+  0-20-056 |   0 |           0 |   3 | Code table        | CLDP     ;     ; Cloud phase
+  0-20-058 |  -1 |           0 |  13 | m                 | VSCS     ;     ; Visibility seawards from a coastal station
+  0-20-059 |  -1 |           0 |   9 | m                 | MINHV    ;     ; Minimum horizontal visibility
+  0-20-060 |  -1 |           0 |  10 | m                 | PRVHV    ;     ; Prevailing horizontal visibility
+  0-20-061 |   0 |           0 |  12 | m                 | V1RIM    ;     ; Runway visual range (RVR)
+  0-20-062 |   0 |           0 |   5 | Code table        | SOGR     ;     ; State of the ground (with or without snow)
+  0-20-063 |   0 |           0 |  10 | Code table        | PHES     ;     ; Special phenomena
+  0-20-065 |   0 |           0 |   7 | %                 | SNOC     ;     ; Snow cover
+  0-20-066 |   3 |           0 |   8 | m                 | MXDH     ;     ; Maximum diameter of hailstones
+  0-20-067 |   3 |           0 |   9 | m                 | DIAD     ;     ; Diameter of deposit
+  0-20-070 |   0 |           0 |   7 | Numeric           | MINA     ;     ; Minimum number of atmospherics
+  0-20-071 |   0 |           0 |   4 | Code table        | AFRA     ;     ; Accuracy of fix and rate of atmospherics
+  0-20-081 |   0 |           0 |   7 | %                 | CLDMNT   ;     ; Cloud amount in segment
+  0-20-082 |   0 |           0 |   7 | %                 | NCLDMNT  ;     ; Amount segment cloud free
+  0-20-083 |   0 |           0 |   7 | %                 | ASCS     ;     ; Amount of segment covered by scene
+  0-20-085 |   0 |           0 |   4 | Code table        | GCRW     ;     ; General condition of runway
+  0-20-086 |   0 |           0 |   4 | Code table        | RWDP     ;     ; Runway deposits
+  0-20-087 |   0 |           0 |   4 | Code table        | RWCT     ;     ; Runway contamination
+  0-20-088 |   3 |           0 |  12 | m                 | DRWD     ;     ; Depth of runway deposits
+  0-20-089 |   0 |           0 |   7 | Code table        | RWFC     ;     ; Runway friction coefficient
+  0-20-090 |   0 |           0 |   4 | Code table        | SPCL     ;     ; Special clouds
+  0-20-091 |  -2 |           0 |  10 | ft                | VTVIF    ;     ; Vertical visibility
+  0-20-092 |  -2 |           0 |  10 | ft                | HOCBF    ;     ; Height of base of cloud
+  0-20-093 |  -1 |           0 |   8 | m                 | HGOB     ;     ; Height of inversion
+  0-20-095 |   3 |           0 |  10 | Numeric           | ICEP     ;     ; Ice probability
+  0-20-096 |   2 |       -4096 |  13 | dB                | ICEA     ;     ; Ice age ("A" parameter)
+  0-20-101 |   0 |           0 |   4 | Code table        | LONA     ;     ; Locust (acridian) name
+  0-20-102 |   0 |           0 |   4 | Code table        | LOCO     ;     ; Locust (maturity) colour
+  0-20-103 |   0 |           0 |   4 | Code table        | SDLO     ;     ; Stage of development of locusts
+  0-20-104 |   0 |           0 |   4 | Code table        | OSLO     ;     ; Organization state of swarm or band of locusts
+  0-20-105 |   0 |           0 |   4 | Code table        | SSLO     ;     ; Size of swarm or band of locusts and duration of passage of swarm
+  0-20-106 |   0 |           0 |   4 | Code table        | LOPD     ;     ; Locust population density
+  0-20-107 |   0 |           0 |   4 | Code table        | DMLO     ;     ; Direction of movements of locust swarm
+  0-20-108 |   0 |           0 |   4 | Code table        | EXTV     ;     ; Extent of vegetation
+  0-20-111 |  -1 |           0 |  17 | m                 | XEEM     ;     ; x-axis error ellipse major component
+  0-20-112 |  -1 |           0 |  17 | m                 | YEEM     ;     ; y-axis error ellipse minor component
+  0-20-113 |  -1 |           0 |  17 | m                 | ZEEM     ;     ; z-axis error ellipse component
+  0-20-114 |   2 |      -18000 |  16 | Degree            | AXEE     ;     ; Angle of x-axis in error ellipse
+  0-20-115 |   2 |      -18000 |  16 | Degree            | AZEE     ;     ; Angle of z-axis in error ellipse
+  0-20-116 |   0 |           0 |  16 | m                 | EHCS     ;     ; Emission height of cloud stroke
+  0-20-117 |  -1 |      -32000 |  16 | A                 | AMPLS    ;     ; Amplitude of lightning strike
+  0-20-118 |   0 |           0 |  19 | m                 | LTDE     ;     ; Lightning detection error
+  0-20-119 |   0 |           0 |   2 | Code table        | PLRTS    ;     ; Lightning discharge polarity
+  0-20-121 |   3 |           0 |  16 | V                 | TVPDV    ;     ; Threshold value for polarity decision
+  0-20-122 |   0 |           0 |  16 | A                 | TVPDA    ;     ; Threshold value for polarity decision
+  0-20-123 |   3 |           0 |  16 | V m**-1           | MTFD     ;     ; Minimum threshold for detection
+  0-20-124 |   0 |           0 |   2 | Code table        | LSOR     ;     ; Lightning stroke or flash
+  0-20-126 |   0 |           0 |  23 | h**-1             | LROD     ;     ; Lightning rate of discharge
+  0-20-127 |  -3 |           0 |   8 | m                 | LDFS     ;     ; Lightning - distance from station
+  0-20-128 |   1 |           0 |  12 | Degree true       | LRFS     ;     ; Lightning - direction from station
+  0-20-129 |   6 |           0 |  10 | m**-2             | LDENS    ;     ; Lightning density (stroke, flash or event)
+  0-20-130 |   0 |           0 |  10 | Numeric           | CHMC     ;     ; Cloud hydrometeor concentration
+  0-20-131 |   5 |           0 |   6 | m                 | ERCH     ;     ; Effective radius of cloud hydrometeors
+  0-20-132 |   5 |           0 |  11 | kg m**-3          | CLWC     ;     ; Cloud liquid water content
+  0-20-133 |   5 |           0 |   6 | m                 | HYMR     ;     ; Hydrometeor radius
+  0-20-135 |   1 |           0 |  10 | kg m**-1          | ICEM     ;     ; Ice mass (on a rod)
+  0-20-136 |   0 |           0 |   9 | Code table        | SUCT     ;     ; Supplementary cloud type
+  0-20-137 |   0 |           0 |   4 | Code table        | EVOC     ;     ; Evolution of clouds
+  0-20-138 |   0 |           0 |   4 | Code table        | ROADSC   ;     ; Road surface condition
+  0-21-001 |   0 |         -64 |   7 | dB                | HREF     ;     ; Horizontal reflectivity
+  0-21-002 |   0 |         -64 |   7 | dB                | VREF     ;     ; Vertical reflectivity
+  0-21-003 |   1 |          -5 |   7 | dB                | DREF     ;     ; Differential reflectivity
+  0-21-004 |   2 |        -800 |  11 | dB                | DREF2    ;     ; Differential reflectivity
+  0-21-005 |   0 |         -65 |   6 | dB                | LDPR     ;     ; Linear depolarization ratio
+  0-21-006 |   0 |         -65 |   6 | dB                | CDPR     ;     ; Circular depolarization ratio
+  0-21-007 |   2 |       -9000 |  15 | dB                | REFF     ;     ; Radar reflectivity factor
+  0-21-008 |   2 |           0 |  13 | dB                | UREFF    ;     ; Uncertainty in radar reflectivity factor
+  0-21-009 |   2 |      -10000 |  15 | m s**-1           | VDVY     ;     ; Vertical Doppler velocity
+  0-21-010 |   2 |      -10000 |  15 | m s**-1           | UVDVY    ;     ; Uncertainty in vertical Doppler velocity
+  0-21-011 |   0 |        -128 |   8 | m s**-1           | DMVX     ;     ; Doppler mean velocity in x-direction
+  0-21-012 |   0 |        -128 |   8 | m s**-1           | DMVY     ;     ; Doppler mean velocity in y-direction
+  0-21-013 |   0 |        -128 |   8 | m s**-1           | DMVZ     ;     ; Doppler mean velocity in z-direction
+  0-21-014 |   1 |       -4096 |  13 | m s**-1           | DMVR     ;     ; Doppler mean velocity (radial)
+  0-21-017 |   1 |           0 |   8 | m s**-1           | DVSW     ;     ; Doppler velocity spectral width
+  0-21-018 |   1 |           0 |  10 | m s**-1           | XNQV     ;     ; Extended NYQUIST velocity
+  0-21-019 |   1 |           0 |  10 | m s**-1           | HNQV     ;     ; High NYQUIST velocity
+  0-21-021 |  -3 |           0 |   4 | m                 | ECHT     ;     ; Echo tops
+  0-21-022 |   1 |           0 |  14 | m                 | RNBO     ;     ; Range bin offset
+  0-21-023 |   0 |           0 |  14 | m                 | RNBS     ;     ; Range bin size
+  0-21-024 |   1 |           0 |  12 | Degree            | AZOF     ;     ; Azimuth offset
+  0-21-025 |   1 |           0 |   8 | Degree            | AZRS     ;     ; Azimuthal resolution
+  0-21-028 |   1 |           0 |  12 | Degree            | DFPH     ;     ; Differential phase
+  0-21-029 |   2 |        -100 |   8 | Numeric           | CPCC     ;     ; Cross-polarization correlation coefficient
+  0-21-030 |   0 |         -32 |   8 | dB                | STNR     ;     ; Signal to noise ratio
+  0-21-031 |   0 |           0 |   7 | kg m**-2          | VILWC    ;     ; Vertically integrated liquid-water content
+  0-21-036 |   7 |           0 |  12 | m s**-1           | RRFI     ;     ; Radar rainfall intensity
+  0-21-041 |  -2 |           0 |   8 | m                 | BBHT     ;     ; Bright-band height
+  0-21-051 |   0 |        -256 |   8 | dB                | SGPW     ;     ; Signal power above 1 mW
+  0-21-062 |   2 |       -5000 |  13 | dB                | BKST     ;     ; Backscatter
+  0-21-063 |   1 |           0 |  10 | %                 | RARE     ;     ; Radiometric resolution (noise value)
+  0-21-064 |   0 |           0 |   8 | Numeric           | CLNE     ;     ; Clutter noise estimate
+  0-21-065 |   0 |        -127 |   8 | Numeric           | MPCN     ;     ; Missing packet counter
+  0-21-066 |   0 |           0 |  12 | Flag table        | WSPC     ;     ; Wave scatterometer product confidence data
+  0-21-067 |   0 |           0 |  13 | Flag table        | WSPC2    ;     ; Wind product confidence data
+  0-21-068 |   0 |           0 |   8 | Flag table        | RAPC     ;     ; Radar altimeter product confidence data
+  0-21-069 |   0 |           0 |  10 | Flag table        | SSPC     ;     ; SST product confidence data
+  0-21-070 |   0 |           0 |  23 | Flag table        | SSPC2    ;     ; SST product confidence data (SADIST-2)
+  0-21-071 |   0 |           0 |  16 | Numeric           | PEAK     ;     ; Peakiness
+  0-21-072 |   0 |           0 |   4 | Flag table        | SACS     ;     ; Satellite altimeter calibration status
+  0-21-073 |   0 |           0 |   9 | Flag table        | SAIM     ;     ; Satellite altimeter instrument mode
+  0-21-075 |   0 |           0 |   8 | Numeric           | SPIN     ;     ; Image spectrum intensity
+  0-21-076 |   0 |           0 |   3 | Code table        | REIN     ;     ; Representation of intensities
+  0-21-077 |   3 |           0 |  14 | m                 | ACIO     ;     ; Altitude correction (ionosphere)
+  0-21-078 |   3 |           0 |   9 | m                 | ACDT     ;     ; Altitude correction (dry troposphere)
+  0-21-079 |   3 |        2000 |  10 | m                 | ACWT     ;     ; Altitude correction (wet troposphere)
+  0-21-080 |   3 |           0 |  11 | m                 | ACCC     ;     ; Altitude correction (calibration constant)
+  0-21-081 |   3 |           0 |  10 | m                 | OLCH     ;     ; Open loop correction (height-time loop)
+  0-21-082 |   3 |       -3000 |  14 | dB                | OLCA     ;     ; Open loop correction (auto gain control)
+  0-21-083 |   0 |           0 |  16 | Numeric           | WTCA     ;     ; Warm target calibration
+  0-21-084 |   0 |           0 |  16 | Numeric           | CTCA     ;     ; Cold target calibration
+  0-21-085 |   0 |           0 |   4 | Numeric           | ATSR     ;     ; ATSR sea-surface temperature across-track band number
+  0-21-086 |   0 |           0 |   9 | Numeric           | NPNA     ;     ; Number of pixels in nadir only, average
+  0-21-087 |   0 |           0 |   9 | Numeric           | NPDA     ;     ; Number of pixels in dual view, average
+  0-21-088 |   2 |       -5000 |  13 | dB                | WBKS     ;     ; Wet backscatter
+  0-21-091 |   0 |        -100 |   8 | dB                | SPP0     ;     ; Radar signal Doppler spectrum 0th moment
+  0-21-092 |   0 |        -100 |   8 | dB                | RPP0     ;     ; RASS signal Doppler spectrum 0th moment, referring to RASS signal
+  0-21-093 |   3 |           0 |  16 | Numeric           | KUBP     ;     ; Ku band peakiness
+  0-21-094 |   3 |           0 |  16 | Numeric           | SBPK     ;     ; S band peakiness
+  0-21-095 |   6 |           0 |  20 | Numeric           | KPCA     ;     ; Kp coefficient A
+  0-21-096 |   6 |           0 |  20 | Numeric           | KPCB     ;     ; Kp coefficient B
+  0-21-097 |   6 |           0 |  20 | Numeric           | KPCC     ;     ; Kp coefficient C
+  0-21-101 |   0 |           0 |   3 | Numeric           | NWVA     ;     ; Number of vector ambiguities
+  0-21-102 |   0 |           0 |   3 | Numeric           | ISWV     ;     ; Index of selected wind vector
+  0-21-103 |   0 |           0 |   5 | Numeric           | TNSM     ;     ; Total number of sigma-0 measurements
+  0-21-104 |   3 |      -30000 |  15 | Numeric           | LKCS     ;     ; Likelihood computed for solution
+  0-21-105 |   2 |      -10000 |  14 | dB                | NRCS     ;     ; Normalized radar cross-section
+  0-21-106 |   3 |           0 |  14 | Numeric           | KVCA     ;     ; Kp variance coefficient (alpha)
+  0-21-107 |   8 |           0 |  16 | Numeric           | KVCB     ;     ; Kp variance coefficient (beta)
+  0-21-109 |   0 |           0 |  17 | Flag table        | SWVQ     ;     ; SEAWINDS wind vector cell quality
+  0-21-110 |   0 |           0 |   6 | Numeric           | NIBF     ;     ; Number of inner-beam sigma-0 (forward of satellite)
+  0-21-111 |   0 |           0 |   6 | Numeric           | NOBF     ;     ; Number of outer-beam sigma-0 (forward of satellite)
+  0-21-112 |   0 |           0 |   6 | Numeric           | NIBA     ;     ; Number of inner-beam sigma-0 (aft of satellite)
+  0-21-113 |   0 |           0 |   6 | Numeric           | NOBA     ;     ; Number of outer-beam sigma-0 (aft of satellite)
+  0-21-114 |   3 |     -140000 |  18 | dB                | KVCG     ;     ; Kp variance coefficient (gamma)
+  0-21-115 |   0 |           0 |  17 | Flag table        | SSQU     ;     ; SEAWINDS sigma-0 quality
+  0-21-116 |   0 |           0 |  17 | Flag table        | SSMD     ;     ; SEAWINDS sigma-0 mode
+  0-21-117 |   2 |           0 |  16 | Numeric           | SVQC     ;     ; Sigma-0 variance quality control
+  0-21-118 |   2 |      -10000 |  14 | dB                | ACRS     ;     ; Attenuation correction on sigma-0
+  0-21-119 |   0 |           0 |   6 | Code table        | WSGF     ;     ; Wind scatterometer geophysical model function
+  0-21-120 |   3 |           0 |  10 | Numeric           | SPRR     ;     ; Probability of rain
+  0-21-121 |   0 |           0 |   8 | Numeric           | SNRI     ;     ; SEAWINDS NOF rain index
+  0-21-122 |   2 |      -10000 |  14 | dB                | ACST     ;     ; Attenuation correction on sigma-0 (from tB)
+  0-21-123 |   2 |      -30000 |  15 | dB                | SNRCS    ;     ; SEAWINDS normalized radar cross-section
+  0-21-128 |   0 |           0 |   8 | Numeric           | NVPP     ;     ; Number of valid points per second used to derive previous parameters
+  0-21-130 |   6 |           0 |  28 | Numeric           | STOE     ;     ; Spectrum total energy
+  0-21-131 |   6 |           0 |  28 | Numeric           | SMXE     ;     ; Spectrum max energy
+  0-21-132 |   3 |           0 |  19 | Degree            | DSXH     ;     ; Direction of spectrum max on higher resolution grid
+  0-21-133 |   3 |           0 |  29 | m                 | WSXH     ;     ; Wavelength of spectrum max on higher resolution grid
+  0-21-134 |   3 |           0 |  19 | rad m**-1         | RRCC     ;     ; Range resolution of cress covariance spectrum
+  0-21-135 |   3 |     -524288 |  20 | Numeric           | RCPN     ;     ; Real part of cross spectra polar grid number of bins
+  0-21-136 |   3 |     -524288 |  20 | Numeric           | ICPN     ;     ; Imaginary part of cross spectra polar grid number of bins
+  0-21-137 |   2 |      -32768 |  16 | dB                | KOBC     ;     ; Ku band corrected ocean backscatter coefficient
+  0-21-138 |   2 |      -32768 |  16 | dB                | SKOBC    ;     ; Std Ku band corrected ocean backscatter coefficient
+  0-21-139 |   2 |       -2048 |  12 | dB                | KNIC     ;     ; Ku band net instrumental correction for AGC
+  0-21-140 |   2 |      -32768 |  16 | dB                | SOBC     ;     ; S band corrected ocean backscatter coefficient
+  0-21-141 |   2 |      -32768 |  16 | dB                | SSOBC    ;     ; Std S band corrected ocean backscatter coefficient
+  0-21-142 |   2 |       -1024 |  11 | dB                | SNIC     ;     ; S band net instrumental correction for AGC
+  0-21-143 |   2 | -1073741824 |  31 | dB                | KRAT     ;     ; Ku band rain attenuation
+  0-21-144 |   0 |           0 |   2 | Flag table        | ALRF     ;     ; Altimeter rain flag
+  0-21-145 |   2 |           0 |  13 | dB                | KAGC     ;     ; Ku band automatic gain control
+  0-21-146 |   2 |           0 |   8 | dB                | RKAGC    ;     ; RMS Ku band automatic gain control
+  0-21-147 |   0 |           0 |   5 | Numeric           | NVKG     ;     ; Number of valid points for Ku band automatic gain control
+  0-21-148 |   0 |           0 |   9 | Flag table        | TEVF     ;     ; Trailing edge variation flag
+  0-21-150 |   0 |           0 |   2 | Code table        | BEAMC    ;     ; Beam co-location
+  0-21-151 |   2 |           0 |   9 | dB                | EES40    ;     ; Estimated error in sigma-0 at 40 degrees incidence angle
+  0-21-152 |   2 |         -80 |   7 | dB degree**-1     | S40IA    ;     ; Slope at 40 degrees incidence angle
+  0-21-153 |   2 |         -40 |   6 | dB degree**-1     | EEL40    ;     ; Estimated error in slope at 40 degrees incidence angle
+  0-21-154 |   2 |           0 |  12 | dB                | SMOS     ;     ; Soil moisture sensitivity
+  0-21-155 |   0 |           0 |  24 | Flag table        | WVCQ     ;     ; Wind vector cell quality
+  0-21-156 |   1 |       -4096 |  13 | Numeric           | BSCD     ;     ; Backscatter distance
+  0-21-157 |  10 |           0 |  22 | dB m**-1          | LULAU    ;     ; Loss per unit length of atmosphere used
+  0-21-158 |   0 |           0 |   2 | Code table        | AKPEQ    ;     ; ASCAT Kp estimate quality
+  0-21-159 |   0 |           0 |   2 | Code table        | ASGU     ;     ; ASCAT sigma-0 usability
+  0-21-160 |   3 |           0 |  10 | Numeric           | AUSY     ;     ; ASCAT use of synthetic data
+  0-21-161 |   3 |           0 |  10 | Numeric           | ASDQ     ;     ; ASCAT synthetic data quantity
+  0-21-162 |   3 |           0 |  10 | Numeric           | ASOAQ    ;     ; ASCAT satellite orbit and attitude quality
+  0-21-163 |   3 |           0 |  10 | Numeric           | ASARC    ;     ; ASCAT solar array reflection contamination
+  0-21-164 |   3 |           0 |  10 | Numeric           | ATPQ     ;     ; ASCAT telemetry presence and quality
+  0-21-165 |   3 |           0 |  10 | Numeric           | AERFP    ;     ; ASCAT extrapolated reference function presence
+  0-21-166 |   3 |           0 |  10 | Numeric           | ALFR     ;     ; Land fraction
+  0-21-169 |   0 |           0 |   2 | Code table        | IPIN     ;     ; Ice presence indicator
+  0-21-170 |   2 |      -32768 |  16 | dB                | CCOB     ;     ; C band corrected ocean backscatter coefficient
+  0-21-171 |   2 |      -32768 |  16 | dB                | RCCOB    ;     ; RMS C band corrected ocean backscatter coefficient
+  0-21-172 |   2 |       -2048 |  12 | dB                | CNIA     ;     ; C band net instrumental correction for AGC
+  0-21-173 |   2 |           0 |  13 | dB                | CAGC     ;     ; C band automatic gain control
+  0-21-174 |   2 |           0 |   9 | dB                | RCAGC    ;     ; RMS C band automatic gain control
+  0-21-175 |   0 |           0 |  10 | Numeric           | NVPCA    ;     ; Number of valid points for C band automatic gain control
+  0-21-176 |   3 |           0 |  16 | m                 | HFVC     ;     ; High frequency variability correction
+  0-21-177 |   2 |           0 |  16 | dB                | CGBC     ;     ; Corrected OCOG backscatter coefficient
+  0-21-178 |   2 |           0 |  16 | dB                | S20GBC   ;     ; STD of 20 Hz OCOG backscatter coefficient
+  0-21-179 |   0 |           0 |  16 | Numeric           | N20GBC   ;     ; Number of 20 Hz valid points for OCOG backscatter coefficient
+  0-21-180 |   0 |           0 |   8 | Numeric           | N20NBC   ;     ; Number of 20 Hz valid points for ocean backscatter coefficient
+  0-21-181 |   2 |           0 |  16 | dB                | BC20     ;     ; 20 Hz ocean backscatter coefficient
+  0-21-182 |   3 |           0 |  16 | Numeric           | PK20     ;     ; 20 Hz Ku band peakiness
+  0-21-183 |   2 |      -32768 |  16 | dB                | COBC     ;     ; Specific band corrected ocean backscatter coefficient
+  0-21-184 |   2 |      -32768 |  16 | dB                | SCOBC    ;     ; STD specific band corrected ocean backscatter coefficient
+  0-21-185 |   2 |       -2048 |  12 | dB                | NIAGC    ;     ; Specific band net instrumental correction for AGC
+  0-21-186 |   2 |           0 |  13 | dB                | SAGC     ;     ; Specific band automatic gain control
+  0-21-187 |   2 |           0 |   8 | dB                | RMSAGC   ;     ; RMS specific band automatic gain control
+  0-21-188 |   0 |           0 |   7 | Numeric           | NVPAGC   ;     ; Number of valid points for specific band automatic gain control
+  0-21-189 |   2 |      -32768 |  16 | dB                | CGBC2    ;     ; Corrected OCOG backscatter coefficient
+  0-22-001 |   0 |           0 |   9 | Degree true       | DOWA     ;     ; Direction of waves
+  0-22-002 |   0 |           0 |   9 | Degree true       | DOWW     ;     ; Direction of wind waves
+  0-22-003 |   0 |           0 |   9 | Degree true       | DOSW     ;     ; Direction of swell waves
+  0-22-004 |   0 |           0 |   9 | Degree true       | DROC     ;     ; Direction of current
+  0-22-005 |   0 |           0 |   9 | Degree true       | DSSC     ;     ; Direction of sea-surface current
+  0-22-011 |   0 |           0 |   6 | s                 | POWV     ;     ; Period of waves
+  0-22-012 |   0 |           0 |   6 | s                 | POWW     ;     ; Period of wind waves
+  0-22-013 |   0 |           0 |   6 | s                 | POSW     ;     ; Period of swell waves
+  0-22-021 |   1 |           0 |  10 | m                 | HOWV     ;     ; Height of waves
+  0-22-022 |   1 |           0 |  10 | m                 | HOWW     ;     ; Height of wind waves
+  0-22-023 |   1 |           0 |  10 | m                 | HOSW     ;     ; Height of swell waves
+  0-22-025 |   2 |           0 |  10 | m                 | SDWH0    ;     ; Standard deviation wave height
+  0-22-026 |   2 |           0 |  10 | m                 | SDWH     ;     ; Standard deviation of significant wave height
+  0-22-031 |   2 |           0 |  13 | m s**-1           | SPOC     ;     ; Speed of current
+  0-22-032 |   2 |           0 |  13 | m s**-1           | SSSC     ;     ; Speed of sea-surface current
+  0-22-035 |   2 |           0 |  14 | m                 | TERCX    ;     ; Tidal elevation with respect to local chart datum
+  0-22-036 |   2 |           0 |  14 | m                 | MRTEX    ;     ; Meteorological residual tidal elevation (surge or offset)
+  0-22-037 |   3 |      -10000 |  15 | m                 | TERL     ;     ; Tidal elevation with respect to national land datum
+  0-22-038 |   3 |      -10000 |  15 | m                 | TERC     ;     ; Tidal elevation with respect to local chart datum
+  0-22-039 |   3 |       -5000 |  13 | m                 | MRTE     ;     ; Meteorological residual tidal elevation (surge or offset)
+  0-22-040 |   3 |       -5000 |  14 | m                 | TIDER    ;     ; Meteorological residual tidal elevation (surge or offset)
+  0-22-041 |   1 |           0 |  12 | K                 | SST15    ;     ; Sea-surface temperature (15-day running mean)
+  0-22-042 |   1 |           0 |  12 | K                 | SSTL     ;     ; Sea/water temperature
+  0-22-043 |   2 |           0 |  15 | K                 | SST1     ;     ; Sea/water temperature
+  0-22-044 |   1 |           0 |  14 | m s**-1           | SVEL     ;     ; Sound velocity
+  0-22-045 |   3 |           0 |  19 | K                 | SSTH     ;     ; Sea/water temperature
+  0-22-046 |   2 |           0 |   7 | Numeric           | SIFR     ;     ; Sea ice fraction
+  0-22-049 |   2 |           0 |  15 | K                 | SST0     ;     ; Sea-surface temperature
+  0-22-050 |   2 |           0 |   8 | K                 | SSTD     ;     ; Standard deviation sea-surface temperature
+  0-22-055 |   0 |           0 |  10 | Numeric           | FCYN     ;     ; Float cycle number
+  0-22-056 |   0 |           0 |   2 | Code table        | DIPR     ;     ; Direction of profile
+  0-22-059 |   2 |           0 |  14 | Part per thousand | SSS0     ;     ; Sea-surface salinity
+  0-22-060 |   0 |           0 |   3 | Code table        | LDDS     ;     ; Lagrangian drifter drogue status
+  0-22-061 |   0 |           0 |   4 | Code table        | SEST     ;     ; State of the sea
+  0-22-062 |   2 |           0 |  14 | Part per thousand | SALN     ;     ; Salinity
+  0-22-063 |   0 |           0 |  14 | m                 | TOWD     ;     ; Total water depth
+  0-22-064 |   3 |           0 |  17 | Part per thousand | SALNH    ;     ; Salinity
+  0-22-065 |  -3 |           0 |  17 | Pa                | WPRS     ;     ; Water pressure
+  0-22-066 |   6 |           0 |  26 | S m**-1           | WCON     ;     ; Water conductivity
+  0-22-067 |   0 |           0 |  10 | Code table        | IWTEMP   ;     ; Instrument type for water temperature/salinity profile measurement
+  0-22-068 |   0 |           0 |   7 | Code table        | WTEMPR   ;     ; Water temperature profile recorder types
+  0-22-069 |   3 |           0 |  22 | m**2 Hz**-1       | SWDE     ;     ; Spectral wave density
+  0-22-070 |   2 |           0 |  13 | m                 | SGWH     ;     ; Significant wave height
+  0-22-071 |   1 |           0 |   9 | s                 | SPWP     ;     ; Spectral peak wave period
+  0-22-072 |   0 |           0 |  13 | m                 | SPWL     ;     ; Spectral peak wavelength
+  0-22-073 |   2 |           0 |  13 | m                 | MXWH     ;     ; Maximum wave height
+  0-22-074 |   1 |           0 |   9 | s                 | AVWP     ;     ; Average wave period
+  0-22-075 |   0 |           0 |  13 | m                 | AVWL     ;     ; Average wavelength
+  0-22-076 |   0 |           0 |   9 | Degree true       | DDWC     ;     ; Direction from which dominant waves are coming
+  0-22-077 |   0 |           0 |   9 | Degree            | DSDW     ;     ; Directional spread of dominant wave
+  0-22-078 |   0 |           0 |  12 | s                 | DOWR     ;     ; Duration of wave record
+  0-22-079 |   0 |           0 |  16 | m                 | LOWR     ;     ; Length of wave record
+  0-22-080 |   3 |           0 |  10 | Hz                | WCFR     ;     ; Waveband central frequency
+  0-22-081 |   5 |           0 |  13 | m**-1             | WCWN     ;     ; Waveband central wave number
+  0-22-082 |   2 |           0 |  20 | m**2 s            | MXSWD    ;     ; Maximum non-directional spectral wave density
+  0-22-083 |   2 |           0 |  20 | m**3              | MXSWN    ;     ; Maximum non-directional spectral wave number
+  0-22-084 |   0 |           0 |   7 | Numeric           | BMXSWD   ;     ; Band containing maximum non-directional spectral wave density
+  0-22-085 |   0 |           0 |   7 | Numeric           | SWDR     ;     ; Spectral wave density ratio
+  0-22-086 |   0 |           0 |   9 | Degree true       | MDWC     ;     ; Mean direction from which waves are coming
+  0-22-087 |   0 |           0 |   9 | Degree true       | PDWC     ;     ; Principal direction from which waves are coming
+  0-22-088 |   2 |           0 |   7 | Numeric           | FNPF     ;     ; First normalized polar coordinate from Fourier coefficients
+  0-22-089 |   2 |           0 |   7 | Numeric           | SNPF     ;     ; Second normalized polar coordinate from Fourier coefficients
+  0-22-090 |   2 |           0 |  20 | m**2 s            | NSWF     ;     ; Non-directional spectral estimate by wave frequency
+  0-22-091 |   2 |           0 |  20 | m**3              | NSWN     ;     ; Non-directional spectral estimate by wave number
+  0-22-092 |   2 |           0 |  20 | m**2 rad**-1 s    | DSWF     ;     ; Directional spectral estimate by wave frequency
+  0-22-093 |   2 |           0 |  20 | m**4              | DSWN     ;     ; Directional spectral estimate by wave number
+  0-22-094 |   0 |           0 |   7 | Numeric           | TNWB     ;     ; Total number of wave bands
+  0-22-095 |   0 |           0 |   8 | Degree            | DSIW     ;     ; Directional spread of individual waves
+  0-22-096 |   3 |           0 |   4 | s**-1             | SBWD     ;     ; Spectral band width
+  0-22-097 |   0 |           0 |  14 | m                 | MWLW     ;     ; Mean wavelength > 731 m of image spectrum at low wave numbers
+  0-22-098 |   0 |           0 |  14 | m                 | WSLW     ;     ; Wavelength spread (wavelength > 731 m) at low wave numbers
+  0-22-099 |   0 |           0 |   9 | Degree true       | MDLW     ;     ; Mean direction at low wave numbers (wavelength > 731 m)
+  0-22-100 |   0 |           0 |   9 | Degree            | DSLW     ;     ; Direction spread at low wave numbers (wavelength > 731 m)
+  0-22-101 |   0 |           0 |  31 | Numeric           | TELW     ;     ; Total energy (wavelength > 731m) at low wave numbers
+  0-22-102 |   0 |           0 |  14 | m**2 s            | SMNDSWDF ;     ; Scaled maximum non-directional spectral wave density by frequency
+  0-22-103 |   0 |           0 |  14 | m**3              | SMNDSWDW ;     ; Scaled maximum non-directional spectral wave density by wave number
+  0-22-104 |   0 |           0 |  14 | m**2 s            | SNDSWDF  ;     ; Scaled non-directional spectral wave density by frequency
+  0-22-105 |   0 |           0 |  14 | m**3              | SNDSWDW  ;     ; Scaled non-directional spectral wave density by wave number
+  0-22-106 |   0 |           0 |  14 | m**2 s rad**-1    | SDSWDF   ;     ; Scaled directional spectral wave density by frequency
+  0-22-107 |   0 |           0 |  14 | m**4              | SDSWDW   ;     ; Scaled directional spectral wave density by wave number
+  0-22-108 |   0 |           0 |   7 | %                 | SWDRP    ;     ; Spectral wave density ratio
+  0-22-120 |   0 |           0 |   5 | Code table        | AWCK     ;     ; Tide station automated water level check
+  0-22-121 |   0 |           0 |   5 | Code table        | MWCK     ;     ; Tide station manual water level check
+  0-22-122 |   0 |           0 |   5 | Code table        | AMCK     ;     ; Tide station automated meteorological data check
+  0-22-123 |   0 |           0 |   5 | Code table        | MMCK     ;     ; Tide station manual meteorological data check
+  0-22-130 |   0 |           0 |  10 | Numeric           | NVPSB    ;     ; Number of valid points for specific band
+  0-22-131 |   3 |           0 |  16 | m                 | RMSSWH   ;     ; RMS specific band significant wave height
+  0-22-132 |   0 |           0 |  10 | Numeric           | NVPSWH   ;     ; Number of valid points for specific band significant wave height
+  0-22-133 |   3 |       -1000 |  11 | m                 | NISWH    ;     ; Specific band net instrument correction for significant wave height
+  0-22-134 |   0 |           0 |  10 | Numeric           | NVPBS    ;     ; Number of valid points for specific band backscatter
+  0-22-141 |   2 |           0 |  15 | K                 | SST15H   ;     ; Sea-surface temperature (15-day running mean)
+  0-22-142 |   3 |   -33554432 |  26 | m**2              | SWHS     ;     ; Square of significant wave height
+  0-22-143 |   3 |    -8388608 |  24 | m**2              | S20SWHS  ;     ; STD of 20 Hz SWH squared
+  0-22-144 |   0 |           0 |   9 | Numeric           | N20SWHS  ;     ; Number of 20 Hz valid points for SWH squared
+  0-22-145 |   3 |   -33554432 |  31 | m                 | S20NR    ;     ; STD of 20 Hz ocean range
+  0-22-146 |   3 |           0 |  31 | m                 | GRAN     ;     ; OCOG range
+  0-22-147 |   3 |    -8388608 |  31 | m                 | S20GR    ;     ; STD of 20 Hz OCOG range
+  0-22-148 |   0 |           0 |   9 | Numeric           | N20NR    ;     ; Number of 20 Hz valid points for ocean range
+  0-22-149 |   3 |   -33554432 |  26 | m**2              | SWHS20   ;     ; 20 Hz significant wave height squared
+  0-22-150 |   0 |           0 |  10 | Numeric           | NVPK     ;     ; Number of 18 Hz valid points for Ku band
+  0-22-151 |   3 |           0 |  31 | m                 | KBOR     ;     ; Ku band ocean range
+  0-22-152 |   3 |           0 |  16 | m                 | SKBOR    ;     ; STD of 18 Hz Ku band ocean range
+  0-22-153 |   0 |           0 |  10 | Numeric           | NVPS     ;     ; Number of 18 Hz valid points for S band
+  0-22-154 |   3 |           0 |  31 | m                 | SBOR     ;     ; S band ocean range
+  0-22-155 |   3 |           0 |  16 | m                 | SSBOR    ;     ; STD of 18 Hz S band ocean range
+  0-22-156 |   3 |           0 |  16 | m                 | KBSW     ;     ; Ku band significant wave height
+  0-22-157 |   3 |           0 |  16 | m                 | SKBSW    ;     ; STD of 18 Hz Ku band ocean range
+  0-22-158 |   3 |           0 |  16 | m                 | SBSW     ;     ; S band significant wave height
+  0-22-159 |   3 |           0 |  16 | m                 | SSBSW    ;     ; STD of 18 Hz S band significant wave height
+  0-22-160 |   6 |           0 |  21 | Numeric           | NIWA     ;     ; Normalized inverse wave age
+  0-22-161 |   4 |           0 |  27 | m**4              | WASP     ;     ; Wave spectra
+  0-22-162 |   3 |           0 |  16 | m                 | RKBOR    ;     ; RMS of 20 Hz Ku band ocean range
+  0-22-163 |   0 |           0 |  10 | Numeric           | NVPK2    ;     ; Number of 20 Hz valid points for Ku band
+  0-22-164 |   3 |           0 |  16 | m                 | RKSW     ;     ; RMS 20 Hz Ku band significant wave height
+  0-22-165 |   0 |           0 |  10 | Numeric           | NVKSW    ;     ; Number of 20 Hz valid points for Ku band significant wave height
+  0-22-166 |   3 |       -1000 |  11 | m                 | KNCS     ;     ; Ku band net instrumental correction for significant wave height
+  0-22-167 |   0 |           0 |  10 | Numeric           | NVPKB    ;     ; Number of valid points for Ku band backscatter
+  0-22-168 |   3 |           0 |  31 | m                 | CBOR     ;     ; C band ocean range
+  0-22-169 |   3 |           0 |  16 | m                 | RCBOR    ;     ; RMS of C band ocean range
+  0-22-170 |   0 |           0 |  10 | Numeric           | NVPC     ;     ; Number of 20 Hz valid points for C band
+  0-22-171 |   3 |           0 |  16 | m                 | CBSW     ;     ; C band significant wave height
+  0-22-172 |   3 |           0 |  16 | m                 | RCSW     ;     ; RMS 20 Hz C band significant wave height
+  0-22-173 |   0 |           0 |  10 | Numeric           | NVCSW    ;     ; Number of 20 Hz valid points for C band significant wave height
+  0-22-174 |   3 |       -1000 |  11 | m                 | CNCS     ;     ; C band net instrumental correction for significant wave height
+  0-22-175 |   0 |           0 |  10 | Numeric           | NVPCB    ;     ; Number of valid points for C band backscatter
+  0-22-177 |   0 |           0 |   6 | m                 | HXXL     ;     ; Height of XBT/XCTD launcher
+  0-22-178 |   0 |           0 |   8 | Code table        | XXLT     ;     ; XBT/XCTD launcher type
+  0-22-179 |   3 |        -500 |  16 | m                 | SVPR     ;     ; Specific band significant wave height
+  0-22-182 |   3 |           0 |  23 | m                 | WCHT     ;     ; Water column height
+  0-22-184 |   3 |       -2000 |  12 | m                 | WCHD     ;     ; Water column height deviation from the reference value
+  0-22-185 |   0 |           0 |  10 | Numeric           | BPRTC    ;     ; BPR transmission count
+  0-22-186 |   0 |           0 |   9 | Degree true       | DFWC     ;     ; Direction from which waves are coming
+  0-22-187 |   0 |           0 |   9 | Degree            | DSOW     ;     ; Directional spread of wave
+  0-22-188 |   3 |           0 |  19 | umol kg**-1       | DOXY2    ;     ; Dissolved oxygen
+  0-22-189 |   3 |           0 |  31 | m                 | SBOCR    ;     ; Specific band ocean range
+  0-22-190 |   3 |           0 |  16 | m                 | SBSWH    ;     ; Specific band significant wave height
+  0-22-191 |   4 |           0 |  16 | m                 | RMSOCR   ;     ; RMS of specific band ocean range
+  0-23-001 |   0 |           0 |   3 | Code table        | AENA     ;     ; Accident early notification - article applicable
+  0-23-002 |   0 |           0 |   5 | Code table        | AFII     ;     ; Activity or facility involved in incident
+  0-23-003 |   0 |           0 |   3 | Code table        | TPRE     ;     ; Type of release
+  0-23-004 |   0 |           0 |   3 | Code table        | CTNB     ;     ; Countermeasures taken near border
+  0-23-005 |   0 |           0 |   2 | Code table        | COIN     ;     ; Cause of incident
+  0-23-006 |   0 |           0 |   3 | Code table        | INSI     ;     ; Incident situation
+  0-23-007 |   0 |           0 |   3 | Code table        | CHOR     ;     ; Characteristics of release
+  0-23-008 |   0 |           0 |   2 | Code table        | SOCR     ;     ; State of current release
+  0-23-009 |   0 |           0 |   2 | Code table        | SOER     ;     ; State of expected release
+  0-23-016 |   0 |           0 |   2 | Code table        | PCTE     ;     ; Possibility of significant chemical toxic health effect
+  0-23-017 |   6 |           0 |  20 | m**3 s**-1        | FDMR     ;     ; Flow discharge of major recipient
+  0-23-018 |   0 |           0 |   3 | Code table        | RBOT     ;     ; Release behaviour over time
+  0-23-019 |   0 |      -15000 |  17 | m                 | ARHT     ;     ; Actual release height
+  0-23-021 |   0 |      -15000 |  17 | m                 | ERHT     ;     ; Effective release height
+  0-23-022 |   0 |           0 |  24 | m                 | DRPS     ;     ; Distance of release point or site of incident
+  0-23-023 |   1 |           0 |  12 | m s**-1           | MTSA     ;     ; Main transport speed in the atmosphere
+  0-23-024 |   2 |           0 |  13 | m s**-1           | MTSW     ;     ; Main transport speed in water
+  0-23-025 |   2 |           0 |  13 | m s**-1           | MTSG     ;     ; Main transport speed in ground water
+  0-23-027 |   0 |           0 |   9 | Degree true       | MTDA     ;     ; Main transport direction in the atmosphere
+  0-23-028 |   0 |           0 |   9 | Degree true       | MTDW     ;     ; Main transport direction in water
+  0-23-029 |   0 |           0 |   9 | Degree true       | MTDG     ;     ; Main transport direction in ground water
+  0-23-031 |   0 |           0 |   2 | Code table        | PEPS     ;     ; Possibility that plume will encounter precipitation in State in which incident occurred
+  0-23-032 |   0 |           0 |   2 | Code table        | PECW     ;     ; Plume will encounter change in wind direction and/or speed flag
+  0-23-040 |   1 |           0 |  22 | m**3 s**-1        | FLWR     ;     ; Flow discharge - river
+  0-23-041 |   3 |           0 |  16 | m**3 s**-1        | FLWW     ;     ; Flow discharge - well
+  0-24-001 | -11 |           0 |  28 | Bq                | EARR     ;     ; Estimate of amount of radioactivity released up to specified time
+  0-24-002 | -11 |           0 |  28 | Bq                | EMXPR    ;     ; Estimated maximum potential release
+  0-24-003 |   0 |           0 |   5 | Code table        | CORE     ;     ; Composition of release
+  0-24-004 |   0 |           0 |  16 | CCITT IA5         | ELEN     ;     ; Element name
+  0-24-005 |   0 |           0 |   9 | Numeric           | ISOM     ;     ; Isotope mass
+  0-24-011 |   2 |           0 |  32 | mSv               | DOSE     ;     ; Dose
+  0-24-012 |   2 |           0 |  32 | mSv               | TDOSE    ;     ; Trajectory dose (defined location and expected time of arrival)
+  0-24-013 |   2 |           0 |  32 | mSv               | GDOSE    ;     ; Gamma dose in air along the main transport path (defined location and time period)
+  0-24-014 |   1 |           0 |  14 | nSv h**-1         | GRDR     ;     ; Gamma radiation dose rate
+  0-24-021 |   2 |           0 |  32 | Bq m**-3          | AIRC     ;     ; Air concentration (of named isotope type including gross beta)
+  0-24-022 |   2 |           0 |  32 | Bq l**-1          | COIP     ;     ; Concentration in precipitation (of named isotope type)
+  0-24-023 |   1 |           0 |  14 | s**-1             | PRBR     ;     ; Pulse rate of beta radiation
+  0-24-024 |   1 |           0 |  14 | s**-1             | PRGR     ;     ; Pulse rate of gamma radiation
+  0-25-001 |  -1 |           0 |   6 | m                 | RAGL     ;     ; Range-gate length
+  0-25-002 |   0 |           0 |   4 | Numeric           | ROGA     ;     ; Number of gates averaged
+  0-25-003 |   0 |           0 |   8 | Numeric           | NOIP     ;     ; Number of integrated pulses
+  0-25-004 |   0 |           0 |   2 | Code table        | ECHP     ;     ; Echo processing
+  0-25-005 |   0 |           0 |   2 | Code table        | ECHI     ;     ; Echo integration
+  0-25-006 |   0 |           0 |   3 | Code table        | Z2RC     ;     ; Z to R conversion
+  0-25-007 |   0 |           0 |  12 | Numeric           | Z2RCF    ;     ; Z to R conversion factor
+  0-25-008 |   2 |           0 |   9 | Numeric           | Z2RCE    ;     ; Z to R conversion exponent
+  0-25-009 |   0 |           0 |   4 | Flag table        | CALM     ;     ; Calibration method
+  0-25-010 |   0 |           0 |   4 | Code table        | CLTR     ;     ; Clutter treatment
+  0-25-011 |   0 |           0 |   2 | Code table        | GOCO     ;     ; Ground occultation correction (screening)
+  0-25-012 |   0 |           0 |   2 | Code table        | RACO     ;     ; Range attenuation correction
+  0-25-013 |   0 |           0 |   2 | Flag table        | BBCO     ;     ; Bright-band correction
+  0-25-014 |   0 |           0 |  12 | Numeric           | ACCO     ;     ; Azimuth clutter cut-off
+  0-25-015 |   0 |           0 |   2 | Flag table        | RDCO     ;     ; Radome attenuation correction
+  0-25-016 |   5 |           0 |   6 | dB m**-1          | CACO     ;     ; Clear-air attenuation correction
+  0-25-017 |   0 |           0 |   2 | Flag table        | PACO     ;     ; Precipitation attenuation correction
+  0-25-018 |   7 |           0 |   6 | Numeric           | A2ZF     ;     ; A to Z law for attenuation factor
+  0-25-019 |   2 |           0 |   7 | Numeric           | A2ZE     ;     ; A to Z law for attenuation exponent
+  0-25-020 |   0 |           0 |   2 | Code table        | MSPE     ;     ; Mean speed estimation
+  0-25-021 |   0 |           0 |   8 | Flag table        | WICE     ;     ; Wind computation enhancement
+  0-25-022 |   0 |           0 |   9 | Flag table        | GRFL     ;     ; GHRSST rejection flag
+  0-25-023 |   0 |           0 |   9 | Flag table        | GCFL     ;     ; GHRSST confidence flag
+  0-25-024 |   0 |           0 |   4 | Code table        | GDQL     ;     ; GHRSST data quality
+  0-25-025 |   1 |           0 |   9 | V                 | BVOL     ;     ; Battery voltage
+  0-25-026 |   1 |           0 |  12 | V                 | BVOLH    ;     ; Battery voltage (large range)
+  0-25-028 |   1 |      -16384 |  15 | Numeric           | OMDP     ;     ; Operator or manufacturer defined parameter
+  0-25-029 |   0 |           0 |   6 | Flag table        | CAMT     ;     ; Calibration method
+  0-25-030 |   0 |           0 |   2 | Code table        | SSTU     ;     ; Running mean sea-surface temperature usage
+  0-25-031 |   0 |           0 |   3 | Code table        | NWPT     ;     ; NWP-generated vertical profile thinning method
+  0-25-032 |   0 |           0 |   2 | Code table        | NPHL     ;     ; Wind profiler mode information
+  0-25-033 |   0 |           0 |   2 | Code table        | NPSM     ;     ; Wind profiler submode information
+  0-25-034 |   0 |           0 |   4 | Flag table        | NPQC     ;     ; Wind profiler quality control test results
+  0-25-035 |   0 |           0 |   3 | Code table        | DMFP     ;     ; Decision method for polarity
+  0-25-036 |   0 |           0 |   4 | Code table        | ALME     ;     ; Atmospherics location method
+  0-25-037 |   2 |        -127 |   8 | K                 | SSTB     ;     ; SST bias
+  0-25-038 |   1 |        -127 |   8 | K                 | DIFSA    ;     ; Difference between SST and analysis
+  0-25-040 |   0 |           0 |   4 | Code table        | CO2W     ;     ; CO2 wind product derivation
+  0-25-041 |   0 |           0 |   2 | Code table        | MPDR     ;     ; Moving platform direction reporting method
+  0-25-042 |   0 |           0 |   2 | Code table        | MPSR     ;     ; Moving platform speed reporting method
+  0-25-043 |   4 |           0 |  15 | s                 | WSIT     ;     ; Wave sampling interval (time)
+  0-25-044 |   2 |           0 |  14 | m                 | WSIS     ;     ; Wave sampling interval (space)
+  0-25-045 |   0 |           0 |  21 | Flag table        | HIRC     ;     ; HIRS channel combination
+  0-25-046 |   0 |           0 |   5 | Flag table        | MSUC     ;     ; MSU channel combination
+  0-25-047 |   0 |           0 |   4 | Flag table        | SSUC     ;     ; SSU channel combination
+  0-25-048 |   0 |           0 |  16 | Flag table        | AMAC     ;     ; AMSU-A channel combination
+  0-25-049 |   0 |           0 |   6 | Flag table        | AMBC     ;     ; AMSU-B channel combination
+  0-25-050 |   4 |     -131072 |  18 | Numeric           | APCOMP   ;     ; Principal component score
+  0-25-051 |   0 |           0 |   7 | Flag table        | AVHCST   ;     ; AVHRR channel combination
+  0-25-052 |   4 |           0 |  15 | Numeric           | APCFIT   ;     ; Log10 of principal components normalized fit to data
+  0-25-053 |   0 |           0 |  12 | Flag table        | OBQL     ;     ; Observation quality
+  0-25-054 |   0 |           0 |   5 | Numeric           | SSID     ;     ; SSMIS subframe ID number
+  0-25-055 |   2 |           0 |  16 | K                 | MUHO     ;     ; Multiplexer housekeeping
+  0-25-060 |   0 |           0 |  14 | Numeric           | SWID     ;     ; Software identification
+  0-25-061 |   0 |           0 |  96 | CCITT IA5         | SOFTV    ;     ; Software identification and version number
+  0-25-062 |   0 |           0 |  14 | Numeric           | DBID     ;     ; Database identification
+  0-25-063 |   0 |           0 |   8 | Code table        | CPSI     ;     ; Central processor or system identifier
+  0-25-065 |   2 |       -1000 |  11 | Degree            | ORCRAZ   ;     ; Orientation correction (azimuth)
+  0-25-066 |   2 |       -1000 |  11 | Degree            | ORCREL   ;     ; Orientation correction (elevation)
+  0-25-067 |   0 |       -8000 |  14 | Pa                | RRPPC    ;     ; Radiosonde release point pressure correction
+  0-25-068 |   0 |           0 |   7 | Numeric           | ARRE     ;     ; Number of archive recomputes
+  0-25-069 |   0 |           0 |   8 | Flag table        | FLPC     ;     ; Flight level pressure corrections
+  0-25-070 |   0 |           0 |   4 | Numeric           | MJFC     ;     ; Major frame count
+  0-25-071 |   0 |           0 |   5 | Numeric           | FRCT     ;     ; Frame count
+  0-25-075 |   0 |           0 |   5 | Numeric           | SACV     ;     ; Satellite antenna corrections version number
+  0-25-076 |   8 |           0 |  30 | log (m**-1)       | LOGRCW   ;     ; Log10 of (temperature-radiance central wave number) for ATOVS
+  0-25-077 |   5 |     -100000 |  18 | Numeric           | BWCC1    ;     ; Bandwidth correction coefficient 1
+  0-25-078 |   5 |           0 |  17 | Numeric           | BWCC2    ;     ; Bandwidth correction coefficient 2
+  0-25-079 |   4 |           0 |  24 | W m**-2           | ASFI     ;     ; Albedo-radiance solar filtered irradiance for ATOVS
+  0-25-080 |  10 |           0 |  14 | m                 | AEFW     ;     ; Albedo-radiance equivalent filter width for ATOVS
+  0-25-081 |   3 |           0 |  17 | Degree            | IANG     ;     ; Incidence angle
+  0-25-082 |   3 |           0 |  19 | Degree            | AANG     ;     ; Azimuth angle
+  0-25-083 |   3 |           0 |  19 | Degree            | FRANG    ;     ; Faraday rotational angle
+  0-25-084 |   5 |           0 |  26 | Degree            | GRANG    ;     ; Geometric rotational angle
+  0-25-085 |   0 |           0 |   7 | Numeric           | FCPH     ;     ; Fraction of clear pixels in HIRS FOV
+  0-25-086 |   0 |           0 |   2 | Code table        | QDEP     ;     ; Depth correction indicator
+  0-25-090 |   0 |           0 |   4 | Code table        | ORSF     ;     ; Orbit state flag
+  0-25-091 |   3 |      -18192 |  13 | dB                | SCRIN    ;     ; Structure constant of the refraction index (Cn2)
+  0-25-092 |   2 |       28000 |  14 | m s**-1           | APVE     ;     ; Acoustic propagation velocity
+  0-25-093 |   0 |           0 |   8 | Flag table        | RACC     ;     ; RASS computation correction
+  0-25-095 |   0 |           0 |   2 | Flag table        | ASFL     ;     ; Altimeter state flag
+  0-25-096 |   0 |           0 |   5 | Flag table        | RSFL     ;     ; Radiometer state flag
+  0-25-097 |   0 |           0 |   4 | Code table        | EENO     ;     ; Three-dimensional error estimate of the navigator orbit
+  0-25-098 |   0 |           0 |   9 | Flag table        | ADQF     ;     ; Altimeter data quality flag
+  0-25-099 |   0 |           0 |   9 | Flag table        | ARQF     ;     ; Altimeter correction quality flag
+  0-25-100 |   5 |           0 |  20 | Numeric           | FRCA     ;     ; XBT/XCTD fall rate equation coefficient a
+  0-25-101 |   5 |     -500000 |  21 | Numeric           | FRCB     ;     ; XBT/XCTD fall rate equation coefficient b
+  0-25-102 |   0 |           0 |   8 | Numeric           | NOML     ;     ; Number of missing lines excluding data gaps
+  0-25-103 |   0 |           0 |   8 | Numeric           | NODB     ;     ; Number of directional bins
+  0-25-104 |   0 |           0 |   8 | Numeric           | NOWB     ;     ; Number of wavelength bins
+  0-25-105 |   3 |           0 |  19 | Degree            | FDIB     ;     ; First directional bin
+  0-25-106 |   3 |           0 |  19 | Degree            | DIBS     ;     ; Directional bin step
+  0-25-107 |   3 |           0 |  29 | m                 | FWLB     ;     ; First wavelength bin
+  0-25-108 |   3 |           0 |  29 | m                 | LWLB     ;     ; Last wavelength bin
+  0-25-110 |   0 |           0 |  10 | Flag table        | IMPS     ;     ; Image processing summary
+  0-25-111 |   0 |           0 |   8 | Numeric           | NOIDG    ;     ; Number of input data gaps
+  0-25-112 |   0 |           0 |   9 | Flag table        | BSADQF   ;     ; Band specific altimeter data quality flag
+  0-25-113 |   0 |           0 |   9 | Flag table        | BSACQF   ;     ; Band specific altimeter correction quality flag
+  0-25-120 |   0 |           0 |   2 | Code table        | RAPF     ;     ; RA2-L2-processing flag
+  0-25-121 |   0 |           0 |   7 | %                 | RAPQ     ;     ; RA2-L2-processing quality
+  0-25-122 |   0 |           0 |   2 | Code table        | HCRF     ;     ; Hardware configuration for RF
+  0-25-123 |   0 |           0 |   2 | Code table        | HCHA     ;     ; Hardware configuration for HPA
+  0-25-124 |   0 |           0 |   2 | Code table        | MRPF     ;     ; MWR-L2-processing flag
+  0-25-125 |   0 |           0 |   7 | %                 | MRPQ     ;     ; MWR-L2-processing quality
+  0-25-126 |   3 |      -32768 |  16 | m                 | MDTC     ;     ; Model dry tropospheric correction
+  0-25-127 |   3 |      -32768 |  16 | m                 | IBCO     ;     ; Inverted barometer correction
+  0-25-128 |   3 |      -32768 |  16 | m                 | MWTC     ;     ; Model wet tropospheric correction
+  0-25-129 |   3 |      -32768 |  16 | m                 | MRWTC    ;     ; MWR derived wet tropospheric correction
+  0-25-130 |   3 |      -32768 |  16 | m                 | RAICK    ;     ; RA2 ionospheric correction on Ku band
+  0-25-131 |   3 |      -32768 |  16 | m                 | ICDK     ;     ; Ionospheric correction from Doris on Ku band
+  0-25-132 |   3 |      -32768 |  16 | m                 | ICMK     ;     ; Ionospheric correction from model on Ku band
+  0-25-133 |   3 |      -32768 |  16 | m                 | SBCK     ;     ; Sea state bias correction on Ku band
+  0-25-134 |   3 |      -32768 |  16 | m                 | RAICS    ;     ; RA2 ionospheric correction on S band
+  0-25-135 |   3 |      -32768 |  16 | m                 | ICDS     ;     ; Ionospheric correction from Doris on S band
+  0-25-136 |   3 |      -32768 |  16 | m                 | ICMS     ;     ; Ionospheric correction from model on S band
+  0-25-137 |   3 |      -32768 |  16 | m                 | SBCS     ;     ; Sea state bias correction on S band
+  0-25-138 |   0 |       -2048 |  12 | Numeric           | ASNR     ;     ; Average signal-to-noise ratio
+  0-25-139 |   0 |           0 |   5 | Numeric           | PROCLVL  ;     ; Processing level
+  0-25-140 |   0 |           0 |  14 | Numeric           | STCH     ;     ; Start channel
+  0-25-141 |   0 |           0 |  14 | Numeric           | ENCH     ;     ; End channel
+  0-25-142 |   0 |           0 |   6 | Numeric           | CHSF     ;     ; Channel scale factor
+  0-25-143 |   6 |    -5000000 |  24 | Numeric           | LINCOF   ;     ; Linear coefficient
+  0-25-148 |   2 |      -10000 |  15 | Numeric           | CVWD     ;     ; Coefficient of variation
+  0-25-149 |   0 |           0 |   8 | Numeric           | OECS     ;     ; Optimal estimation cost
+  0-25-150 |   0 |           0 |   4 | Code table        | MTIS     ;     ; Method of tropical cyclone intensity analysis using satellite data
+  0-25-160 |   4 |     -120000 |  18 | m                 | KBIC     ;     ; Ku band net instrumental correction
+  0-25-161 |   4 |     -120000 |  18 | m                 | CBIC     ;     ; C band net instrumental correction
+  0-25-162 |   4 |       -6000 |  13 | m                 | SBCC     ;     ; Sea state bias correction on C band
+  0-25-163 |   3 |      -32768 |  16 | m                 | AICK     ;     ; Altimeter ionospheric correction on Ku band
+  0-25-164 |   4 |       -5000 |  13 | m                 | RWTC     ;     ; Radiometer wet tropospheric correction
+  0-25-165 |   4 |      -32768 |  16 | m                 | ICMSB    ;     ; Ionospheric correction from model on specific band
+  0-25-166 |   4 |      -32768 |  16 | m                 | SBCSB    ;     ; Sea state bias correction on specific band
+  0-25-167 |   4 |     -120000 |  18 | m                 | SBNIC    ;     ; Specific band net instrumental correction
+  0-25-170 |   0 |           0 |  10 | s                 | SINT     ;     ; Sampling interval (time)
+  0-25-171 |   0 |           0 |  10 | s                 | SAVG     ;     ; Sample averaging period
+  0-25-172 |   0 |           0 |  10 | Numeric           | NSMP     ;     ; Number of samples
+  0-25-174 |   0 |           0 |  14 | Flag table        | SMIF     ;     ; SMOS information flag
+  0-25-175 |   2 |           0 |  13 | Numeric           | MODR     ;     ; Modified residual
+  0-25-180 |   2 |           0 |  16 | %                 | LRMP     ;     ; LRM per cent
+  0-25-181 |   0 |           0 |   2 | Code table        | L2PF     ;     ; L2 processing flag
+  0-25-182 |   0 |           0 |   2 | Code table        | L1PF     ;     ; L1 processing flag
+  0-25-183 |   2 |           0 |  14 | %                 | L1PQ     ;     ; L1 processing quality
+  0-25-184 |   0 |           0 |   2 | Code table        | L2PS     ;     ; L2 product status
+  0-25-185 |   0 |           0 |   8 | Code table        | ENCMETH  ;     ; Encryption method
+  0-25-186 |   0 |           0 |  96 | CCITT IA5         | ENCKEYV  ;     ; Encryption key version
+  0-25-187 |   0 |           0 |   4 | Code table        | CONFLG   ;     ; Confidence flag
+  0-25-188 |   0 |           0 |   5 | Code table        | MRSLP    ;     ; Method for reducing pressure to sea level
+  0-25-189 |   0 |           1 |   9 | m                 | RCWV     ;     ; Range cut-off wavelength
+  0-25-190 |   0 |           0 |   8 | Code table        | AEPM     ;     ; Altimeter echo processing mode
+  0-25-191 |   0 |           0 |   8 | Code table        | ATRM     ;     ; Altimeter tracking mode
+  0-26-001 |   1 |           0 |  12 | Hour              | PTMXT    ;     ; Principal time of daily reading in UTC of maximum temperature
+  0-26-002 |   1 |           0 |  12 | Hour              | PTMIT    ;     ; Principal time of daily reading in UTC of minimum temperature
+  0-26-003 |   0 |       -1440 |  12 | Minute            | TDIF     ;     ; Time difference
+  0-26-010 |   0 |           0 |  26 | Flag table        | HRIN     ;     ; Hours included
+  0-26-020 |   0 |           0 |  11 | Minute            | DURP     ;     ; Duration of precipitation
+  0-26-021 |   0 |           0 |  12 | Year              | DYEAR    ;     ; Year
+  0-26-022 |   0 |           0 |   4 | Month             | DMNTH    ;     ; Month
+  0-26-023 |   0 |           0 |   6 | Day               | DDAYS    ;     ; Day
+  0-26-030 |   2 |           0 |   8 | s                 | INTIME   ;     ; Measurement integration time
+  0-27-001 |   5 |    -9000000 |  25 | Degree            | DLATH    ;     ; Latitude (high accuracy)
+  0-27-002 |   2 |       -9000 |  15 | Degree            | DLAT     ;     ; Latitude (coarse accuracy)
+  0-27-003 |   2 |       -9000 |  15 | Degree            | ALAT     ;     ; Alternate latitude (coarse accuracy)
+  0-27-004 |   5 |    -9000000 |  25 | Degree            | ALATH    ;     ; Alternate latitude (high accuracy)
+  0-27-010 |  -1 |           0 |  14 | m                 | FPA1     ;     ; Footprint axis 1
+  0-27-020 |   0 |           0 |  16 | Numeric           | SALC     ;     ; Satellite location counter
+  0-27-021 |   0 |           0 |  16 | Numeric           | SASL     ;     ; Satellite sublocation dimension
+  0-27-031 |   2 | -1073741824 |  31 | m                 | PD00     ;     ; In direction of 0 degrees longitude, distance from the Earth's centre
+  0-27-079 |   0 |           0 |  18 | m                 | HWSV     ;     ; Horizontal width of sampled volume
+  0-27-080 |   2 |           0 |  16 | Degree true       | VAZA     ;     ; Viewing azimuth angle
+  0-28-001 |   5 |   -18000000 |  26 | Degree            | DLONH    ;     ; Longitude (high accuracy)
+  0-28-002 |   2 |      -18000 |  16 | Degree            | DLON     ;     ; Longitude (coarse accuracy)
+  0-28-003 |   2 |      -18000 |  16 | Degree            | ALON     ;     ; Alternate longitude (coarse accuracy)
+  0-28-004 |   5 |   -18000000 |  26 | Degree            | ALONH    ;     ; Alternate longitude (high accuracy)
+  0-28-010 |  -1 |           0 |  14 | m                 | FPA2     ;     ; Footprint axis 2
+  0-28-031 |   2 | -1073741824 |  31 | m                 | PD90     ;     ; In direction 90 degrees East, distance from the Earth's centre
+  0-29-001 |   0 |           0 |   3 | Code table        | PROT     ;     ; Projection type
+  0-29-002 |   0 |           0 |   3 | Code table        | COGT     ;     ; Coordinate grid type
+  0-29-014 |   0 |           0 | 504 | CCITT IA5         | OPRPRJ   ;     ; Optional list of parameters for an external map projection library
+  0-30-001 |   0 |           0 |   4 | Numeric           | PIX4     ;     ; Pixel value (4 bits)
+  0-30-002 |   0 |           0 |   8 | Numeric           | PIX8     ;     ; Pixel value (8 bits)
+  0-30-004 |   0 |           0 |  16 | Numeric           | PIX16    ;     ; Pixel value (16 bits)
+  0-30-010 |   0 |           0 |  13 | Numeric           | NOGP     ;     ; Number of grid points
+  0-30-021 |   0 |           0 |  12 | Numeric           | NPPR     ;     ; Number of pixels per row
+  0-30-022 |   0 |           0 |  12 | Numeric           | NPPC     ;     ; Number of pixels per column
+  0-30-031 |   0 |           0 |   4 | Code table        | PICT     ;     ; Picture type
+  0-30-032 |   0 |           0 |  16 | Flag table        | CWOD     ;     ; Combination with other data
+  0-30-033 |   0 |           0 |  12 | Numeric           | NBAR     ;     ; Number of bins along the radial
+  0-30-034 |   0 |           0 |  12 | Numeric           | NAZM     ;     ; Number of azimuths
+  0-31-000 |   0 |           0 |   1 | Numeric           | DRF1BIT  ;     ; Short delayed descriptor replication factor
+  0-31-001 |   0 |           0 |   8 | Numeric           | DRF8BIT  ;     ; Delayed descriptor replication factor
+  0-31-002 |   0 |           0 |  16 | Numeric           | DRF16BIT ;     ; Extended delayed descriptor replication factor
+  0-31-011 |   0 |           0 |   8 | Numeric           | DDDRF    ;     ; Delayed descriptor and data repetition factor
+  0-31-012 |   0 |           0 |  16 | Numeric           | EDDDRF   ;     ; Extended delayed descriptor and data repetition factor
+  0-31-021 |   0 |           0 |   6 | Code table        | AFSI     ;     ; Associated field significance
+  0-31-031 |   0 |           0 |   1 | Flag table        | DPRI     ;     ; Data present indicator
+  0-33-002 |   0 |           0 |   2 | Code table        | QMRK     ;     ; Quality information
+  0-33-003 |   0 |           0 |   3 | Code table        | QMRKH    ;     ; Quality information
+  0-33-005 |   0 |           0 |  30 | Flag table        | QUALI    ;     ; Quality information (AWS data)
+  0-33-006 |   0 |           0 |   3 | Code table        | IMSI     ;     ; Internal measurement status information (AWS)
+  0-33-007 |   0 |           0 |   7 | %                 | PCCF     ;     ; Per cent confidence
+  0-33-015 |   0 |           0 |   6 | Code table        | QCCHEK   ;     ; Data quality-check indicator
+  0-33-020 |   0 |           0 |   3 | Code table        | QCIND    ;     ; Quality control indication of following value
+  0-33-021 |   0 |           0 |   2 | Code table        | QOFV     ;     ; Quality of following value
+  0-33-022 |   0 |           0 |   2 | Code table        | QBST     ;     ; Quality of buoy satellite transmission
+  0-33-023 |   0 |           0 |   2 | Code table        | QCIL     ;     ; Quality of buoy location
+  0-33-024 |   0 |           0 |   4 | Code table        | QCEVR    ;     ; Station elevation quality mark (for mobile stations)
+  0-33-025 |   0 |           0 |   3 | Code table        | INTV     ;     ; ACARS interpolated values indicator
+  0-33-026 |   0 |           0 |   6 | Code table        | MSTQ     ;     ; Moisture quality
+  0-33-027 |   0 |           0 |   3 | Code table        | QCLS     ;     ; Location quality class (range of radius of 66 % confidence)
+  0-33-028 |   0 |           0 |   3 | Code table        | SSOQ     ;     ; Snapshot overall quality
+  0-33-030 |   0 |           0 |  24 | Flag table        | SLSF     ;     ; Scan line status flags for ATOVS
+  0-33-031 |   0 |           0 |  24 | Flag table        | SLQF     ;     ; Scan line quality flags for ATOVS
+  0-33-032 |   0 |           0 |  24 | Flag table        | ACQF     ;     ; Channel quality flags for ATOVS
+  0-33-033 |   0 |           0 |  24 | Flag table        | FOVQ     ;     ; Field of view quality flags for ATOVS
+  0-33-035 |   0 |           0 |   4 | Code table        | MAQC     ;     ; Manual/automatic quality control
+  0-33-036 |   0 |           0 |   7 | %                 | NCTH     ;     ; Nominal confidence threshold
+  0-33-037 |   0 |           0 |  20 | Flag table        | WCOE     ;     ; Wind correlation error
+  0-33-038 |   0 |           0 |  10 | Flag table        | QFGN     ;     ; Quality flags for ground-based GNSS data
+  0-33-039 |   0 |           0 |  16 | Flag table        | QFRO     ;     ; Quality flags for radio occultation data
+  0-33-040 |   0 |           0 |   7 | %                 | CONFI    ;     ; Confidence interval
+  0-33-041 |   0 |           0 |   2 | Code table        | AOFV     ;     ; Attribute of following value
+  0-33-042 |   0 |           0 |   3 | Code table        | TLRFV    ;     ; Type of limit represented by following value
+  0-33-043 |   0 |           0 |   8 | Flag table        | ASTC     ;     ; AST confidence
+  0-33-044 |   0 |           0 |  15 | Flag table        | ASARQI   ;     ; ASAR quality information
+  0-33-045 |   0 |           0 |   7 | %                 | POFE     ;     ; Probability of following event
+  0-33-046 |   0 |           0 |   7 | %                 | CPOFE    ;     ; Conditional probability of following event with respect to specified conditioning event
+  0-33-047 |   0 |           0 |  31 | Flag table        | MCOD     ;     ; Measurement confidence data
+  0-33-048 |   0 |           0 |   2 | Code table        | CMSI     ;     ; Confidence measure of SAR inversion
+  0-33-049 |   0 |           0 |   2 | Code table        | CMWR     ;     ; Confidence measure of wind retrieval
+  0-33-050 |   0 |           0 |   4 | Code table        | GGQF     ;     ; Global GTSPP quality flag
+  0-33-052 |   0 |           0 |  21 | Flag table        | SORQ     ;     ; S band ocean retracking quality
+  0-33-053 |   0 |           0 |  21 | Flag table        | KORQ     ;     ; Ku band ocean retracking quality
+  0-33-055 |   0 |           0 |  24 | Flag table        | WVQF     ;     ; Wind vector quality flag
+  0-33-056 |   0 |           0 |  24 | Flag table        | SZQF     ;     ; Sigma-0 quality flag
+  0-33-060 |   0 |           0 |   2 | Code table        | QGFQ     ;     ; GqisFlagQual - individual IASI-System quality flag
+  0-33-061 |   0 |           0 |   7 | %                 | QGQI     ;     ; GqisQualIndex - indicator for instrument noise performance (contributions from spectral and radiometric calibration)
+  0-33-062 |   0 |           0 |   7 | %                 | QGQIL    ;     ; GqisQualIndexLoc - indicator for geometric quality index
+  0-33-063 |   0 |           0 |   7 | %                 | QGQIR    ;     ; GqisQualIndexRad - indicator for instrument noise performance (contributions from radiometric calibration)
+  0-33-064 |   0 |           0 |   7 | %                 | QGQIS    ;     ; GqisQualIndexSpect - indicator for instrument noise performance (contributions from spectral calibration)
+  0-33-065 |   0 |           0 |  24 | Numeric           | QGSSQ    ;     ; GqisSysTecSondQual - output of system TEC (Technical Expertise Centre) quality function
+  0-33-066 |   0 |           0 |  24 | Flag table        | AMVQ     ;     ; AMV quality flag
+  0-33-070 |   0 |           0 |   4 | Code table        | SBUVTOQ  ;     ; Total ozone quality
+  0-33-071 |   0 |           0 |   4 | Code table        | SBUVPOQ  ;     ; Profile ozone quality
+  0-33-072 |   0 |           0 |   5 | Code table        | GOMEEF   ;     ; Ozone error
+  0-33-075 |   0 |           0 |  13 | Flag table        | NSQF     ;     ; Scan-level quality flags
+  0-33-076 |   0 |           0 |   9 | Flag table        | NCQF     ;     ; Calibration quality flags
+  0-33-077 |   0 |           0 |  19 | Flag table        | NFQF     ;     ; Field-of-view quality flags
+  0-33-078 |   0 |           0 |   4 | Code table        | NGQI     ;     ; Geolocation quality
+  0-33-079 |   0 |           0 |  16 | Flag table        | ATMSGQ   ;     ; Granule level quality flags
+  0-33-080 |   0 |           0 |  20 | Flag table        | ATMSSQ   ;     ; Scan level quality flags
+  0-33-081 |   0 |           0 |  12 | Flag table        | ATMSCHQ  ;     ; Channel data quality flags
+  0-33-082 |   0 |           0 |  16 | Flag table        | VIIRGQ   ;     ; Geolocation quality flags
+  0-33-083 |   0 |           0 |  16 | Flag table        | VIIRSQ   ;     ; Radiance data quality flags
+  0-33-084 |   0 |           0 |  16 | Flag table        | SSTPQ    ;     ; Pixel level quality flags
+  0-33-085 |   0 |           0 |  18 | Flag table        | AOTQ     ;     ; Aerosol optical thickness quality flags
+  0-33-086 |   0 |           0 |   3 | Code table        | RETRQ    ;     ; Quality of pixel level retrieval
+  0-33-087 |   0 |           0 |   4 | Code table        | XSAA     ;     ; Extent of satellite within South Atlantic anomaly (based on climatological data)
+  0-33-088 |   0 |           0 |  18 | Flag table        | OTCQ     ;     ; Ozone total column quality flag
+  0-33-089 |   2 |           0 |  12 | K                 | NEDTQW   ;     ; Noise equivalent delta temperature (NEdT) quality indicators for warm target calibration
+  0-33-090 |   2 |           0 |  12 | K                 | NEDTQC   ;     ; NEdT quality indicators for cold target calibration
+  0-33-091 |   2 |           0 |  12 | K                 | NEDTQO   ;     ; NEdT quality indicators for overall calibration
+  0-33-092 |   0 |           0 |   9 | Flag table        | BSOQ     ;     ; Band specific ocean quality flag
+  0-33-093 |   0 |           0 |  31 | Flag table        | QFGNX    ;     ; Extended quality flags for ground-based GNSS data
+  0-33-094 |   0 |           0 |  24 | Flag table        | NCQCF    ;     ; Calibration quality control flags
+  0-35-000 |   0 |           0 |  10 | Code table        | FMRCN    ;     ; FM and regional code number
+  0-35-001 |   0 |           0 |   3 | Code table        | TFFM     ;     ; Time frame for monitoring
+  0-35-011 |   0 |           0 |  14 | Numeric           | NRAR     ;     ; Number of reports actually received
+  0-35-021 |   0 |           0 |  48 | CCITT IA5         | BUHD     ;     ; Bulletin being monitored (TTAAii)
+  0-35-022 |   0 |           0 |  48 | CCITT IA5         | BULTIM   ;     ; Bulletin being monitored (YYGGgg)
+  0-35-023 |   0 |           0 |  32 | CCITT IA5         | BORG     ;     ; Bulletin being monitored (CCCC)
+  0-35-024 |   0 |           0 |  24 | CCITT IA5         | BBBX     ;     ; Bulletin being monitored (BBB)
+  0-35-030 |   0 |           0 |   4 | Code table        | DAED     ;     ; Discrepancies in the availability of expected data
+  0-35-031 |   0 |           0 |   7 | Code table        | QOMR     ;     ; Qualifier on monitoring results
+  0-35-032 |   0 |           0 |   4 | Code table        | COMD     ;     ; Cause of missing data
+  0-35-033 |   0 |           0 |   7 | Code table        | OACD     ;     ; Observation and collection deficiencies
+  0-35-034 |   0 |           0 |   3 | Code table        | STAD     ;     ; Statistical trends for availability of data (during the survey period(s))
+  0-35-035 |   0 |           0 |   5 | Code table        | RTERM    ;     ; Reason for termination
+  0-40-001 |   1 |           0 |  10 | %                 | SSOM     ;     ; Surface soil moisture (ms)
+  0-40-002 |   1 |           0 |  10 | %                 | EESSM    ;     ; Estimated error in surface soil moisture
+  0-40-003 |   3 |           0 |  10 | Numeric           | MSSM     ;     ; Mean surface soil moisture
+  0-40-004 |   3 |           0 |  10 | Numeric           | RFDT     ;     ; Rain fall detection
+  0-40-005 |   0 |           0 |   8 | Flag table        | SMCF     ;     ; Soil moisture correction flag
+  0-40-006 |   0 |           0 |  16 | Flag table        | SMPF     ;     ; Soil moisture processing flag
+  0-40-007 |   1 |           0 |  10 | %                 | SMQL     ;     ; Soil moisture quality
+  0-40-008 |   1 |           0 |  10 | %                 | FLSF     ;     ; Frozen land surface fraction
+  0-40-009 |   1 |           0 |  10 | %                 | IWFR     ;     ; Inundation and wetland fraction
+  0-40-010 |   1 |           0 |  10 | %                 | TPCX     ;     ; Topographic complexity
+  0-40-011 |   0 |           0 |   8 | Flag table        | INTF     ;     ; Interpolation flag
+  0-40-012 |   0 |           0 |   8 | Flag table        | RDQF     ;     ; Radiometer data quality flag
+  0-40-013 |   0 |           0 |   3 | Code table        | RBIF     ;     ; Radiometer brightness temperature interpretation flag
+  0-40-014 |   4 |       -3000 |  13 | m                 | HFSTC    ;     ; High-frequency fluctuations of the sea-surface topography correction
+  0-40-015 |   2 |        -100 |   8 | Numeric           | QFAC     ;     ; Normalized differential vegetation index (NDVI)
+  0-40-016 |   3 |           0 |  14 | Numeric           | RRIB     ;     ; Residual RMS in band
+  0-40-017 |   0 | -1073741824 |  31 | Numeric           | NNPCS    ;     ; Non-normalized principal component score
+  0-40-018 |   6 |           0 |  24 | W m**-2 sr**-1 m  | AOIM     ;     ; GIacAvgImagIIS - average of imager measurements
+  0-40-019 |   6 |           0 |  24 | W m**-2 sr**-1 m  | VOIM     ;     ; GIacVarImagIIS - variance of imager measurements
+  0-40-020 |   0 |           0 |  17 | Flag table        | QFFS     ;     ; GqisFlagQualDetailed - quality flag for the system
+  0-40-021 |   0 |           0 |   7 | %                 | FICSI    ;     ; Fraction of weighted AVHRR pixel in IASI FOV covered with snow/ice
+  0-40-022 |   0 |           0 |   7 | Numeric           | NMBFA    ;     ; Number of missing, bad or failed AVHRR pixels
+  0-40-023 |   0 |           0 |   5 | Flag table        | AASF     ;     ; Auxiliary altimeter state flags
+  0-40-024 |   0 |           0 |   3 | Code table        | MMAC     ;     ; Meteorological map availability
+  0-40-025 |   0 |           0 |   2 | Code table        | IFDT     ;     ; Interpolation flag for mean diurnal tide
+  0-40-026 |   2 |           0 |  16 | Numeric           | SQFA     ;     ; Score quantization factor
+  0-40-027 |   2 |      -18000 |  16 | Degree            | SGAN     ;     ; Sun glint angle
+  0-40-028 |   0 |           0 |   4 | Code table        | GMIQ     ;     ; GMI quality flag
+  0-40-029 |   0 |           0 |  26 | m                 | HOIL     ;     ; Horizontal observation integration length
+  0-40-030 |   2 |      -32767 |  16 | m s**-1           | HLSW     ;     ; Horizontal line of sight wind
+  0-40-031 |   2 |           0 |  15 | m s**-1           | HLSWEE   ;     ; Error estimate of horizontal line of sight wind
+  0-40-032 |   3 |     -100000 |  18 | m s**-1 Pa**-1    | DWPRS    ;     ; Derivative wind to pressure
+  0-40-033 |   3 |     -100000 |  18 | m s**-1 K**-1     | DWTMP    ;     ; Derivative wind to temperature
+  0-40-034 |   3 |     -200000 |  19 | m s**-1           | DWBR     ;     ; Derivative wind to backscatter ratio
+  0-40-035 |   0 |      380000 |  18 | m                 | SATRG    ;     ; Satellite range
+  0-40-036 |   0 |           0 |   4 | Code table        | LL2BCT   ;     ; Lidar L2b classification type
+  0-40-037 |   3 |         500 |  20 | Numeric           | BKSTR    ;     ; Backscatter ratio
+  0-40-038 |   7 |           0 |  28 | m                 | COTH     ;     ; Cloud particle size
+  0-40-039 |   0 |         -25 |   5 | Numeric           | SLCII    ;     ; Single look complex image intensity
+  0-40-040 |   2 |           1 |  13 | Numeric           | SLCIS    ;     ; Single look complex image skewness
+  0-40-041 |   2 |           1 |  13 | Numeric           | SLCIK    ;     ; Single look complex image kurtosis
+  0-40-042 |   2 |           1 |  13 | Numeric           | SLCIV    ;     ; Single look complex image variance
+  0-40-043 |   0 |           0 |   3 | Code table        | SMNI     ;     ; Satellite manoeuvre indicator
+  0-40-044 |   1 |           0 |   8 | Numeric           | DIDX     ;     ; Dust index
+  0-40-045 |   0 |           0 |   5 | Flag table        | CFHA     ;     ; Cloud formation and height assignment
+  0-40-046 |   0 |           0 |   3 | Code table        | CLDSM    ;     ; Cloudiness summary
+  0-40-047 |   0 |           0 |   3 | Code table        | VIL1P    ;     ; Validation flag for IASI or IASI-NG level 1 product
+  0-40-048 |   0 |           0 |   3 | Code table        | VAL1F    ;     ; Validation flag of AMSU-A level 1 data flow
+  0-40-049 |   0 |           0 |  16 | Flag table        | CTXR     ;     ; Cloud tests executed and results
+  0-40-050 |   0 |           0 |   8 | Flag table        | RTRIN    ;     ; Retrieval initialisation
+  0-40-051 |   0 |           0 |   3 | Code table        | CVIR     ;     ; Convergence of the iterative retrieval
+  0-40-052 |   0 |           0 |   8 | Flag table        | ISFRTR   ;     ; Indication of super-adiabatic and super-saturation in final retrieval
+  0-40-053 |   0 |           0 |   8 | Numeric           | NIRTR    ;     ; Number of iterations used for retrieval
+  0-40-054 |   0 |           0 |  13 | Flag table        | PPIE     ;     ; Potential processing and inputs errors
+  0-40-055 |   0 |           0 |  21 | Flag table        | DRTR     ;     ; Diagnostics on the retrieval
+  0-40-056 |   0 |           0 |   3 | Code table        | GRTRQ    ;     ; General retrieval quality
+  0-40-057 |   0 |           0 |  31 | Flag table        | IL2RTR   ;     ; IASI level 2 retrieval flags
+  0-40-058 |   0 |           0 |   8 | Numeric           | NVDCM    ;     ; Number of vectors describing the characterization matrices
+  0-40-059 |   0 |           0 |   8 | Numeric           | NLYRTR   ;     ; Number of layers actually retrieved
+  0-40-060 |   0 |           0 |   8 | Numeric           | NPRTRS   ;     ; Number of profiles retrieved in scanline
+  0-40-061 |   3 |           0 |  16 | mol cm**-2        | AIRPCRL  ;     ; Air partial columns on each retrieved layer
+  0-40-062 |  10 |           0 |  16 | mol cm**-2        | APRPCRL  ;     ; A-priori partial columns on each retrieved layer
+  0-40-063 |   5 |           0 |  26 | Numeric           | SVMACO   ;     ; Scaling vector multiplying the a priori vector in order to define the retrieved vector
+  0-40-064 |   6 |           0 |  31 | Numeric           | MEVLSM   ;     ; Main eigenvalues of the sensitivity matrix
+  0-40-065 |   6 | -1000000000 |  31 | Numeric           | MEVCSM   ;     ; Main eigenvectors of the sensitivity matrix
+  0-40-066 |   1 |           0 |   8 | Numeric           | QIAWV    ;     ; Quality indicator for atmospheric water vapour
+  0-40-067 |   1 |           0 |   8 | Numeric           | QIAT     ;     ; Quality indicator for atmospheric temperature
+  0-40-068 |   0 |           0 |   4 | Code table        | GRTRQSO2 ;     ; General retrieval quality flag for SO2
+  0-40-069 |   4 |    -1000000 |  21 | K                 | PWLRESA  ;     ; PWLR estimated retrieval error for surface air temperature
+  0-40-070 |   4 |    -1000000 |  21 | K                 | PWLRESD  ;     ; PWLR estimated retrieval error of surface dewpoint
+  0-40-071 |   4 |    -1000000 |  21 | Numeric           | RECMO    ;     ; Retrieval error covariance matrix for ozone in principal component domain
+  0-40-072 |   1 |           0 |   8 | Numeric           | PWLRQAO  ;     ; PWLR estimated retrieval quality indicator of atmospheric ozone
+  0-40-073 |   1 |           0 |   8 | K                 | PWLRESS  ;     ; PWLR estimated retrieval error of surface skin temperature
+  0-40-074 |   0 |           0 |  16 | Flag table        | GIQF     ;     ; General interferometry quality flags
+  0-41-001 |   3 |           0 |  18 | Pa                | PCO2     ;     ; pCO2
+  0-41-002 |  12 |           0 |  16 | kg l**-1          | FLRS     ;     ; Fluorescence
+  0-41-003 |   3 |           0 |  17 | umol kg**-1       | DSNT     ;     ; Dissolved nitrates
+  0-41-005 |   2 |           0 |  12 | NTU               | TURBDN   ;     ; Turbidity
+  0-42-001 |   0 |           0 |   9 | Degree            | DSWDSP   ;     ; Dominant swell wave direction of spectral partition
+  0-42-002 |   1 |           0 |   9 | m                 | SSWHSP   ;     ; Significant swell wave height of spectral partition
+  0-42-003 |   2 |         100 |  17 | m                 | DSWVSP   ;     ; Dominant swell wavelength of spectral partition
+  0-42-004 |   0 |           0 |   4 | Code table        | CIPSWV   ;     ; Confidence of inversion for each partition of swell wave spectra
+  0-42-005 |   5 |     -100000 |  18 | Numeric           | ARFSWV   ;     ; Ambiguity removal factor for swell wave partition
+  0-42-006 |   2 |           1 |   8 | Numeric           | WVAGE    ;     ; Wave age
+  0-42-007 |   2 |           0 |  16 | m                 | SOWVSP   ;     ; Shortest ocean wavelength on spectral resolution
+  0-42-008 |   2 |           0 |  16 | m                 | NISW     ;     ; Nonlinear inverse spectral width
+  0-42-009 |   0 |           0 |   8 | Numeric           | BPRF     ;     ; Bin partition reference
+  0-42-010 |   0 |           1 |   4 | Numeric           | PTNUM    ;     ; Partition number
+  0-42-011 |   4 |      -20000 |  15 | Numeric           | A1CFDFS  ;     ; a1 coefficient of the directional Fourier series
+  0-42-012 |   4 |      -20000 |  15 | Numeric           | B1CFDFS  ;     ; b1 coefficient of the directional Fourier series
+  0-42-013 |   4 |      -20000 |  15 | Numeric           | A2CFDFS  ;     ; a2 coefficient of the directional Fourier series
+  0-42-014 |   4 |      -20000 |  15 | Numeric           | B2CFDFS  ;     ; b2 coefficient of the directional Fourier series
+  0-42-015 |   2 |           0 |  12 | Numeric           | CHKFK    ;     ; Check factor K
+END

--- a/tables/bufrtab.TableD_STD_0_24
+++ b/tables/bufrtab.TableD_STD_0_24
@@ -1,7 +1,7 @@
 Table D STD |  0 | 24
 #
 # Standard BUFR Table D, Master Table 0, Version 24
-# This file was generated: 2021/05/11 22:56:16
+# This file was generated: 2022/11/08 16:33:04
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -6705,69 +6705,6 @@ Table D STD |  0 | 24
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring center
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_25
+++ b/tables/bufrtab.TableD_STD_0_25
@@ -1,7 +1,7 @@
 Table D STD |  0 | 25
 #
 # Standard BUFR Table D, Master Table 0, Version 25
-# This file was generated: 2021/05/11 22:56:18
+# This file was generated: 2022/11/08 16:33:09
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -6856,69 +6856,6 @@ Table D STD |  0 | 25
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_26
+++ b/tables/bufrtab.TableD_STD_0_26
@@ -1,7 +1,7 @@
 Table D STD |  0 | 26
 #
 # Standard BUFR Table D, Master Table 0, Version 26
-# This file was generated: 2021/05/11 22:56:21
+# This file was generated: 2022/11/08 16:33:14
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7013,69 +7013,6 @@ Table D STD |  0 | 26
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_27
+++ b/tables/bufrtab.TableD_STD_0_27
@@ -1,7 +1,7 @@
 Table D STD |  0 | 27
 #
 # Standard BUFR Table D, Master Table 0, Version 27
-# This file was generated: 2021/05/11 22:56:23
+# This file was generated: 2022/11/08 16:33:18
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7153,69 +7153,6 @@ Table D STD |  0 | 27
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_28
+++ b/tables/bufrtab.TableD_STD_0_28
@@ -1,7 +1,7 @@
 Table D STD |  0 | 28
 #
 # Standard BUFR Table D, Master Table 0, Version 28
-# This file was generated: 2021/05/11 22:56:26
+# This file was generated: 2022/11/08 16:33:23
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7233,69 +7233,6 @@ Table D STD |  0 | 28
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_29
+++ b/tables/bufrtab.TableD_STD_0_29
@@ -1,7 +1,7 @@
 Table D STD |  0 | 29
 #
 # Standard BUFR Table D, Master Table 0, Version 29
-# This file was generated: 2021/05/11 22:56:28
+# This file was generated: 2022/11/08 16:33:27
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7396,69 +7396,6 @@ Table D STD |  0 | 29
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_30
+++ b/tables/bufrtab.TableD_STD_0_30
@@ -1,7 +1,7 @@
 Table D STD |  0 | 30
 #
 # Standard BUFR Table D, Master Table 0, Version 30
-# This file was generated: 2021/05/11 22:56:31
+# This file was generated: 2022/11/08 16:33:32
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7472,69 +7472,6 @@ Table D STD |  0 | 30
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and Regional Code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_31
+++ b/tables/bufrtab.TableD_STD_0_31
@@ -1,7 +1,7 @@
 Table D STD |  0 | 31
 #
 # Standard BUFR Table D, Master Table 0, Version 31
-# This file was generated: 2021/05/11 22:56:33
+# This file was generated: 2022/11/08 16:33:37
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7833,69 +7833,6 @@ Table D STD |  0 | 31
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_32
+++ b/tables/bufrtab.TableD_STD_0_32
@@ -1,7 +1,7 @@
 Table D STD |  0 | 32
 #
 # Standard BUFR Table D, Master Table 0, Version 32
-# This file was generated: 2021/05/11 22:56:36
+# This file was generated: 2022/11/08 16:33:41
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7845,69 +7845,6 @@ Table D STD |  0 | 32
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_33
+++ b/tables/bufrtab.TableD_STD_0_33
@@ -1,7 +1,7 @@
 Table D STD |  0 | 33
 #
 # Standard BUFR Table D, Master Table 0, Version 33
-# This file was generated: 2021/05/11 22:56:38
+# This file was generated: 2022/11/08 16:33:46
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -7883,69 +7883,6 @@ Table D STD |  0 | 33
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_35
+++ b/tables/bufrtab.TableD_STD_0_35
@@ -1,7 +1,7 @@
 Table D STD |  0 | 35
 #
 # Standard BUFR Table D, Master Table 0, Version 35
-# This file was generated: 2021/05/11 22:56:43
+# This file was generated: 2022/11/08 16:33:55
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -8080,69 +8080,6 @@ Table D STD |  0 | 35
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_36
+++ b/tables/bufrtab.TableD_STD_0_36
@@ -1,7 +1,7 @@
 Table D STD |  0 | 36
 #
 # Standard BUFR Table D, Master Table 0, Version 36
-# This file was generated: 2021/05/11 22:56:46
+# This file was generated: 2022/11/08 16:34:00
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -8265,69 +8265,6 @@ Table D STD |  0 | 36
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_37
+++ b/tables/bufrtab.TableD_STD_0_37
@@ -1,7 +1,7 @@
 Table D STD |  0 | 37
 #
 # Standard BUFR Table D, Master Table 0, Version 37
-# This file was generated: 2021/11/02 21:15:52
+# This file was generated: 2022/11/08 16:34:05
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -8296,69 +8296,6 @@ Table D STD |  0 | 37
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_38
+++ b/tables/bufrtab.TableD_STD_0_38
@@ -1,7 +1,7 @@
 Table D STD |  0 | 38
 #
 # Standard BUFR Table D, Master Table 0, Version 38
-# This file was generated: 2022/05/10 17:21:56
+# This file was generated: 2022/11/08 16:34:09
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -8355,69 +8355,6 @@ Table D STD |  0 | 38
            | 0-08-043 > | Atmospheric chemical or physical constituent type
            | 0-08-044 > | CAS registry number
            | 0-15-021   | Integrated mass density
-
-  3-35-001 | SPECMSTN   ;     ; Specify monitoring station
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 3-01-001   | WMO block and station numbers
-
-  3-35-002 | SPECMCTR   ;     ; Specify monitoring centre
-           | 0-08-035 > | Type of monitoring exercise
-           | 0-35-001 > | Time frame for monitoring
-           | 0-08-036 > | Type of centre or station performing monitoring
-           | 0-01-033   | Identification of originating/generating centre
-
-  3-35-003 | SPECMPER   ;     ; Specify monitoring period
-           | 0-08-021 > | Time significance
-           | 0-04-001 > | Year
-           | 0-04-002 > | Month
-           | 0-04-003 > | Day
-           | 0-04-004 > | Hour
-           | 0-04-073   | Short time period or displacement
-
-  3-35-004 | SPECRTSS   ;     ; Specify report type and single station being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 3-01-001 > | WMO block and station numbers
-           | 0-35-011   | Number of reports actually received
-
-  3-35-005 | SPECRTWB   ;     ; Specify report type and WMO block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-006 | SPECRTWR   ;     ; Specify report type and WMO region being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-003 > | WMO Region number/geographical area
-           | 0-35-011   | Number of reports actually received
-
-  3-35-007 | RTYPMUMO   ;     ; Report type and multiple stations from one block being monitored
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-08-021 > | Time significance
-           | 0-04-004 > | Hour
-           | 0-35-000 > | FM and regional code number
-           | 0-01-001 > | WMO block number
-           | 1-02-000 > | Delayed replication of 2 descriptors
-           | 0-01-002 > | WMO station number
-           | 0-35-011   | Number of reports actually received
-
-  3-35-010 | MONRTPMS   ;     ; Monitoring a report type from multiple stations
-           | 3-35-002 > | Specify monitoring centre
-           | 3-35-003 > | Specify monitoring period
-           | 3-35-007   | Report type and multiple stations from one block being monitored
 
   3-40-001 | IASIL1CD   ;     ; IASI Level 1c data
            | 0-01-007 > | Satellite identifier

--- a/tables/bufrtab.TableD_STD_0_39
+++ b/tables/bufrtab.TableD_STD_0_39
@@ -1,7 +1,7 @@
-Table D STD |  0 | 34
+Table D STD |  0 | 39
 #
-# Standard BUFR Table D, Master Table 0, Version 34
-# This file was generated: 2022/11/08 16:33:51
+# Standard BUFR Table D, Master Table 0, Version 39
+# This file was generated: 2022/11/08 16:34:15
 #
 #========================================================================================================
 # F-XX-YYY | MNEMONIC   ;DCOD ; NAME           <-- sequence definition
@@ -647,6 +647,18 @@ Table D STD |  0 | 34
            | 0-05-021 > | Bearing or azimuth
            | 0-07-025 > | Solar zenith angle
            | 0-05-022   | Solar azimuth
+
+  3-01-132 | CMNHSEQ    ;     ; Common header sequence
+           | 3-01-150 > | WIGOS identifier
+           | 3-01-001 > | WMO block and station numbers
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-07-030 > | Height of station ground above mean sea level
+           | 0-08-021 > | Time significance
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 0-02-006 > | Upper air remote sensing instrument type
+           | 0-01-079 > | Unique identifier for the profile
+           | 0-01-085   | Observing platform manufacturer's model
 
   3-01-150 | WIGOSID    ;     ; WIGOS identifier
            | 0-01-125 > | WIGOS identifier series
@@ -2478,6 +2490,75 @@ Table D STD |  0 | 34
            | 2-01-000 > | Cancel change data width
            | 0-15-011   | Log10 of integrated electron density
 
+  3-07-024 | GBGNSSTD   ;     ; Ground-based GNSS data - slant total delay
+           | 3-01-150 > | WIGOS identifier
+           | 0-01-015 > | Station or site name
+           | 0-01-040 > | Processing centre ID code
+           | 0-08-021 > | Time significance
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-022 > | Latitude/longitude (high accuracy), height of station
+           | 0-10-036 > | Geoid undulation
+           | 0-25-061 > | Software identification and version number
+           | 0-10-004 > | Pressure
+           | 0-12-001 > | Temperature/air temperature
+           | 0-13-003 > | Relative humidity
+           | 1-20-000 > | Delayed replication of 20 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-25-060 > | Software identification
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 1-15-000 > | Delayed replication of 15 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-15-079 > | Zenith path delay due to neutral atmosphere
+           | 0-15-080 > | Estimated error in neutral atmosphere zenith path delay
+           | 0-08-022 > | Total number (with respect to accumulation or average)
+           | 0-33-093 > | Extended quality flags for ground-based GNSS data
+           | 0-15-089 > | Zenith path delay due to neutral hydrostatic atmosphere
+           | 0-15-035 > | Component of zenith path delay due to water vapour
+           | 1-02-002 > | Replicate 2 descriptors 2 times
+           | 0-08-060 > | Sample scanning mode significance
+           | 0-15-083 > | GNSS derived neutral atmosphere gradient
+           | 2-01-131 > | Change data width
+           | 2-02-129 > | Change scale
+           | 0-13-016 > | Precipitable water
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 0-15-011 > | Log10 of integrated electron density
+           | 1-31-000 > | Delayed replication of 31 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-25-060 > | Software identification
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 0-33-093 > | Extended quality flags for ground-based GNSS data
+           | 1-25-000 > | Delayed replication of 25 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-02-020 > | Satellite classification
+           | 0-01-050 > | Platform transmitter ID number
+           | 0-01-150 > | Coordinate reference system
+           | 2-02-127 > | Change scale
+           | 3-04-030 > | Location of platform
+           | 2-02-000 > | Cancel change scale
+           | 0-05-021 > | Bearing or azimuth
+           | 0-07-021 > | Elevation
+           | 0-15-038 > | Path delay due to neutral atmosphere
+           | 0-15-039 > | Estimated error in neutral atmosphere path delay
+           | 0-15-090 > | Path delay due to neutral hydrostatic atmosphere
+           | 0-15-081 > | Wet path delay due to neutral atmosphere
+           | 0-15-082 > | Path integrated water vapour
+           | 0-15-079 > | Zenith path delay due to neutral atmosphere
+           | 0-15-089 > | Zenith path delay due to neutral hydrostatic atmosphere
+           | 0-15-035 > | Component of zenith path delay due to water vapour
+           | 1-02-002 > | Replicate 2 descriptors 2 times
+           | 0-08-060 > | Sample scanning mode significance
+           | 0-15-083 > | GNSS derived neutral atmosphere gradient
+           | 0-15-084 > | GNSS least squares residual
+           | 0-15-085 > | GNSS multi-path delay
+           | 0-15-086 > | GNSS hydrostatic mapping function
+           | 0-15-087 > | GNSS wet mapping function
+           | 0-15-088 > | GNSS gradient mapping function
+           | 0-15-011   | Log10 of integrated electron density
+
   3-07-030 | OZONSNGL   ;     ; Ozone data - single observation
            | 0-15-001 > | Total ozone
            | 0-15-002   | Air mass (slant path at 22 km)
@@ -2531,7 +2612,7 @@ Table D STD |  0 | 34
            | 3-01-074 > | Ozone instrumentation - Dobson spectrophotometer
            | 3-07-031   | Ozone data - averaged observations
 
-  3-07-045 | METARSPM   ;     ; Main part of METAR/SPECI, replacing 3-07-011
+  3-07-045 | METARSPM   ;     ; Main part of METAR/SPECI
            | 0-01-063 > | ICAO location indicator
            | 0-08-079 > | Product status
            | 0-02-001 > | Type of station
@@ -2567,7 +2648,7 @@ Table D STD |  0 | 34
            | 0-05-021 > | Bearing or azimuth
            | 0-20-059   | Minimum horizontal visibility
 
-  3-07-047 | METARSPC   ;     ; METAR/SPECI/TAF clouds, replacing 3-07-015
+  3-07-047 | METARSPC   ;     ; METAR/SPECI/TAF clouds
            | 1-05-000 > | Delayed replication of 5 descriptors
            | 0-31-001 > | Delayed descriptor replication factor
            | 0-08-002 > | Vertical significance (surface observations)
@@ -2578,7 +2659,7 @@ Table D STD |  0 | 34
            | 0-20-002 > | Vertical visibility
            | 0-20-091   | Vertical visibility
 
-  3-07-048 | TRENDFST   ;     ; Trend type forecast, replacing 3-07-018
+  3-07-048 | TRENDFST   ;     ; Trend type forecast
            | 0-08-016 > | Change qualifier of a trend-type forecast or an aerodrome forecast
            | 1-02-000 > | Delayed replication of 2 descriptors
            | 0-31-001 > | Delayed descriptor replication factor
@@ -2627,7 +2708,7 @@ Table D STD |  0 | 34
            | 0-20-088 > | Depth of runway deposits
            | 0-20-089   | Runway friction coefficient
 
-  3-07-051 | METARSPI   ;     ; Full METAR/SPECI, replacing 3-07-021
+  3-07-051 | METARSPI   ;     ; Full METAR/SPECI
            | 3-07-045 > | Main part of METAR/SPECI), replacing 3 07 01
            | 3-07-046 > | METAR/SPECI visibility
            | 3-07-013 > | Runway visual range
@@ -2861,6 +2942,44 @@ Table D STD |  0 | 34
            | 0-13-060 > | Total accumulated precipitation
            | 0-13-012 > | Depth of fresh snow
            | 0-13-013   | Total snow depth
+
+  3-07-075 | SDXTMPC2   ;     ; Supplemental daily temperature and precipitation values with the time of occurrence for monthly climate report
+           | 3-01-150 > | WIGOS identifier
+           | 3-01-001 > | WMO block and station numbers
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-07-030 > | Height of station ground above mean sea level
+           | 0-08-095 > | Siting and measurement quality classification for temperature
+           | 0-08-096 > | Siting and measurement quality classification for precipitation
+           | 0-08-094 > | Method used to calculate the average daily temperature
+           | 3-01-011 > | Year, month, day
+           | 0-04-023 > | Time period or displacement
+           | 3-01-013 > | Hour, minute, second
+           | 2-04-008 > | Add associated field
+           | 0-31-021 > | Associated field significance
+           | 0-13-060 > | Total accumulated precipitation
+           | 2-04-000 > | Cancel add associated field
+           | 0-04-023 > | Time period or displacement
+           | 3-01-013 > | Hour, minute, second
+           | 2-04-008 > | Add associated field
+           | 0-31-021 > | Associated field significance
+           | 0-13-012 > | Depth of fresh snow
+           | 2-04-000 > | Cancel add associated field
+           | 0-04-023 > | Time period or displacement
+           | 3-01-013 > | Hour, minute, second
+           | 2-04-008 > | Add associated field
+           | 0-31-021 > | Associated field significance
+           | 0-13-013 > | Total snow depth
+           | 2-04-000 > | Cancel add associated field
+           | 0-07-032 > | Height of sensor above local ground (or deck of marine platform)
+           | 1-07-003 > | Replicate 7 descriptors 3 times
+           | 0-04-023 > | Time period or displacement
+           | 3-01-013 > | Hour, minute, second
+           | 0-08-023 > | First-order statistics
+           | 2-04-008 > | Add associated field
+           | 0-31-021 > | Associated field significance
+           | 0-12-101 > | Temperature/air temperature
+           | 2-04-000 > | Cancel add associated field
+           | 0-08-023   | First-order statistics
 
   3-07-076 | MNTHVLRP   ;     ; Monthly values from a land station in compliance with regional or national reporting practices
            | 3-01-090 > | Surface station identification; time, horizontal and vertical coordinates
@@ -3974,7 +4093,7 @@ Table D STD |  0 | 34
            | 0-11-004 > | v-component
            | 0-11-005   | w-component
 
-  3-09-021 | RWPWND     ;     ; Radar wind profiler wind data (product data)
+  3-09-021 | RWPWND     ;     ; Single wavelength wind profiler wind data (product data)
            | 3-01-001 > | WMO block and station numbers
            | 0-05-001 > | Latitude (high accuracy)
            | 0-06-001 > | Longitude (high accuracy)
@@ -4018,7 +4137,7 @@ Table D STD |  0 | 34
            | 0-10-071 > | Vertical resolution
            | 0-27-079   | Horizontal width of sampled volume
 
-  3-09-023 | LIDARSEQ   ;     ; Lidar sequence
+  3-09-023 | LIDARSEQ   ;     ; Single wavelength elastic backscatter lidar sequence
            | 3-01-001 > | WMO block and station numbers
            | 0-05-001 > | Latitude (high accuracy)
            | 0-06-001 > | Longitude (high accuracy)
@@ -4043,6 +4162,107 @@ Table D STD |  0 | 34
            | 0-15-069 > | Particle lidar ratio
            | 0-15-070 > | Uncertainty in lidar ratio
            | 0-15-071 > | Particle depolarization ratio
+           | 0-15-072 > | Uncertainty in depolarization ratio
+           | 0-33-002 > | Quality information
+           | 0-10-071 > | Vertical resolution
+           | 0-27-079   | Horizontal width of sampled volume
+
+  3-09-024 | RWPWND2    ;     ; Single wavelength wind profiler wind data sequence (product data)
+           | 3-01-132 > | Common header sequence
+           | 2-01-151 > | Change data width
+           | 2-02-130 > | Change scale
+           | 0-02-121 > | Mean frequency
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 1-09-000 > | Delayed replication of 9 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-007 > | Height
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-11-003 > | u-component
+           | 0-11-004 > | v-component
+           | 0-33-002 > | Quality information
+           | 0-11-006 > | w-component
+           | 0-33-002 > | Quality information
+           | 0-10-071 > | Vertical resolution
+           | 0-27-079   | Horizontal width of sampled volume
+
+  3-09-025 | RASSTMV2   ;     ; RASS virtual temperature sequence (product data)
+           | 3-01-132 > | Common header sequence
+           | 2-01-151 > | Change data width
+           | 2-02-130 > | Change scale
+           | 0-02-121 > | Mean frequency
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 1-06-000 > | Delayed replication of 6 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-007 > | Height
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-12-007 > | Virtual temperature
+           | 0-33-002 > | Quality information
+           | 0-10-071 > | Vertical resolution
+           | 0-27-079   | Horizontal width of sampled volume
+
+  3-09-026 | LIDARSQ2   ;     ; Single wavelength elastic backscatter lidar sequence
+           | 3-01-132 > | Common header sequence
+           | 3-02-004 > | General cloud information
+           | 3-02-005 > | Cloud layer
+           | 0-08-092 > | Measurement uncertainty expression
+           | 0-08-093 > | Measurement uncertainty significance
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 2-01-138 > | Change data width
+           | 2-02-126 > | Change scale
+           | 0-02-121 > | Mean frequency
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 1-15-000 > | Delayed replication of 15 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-007 > | Height
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-15-073 > | Attenuated backscatter
+           | 0-15-064 > | Uncertainty in attenuated backscatter
+           | 0-15-074 > | Particle backscatter coefficient
+           | 0-15-066 > | Uncertainty in particle backscatter coefficient
+           | 0-15-075 > | Particle extinction coefficient
+           | 0-15-068 > | Uncertainty in particle extinction coefficient
+           | 0-15-076 > | Particle lidar ratio
+           | 0-15-077 > | Uncertainty in lidar ratio
+           | 0-15-078 > | Particle depolarization ratio
+           | 0-15-072 > | Uncertainty in depolarization ratio
+           | 0-33-002 > | Quality information
+           | 0-10-071 > | Vertical resolution
+           | 0-27-079   | Horizontal width of sampled volume
+
+  3-09-027 | LIDARSQ3   ;     ; Multi wavelength ground-based lidar sequence
+           | 3-01-132 > | Common header sequence
+           | 0-08-043 > | Atmospheric chemical or physical constituent type
+           | 0-25-061 > | Software identification and version number
+           | 3-02-004 > | General cloud information
+           | 3-02-005 > | Cloud layer
+           | 0-08-092 > | Measurement uncertainty expression
+           | 0-08-093 > | Measurement uncertainty significance
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 1-18-000 > | Delayed replication of 18 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-02-090 > | Instrument wavelength
+           | 1-15-000 > | Delayed replication of 15 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-007 > | Height
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-15-073 > | Attenuated backscatter
+           | 0-15-064 > | Uncertainty in attenuated backscatter
+           | 0-15-074 > | Particle backscatter coefficient
+           | 0-15-066 > | Uncertainty in particle backscatter coefficient
+           | 0-15-075 > | Particle extinction coefficient
+           | 0-15-068 > | Uncertainty in particle extinction coefficient
+           | 0-15-076 > | Particle lidar ratio
+           | 0-15-077 > | Uncertainty in lidar ratio
+           | 0-15-078 > | Particle depolarization ratio
            | 0-15-072 > | Uncertainty in depolarization ratio
            | 0-33-002 > | Quality information
            | 0-10-071 > | Vertical resolution
@@ -6292,6 +6512,43 @@ Table D STD |  0 | 34
            | 3-01-023 > | Latitude/longitude (coarse accuracy)
            | 3-21-028   | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
 
+  3-12-029 | SCATLV2B   ;     ; Scatterometer level 2b data
+           | 3-01-046 > | Satellite identifier, direction of motion, sensor, model function, software, resolution
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-08-025 > | Time difference qualifier
+           | 2-01-136 > | Change data width
+           | 0-04-006 > | Second
+           | 2-01-000 > | Cancel change data width
+           | 0-05-034 > | Along track row number
+           | 2-01-129 > | Change data width
+           | 0-06-034 > | Cross-track cell number
+           | 2-01-000 > | Cancel change data width
+           | 0-33-055 > | Wind vector quality flag
+           | 0-11-081 > | Model wind direction at 10 m
+           | 0-11-082 > | Model wind speed at 10 m
+           | 0-21-101 > | Number of vector ambiguities
+           | 0-21-102 > | Index of selected wind vector
+           | 0-21-103 > | Total number of sigma-0 measurements
+           | 3-12-032 > | SEAWINDS precipitation
+           | 1-01-004 > | Replicate 1 descriptor 4 times
+           | 3-12-030 > | Wind, formal uncertainty, likelihood
+           | 1-01-002 > | Replicate 1 descriptor 2 times
+           | 3-12-033 > | Antenna polarization, brightness temperature
+           | 0-21-110 > | Number of inner-beam sigma-0 (forward of satellite)
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 3-21-028 > | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
+           | 0-21-111 > | Number of outer-beam sigma-0 (forward of satellite)
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 3-21-028 > | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
+           | 0-21-112 > | Number of inner-beam sigma-0 (aft of satellite)
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 3-21-028 > | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
+           | 0-21-113 > | Number of outer-beam sigma-0 (aft of satellite)
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 3-21-028   | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
+
   3-12-030 | WNFRMUNL   ;     ; Wind, formal uncertainty, likelihood
            | 2-01-130 > | Change data width
            | 2-02-129 > | Change scale
@@ -6328,6 +6585,58 @@ Table D STD |  0 | 34
            | 0-08-022 > | Total number (with respect to accumulation or average)
            | 0-12-063 > | Brightness temperature
            | 0-12-065   | Standard deviation brightness temperature
+
+  3-12-034 | SCATCFOS   ;     ; CFOSAT scatterometer data
+           | 3-01-046 > | Satellite identifier, direction of motion, sensor, model function, software, resolution
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-08-025 > | Time difference qualifier
+           | 2-01-136 > | Change data width
+           | 0-04-006 > | Second
+           | 2-01-000 > | Cancel change data width
+           | 3-12-031 > | SEAWINDS wind
+           | 3-12-032 > | SEAWINDS precipitation
+           | 1-01-004 > | Replicate 1 descriptor 4 times
+           | 3-12-030 > | Wind, formal uncertainty, likelihood
+           | 1-01-002 > | Replicate 1 descriptor 2 times
+           | 3-12-033 > | Antenna polarization, brightness temperature
+           | 1-03-018 > | Replicate 3 descriptors 18 times
+           | 0-21-110 > | Number of inner-beam sigma-0 (forward of satellite)
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 3-21-028   | Radar specification, SEAWINDS normalized radar cross-section, Kp variance coefficient
+
+  3-12-035 | SCATLV2A   ;     ; Scatterometer level 2a data
+           | 0-01-007 > | Satellite identifier
+           | 0-01-031 > | Identification of originating/generating centre
+           | 0-02-048 > | Satellite sensor indicator
+           | 2-02-124 > | Change scale
+           | 0-02-026 > | Cross-track resolution
+           | 0-02-027 > | Along-track resolution
+           | 2-02-000 > | Cancel change scale
+           | 0-05-040 > | Orbit number
+           | 0-04-001 > | Year
+           | 0-04-002 > | Month
+           | 0-04-003 > | Day
+           | 0-04-004 > | Hour
+           | 0-04-005 > | Minute
+           | 0-04-006 > | Second
+           | 0-05-002 > | Latitude (coarse accuracy)
+           | 0-06-002 > | Longitude (coarse accuracy)
+           | 0-05-034 > | Along track row number
+           | 0-06-031 > | Column number
+           | 2-01-129 > | Change data width
+           | 0-06-034 > | Cross-track cell number
+           | 2-01-000 > | Cancel change data width
+           | 0-05-021 > | Bearing or azimuth
+           | 0-02-111 > | Radar incidence angle
+           | 0-12-063 > | Brightness temperature
+           | 0-21-095 > | Kp coefficient A
+           | 0-21-096 > | Kp coefficient B
+           | 0-21-097 > | Kp coefficient C
+           | 0-21-030 > | Signal to noise ratio
+           | 0-21-105 > | Normalized radar cross-section
+           | 0-33-056   | Sigma-0 quality flag
 
   3-12-041 | ALTITUDE   ;     ; Altitude
            | 2-01-141 > | Change data width
@@ -6653,6 +6962,17 @@ Table D STD |  0 | 34
            | 3-12-058 > | ASCAT level 1b data
            | 3-12-060 > | Scatterometer soil moisture data
            | 3-12-059   | Scatterometer wind data
+
+  3-12-062 | SNOWCVR    ;     ; Snow cover
+           | 0-01-007 > | Satellite identifier
+           | 0-02-019 > | Satellite instruments
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-20-065 > | Snow cover
+           | 0-08-023 > | First-order statistics
+           | 0-20-065 > | Snow cover
+           | 0-08-023   | First-order statistics
 
   3-12-070 | SMOSDATA   ;     ; SMOS data
            | 0-01-007 > | Satellite identifier
@@ -7067,6 +7387,138 @@ Table D STD |  0 | 34
            | 0-42-013 > | a2 coefficient of the directional Fourier series
            | 0-42-014 > | b2 coefficient of the directional Fourier series
            | 0-42-015   | Check factor K
+
+  3-15-011 | MOOBASFV   ;     ; Met-ocean observations from autonomous surface vehicles
+           | 3-01-150 > | WIGOS identifier
+           | 0-01-087 > | WMO marine observing platform extended identifier
+           | 0-01-036 > | Agency in charge of operating the observing platform
+           | 0-01-085 > | Observing platform manufacturer's model
+           | 0-01-086 > | Observing platform manufacturer's serial number
+           | 0-03-001 > | Surface station type
+           | 2-08-032 > | Change width of CCITT IA5 field
+           | 0-01-079 > | Unique identifier for the profile
+           | 2-08-000 > | Cancel change width of CCITT IA5 field
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-01-012 > | Direction of motion of moving observing platform
+           | 0-01-014 > | Platform drift speed (high precision)
+           | 0-11-104 > | True heading of aircraft, ship or other mobile platform
+           | 1-03-000 > | Delayed replication of 3 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-07-031 > | Height of barometer above mean sea level
+           | 3-06-038 > | Sequence for representation of standard surface marine meteorological observations from moored buoys
+           | 0-12-161 > | Skin temperature
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-034 > | Surface current
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-039 > | Sequence for representation of basic wave measurements
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-033 > | Surface salinity
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-041 > | Depth and temperature profile (high accuracy/precision)
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-004 > | Depth, temperature, salinity
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-005 > | 
+           | 1-05-000 > | Delayed replication of 5 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-41-001 > | pCO2
+           | 0-08-043 > | Atmospheric chemical or physical constituent type
+           | 0-15-028 > | Mole fraction of atmospheric constituent/pollutant in dry air
+           | 0-08-043 > | Atmospheric chemical or physical constituent type
+           | 0-13-080 > | Water pH
+           | 1-04-000 > | Delayed replication of 4 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-41-005 > | Turbidity
+           | 0-41-003 > | Dissolved nitrates
+           | 0-22-188 > | Dissolved oxygen
+           | 0-41-002 > | Fluorescence
+           | 1-01-000 > | Delayed replication of 1 descriptor
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 3-06-040 > | Sequence for representation of detailed spectral wave measurements
+           | 1-04-000 > | Delayed replication of 4 descriptors
+           | 0-31-000 > | Short delayed descriptor replication factor
+           | 0-08-021 > | Time significance
+           | 0-04-025 > | Time period or displacement
+           | 0-14-017 > | Instantaneous long-wave radiation
+           | 0-14-018   | Instantaneous short-wave radiation
+
+  3-15-013 | PFMRANML   ;     ; Sequence for reporting trajectory profile data from marine animal tags
+           | 3-01-150 > | WIGOS identifier
+           | 0-01-087 > | WMO marine observing platform extended identifier
+           | 2-08-032 > | Change width of CCITT IA5 field
+           | 0-01-019 > | Long station or site name
+           | 2-08-000 > | Cancel change width of CCITT IA5 field
+           | 0-03-001 > | Surface station type
+           | 0-22-067 > | Instrument type for water temperature/salinity profile measurement
+           | 0-01-051 > | Platform transmitter ID number
+           | 0-02-148 > | Data collection and/or location system
+           | 1-12-000 > | Delayed replication of 12 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-08-021 > | Time significance
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-01-012 > | Direction of motion of moving observing platform
+           | 0-01-014 > | Platform drift speed (high precision)
+           | 0-33-022 > | Quality of buoy satellite transmission
+           | 0-33-023 > | Quality of buoy location
+           | 0-33-027 > | Location quality class (range of radius of 66 % confidence)
+           | 0-07-063 > | Depth below sea/water surface (cm)
+           | 0-22-045 > | Sea/water temperature
+           | 0-08-021 > | Time significance
+           | 1-07-000 > | Delayed replication of 7 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-01-079 > | Unique identifier for the profile
+           | 0-01-023 > | Observation sequence number
+           | 0-22-056 > | Direction of profile
+           | 3-06-035   | Temperature and salinity profile
+
+  3-15-023 | PFMRANM2   ;     ; Sequence for reporting trajectory profile data from marine animal tags
+           | 3-01-150 > | WIGOS identifier
+           | 2-01-129 > | Change data width
+           | 0-01-087 > | WMO marine observing platform extended identifier
+           | 2-01-000 > | Cancel change data width
+           | 2-08-032 > | Change width of CCITT IA5 field
+           | 0-01-019 > | Long station or site name
+           | 2-08-000 > | Cancel change width of CCITT IA5 field
+           | 0-03-001 > | Surface station type
+           | 0-22-067 > | Instrument type for water temperature/salinity profile measurement
+           | 0-01-051 > | Platform transmitter ID number
+           | 0-02-148 > | Data collection and/or location system
+           | 1-12-000 > | Delayed replication of 12 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-08-021 > | Time significance
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-01-012 > | Direction of motion of moving observing platform
+           | 0-01-014 > | Platform drift speed (high precision)
+           | 0-33-022 > | Quality of buoy satellite transmission
+           | 0-33-023 > | Quality of buoy location
+           | 0-33-027 > | Location quality class (range of radius of 66 % confidence)
+           | 0-07-063 > | Depth below sea/water surface (cm)
+           | 0-22-045 > | Sea/water temperature
+           | 0-08-021 > | Time significance
+           | 1-07-000 > | Delayed replication of 7 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-01-079 > | Unique identifier for the profile
+           | 0-01-023 > | Observation sequence number
+           | 0-22-056 > | Direction of profile
+           | 3-06-035   | Temperature and salinity profile
 
   3-16-001 | DLIMTPRT   ;     ; 
            | 3-01-011 > | Year, month, day
@@ -7602,6 +8054,52 @@ Table D STD |  0 | 34
            | 0-08-041 > | Data significance
            | 0-08-079   | Product status
 
+  3-16-082 | TCTRKWRD   ;     ; Tropical cyclone track and wind radii
+           | 0-01-033 > | Identification of originating/generating centre
+           | 0-01-034 > | Identification of originating/generating sub-centre
+           | 0-01-032 > | Generating application
+           | 0-01-025 > | Storm identifier
+           | 0-01-027 > | WMO long storm name
+           | 0-01-090 > | Technique for making up initial perturbations
+           | 0-01-091 > | Ensemble member number
+           | 0-01-092 > | Type of ensemble forecast
+           | 3-01-011 > | Year, month, day
+           | 3-01-012 > | Hour, minute
+           | 0-08-005 > | Meteorological attribute significance
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-08-005 > | Meteorological attribute significance
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-10-051 > | Pressure reduced to mean sea level
+           | 0-08-005 > | Meteorological attribute significance
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-11-012 > | Wind speed at 10 m
+           | 1-07-003 > | Replicate 7 descriptors 3 times
+           | 0-19-003 > | Wind speed threshold
+           | 1-05-004 > | Replicate 5 descriptors 4 times
+           | 0-05-021 > | Bearing or azimuth
+           | 0-05-021 > | Bearing or azimuth
+           | 2-01-131 > | Change data width
+           | 0-19-004 > | Effective radius with respect to wind speeds above threshold
+           | 2-01-000 > | Cancel change data width
+           | 1-16-000 > | Delayed replication of 16 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-08-021 > | Time significance
+           | 0-04-024 > | Time period or displacement
+           | 0-08-005 > | Meteorological attribute significance
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-10-051 > | Pressure reduced to mean sea level
+           | 0-08-005 > | Meteorological attribute significance
+           | 3-01-023 > | Latitude/longitude (coarse accuracy)
+           | 0-11-012 > | Wind speed at 10 m
+           | 1-07-003 > | Replicate 7 descriptors 3 times
+           | 0-19-003 > | Wind speed threshold
+           | 1-05-004 > | Replicate 5 descriptors 4 times
+           | 0-05-021 > | Bearing or azimuth
+           | 0-05-021 > | Bearing or azimuth
+           | 2-01-131 > | Change data width
+           | 0-19-004 > | Effective radius with respect to wind speeds above threshold
+           | 2-01-000   | Cancel change data width
+
   3-18-001 | LALODOSE   ;     ; 
            | 3-01-025 > | Latitude/longitude (coarse accuracy), day/time
            | 0-24-011   | Dose
@@ -7845,6 +8343,27 @@ Table D STD |  0 | 34
            | 0-21-164 > | ASCAT telemetry presence and quality
            | 0-21-165 > | ASCAT extrapolated reference function presence
            | 0-21-166   | Land fraction
+
+  3-21-031 | SATRDOBS   ;     ; Satellite radar observations
+           | 0-01-007 > | Satellite identifier
+           | 0-02-019 > | Satellite instruments
+           | 0-01-033 > | Identification of originating/generating centre
+           | 0-01-034 > | Identification of originating/generating sub-centre
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-10-033 > | Altitude (platform to ellipsoid)
+           | 0-08-043 > | Atmospheric chemical or physical constituent type
+           | 0-25-139 > | Processing level
+           | 0-02-153 > | Satellite channel centre frequency
+           | 1-06-000 > | Delayed replication of 6 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-071 > | Height (high resolution)
+           | 0-21-007 > | Radar reflectivity factor
+           | 0-21-008 > | Uncertainty in radar reflectivity factor
+           | 0-21-009 > | Vertical Doppler velocity
+           | 0-21-010 > | Uncertainty in vertical Doppler velocity
+           | 0-33-003   | Quality information
 
   3-22-028 | GOME2TMP   ;     ; METOP GOME-2
            | 0-01-007 > | Satellite identifier
@@ -8707,4 +9226,232 @@ Table D STD |  0 | 34
            | 0-13-013 > | Total snow depth
            | 0-25-112 > | Band specific altimeter data quality flag
            | 0-33-092   | Band specific ocean quality flag
+
+  3-40-018 | IKFS2SP    ;     ; Infrared Fourier spectrometer - 2 (IKFS-2) spectra
+           | 3-01-129 > | Observing satellite and instruments
+           | 3-01-130 > | High precision timestamp
+           | 3-01-131 > | Pixel geolocation
+           | 0-07-072 > | Scan angle
+           | 0-40-074 > | General interferometry quality flags
+           | 1-04-000 > | Delayed replication of 4 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 2-01-136 > | Change data width
+           | 0-05-042 > | Channel number
+           | 2-01-000 > | Cancel change data width
+           | 0-14-044   | Channel radiance
+
+  3-40-019 | ALTMPROD   ;     ; Altimeter product
+           | 3-40-020 > | Satellite general values
+           | 3-40-021 > | General radiometer values
+           | 3-40-022 > | Altimeter model values
+           | 3-40-023   | Altimeter main values
+
+  3-40-020 | SATGENV    ;     ; Satellite general values
+           | 0-01-007 > | Satellite identifier
+           | 0-02-019 > | Satellite instruments
+           | 0-05-044 > | Satellite cycle number
+           | 0-01-096 > | Station acquisition
+           | 0-05-040 > | Orbit number
+           | 0-01-040 > | Processing centre ID code
+           | 0-25-061 > | Software identification and version number
+           | 0-25-182 > | L1 processing flag
+           | 0-25-183 > | L1 processing quality
+           | 0-25-181 > | L2 processing flag
+           | 0-25-184 > | L2 product status
+           | 0-08-075 > | Ascending/descending orbit qualifier
+           | 0-25-090 > | Orbit state flag
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 0-04-007 > | Seconds within a minute (microsecond accuracy)
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-05-063 > | Spacecraft roll
+           | 0-05-064 > | Spacecraft pitch
+           | 0-05-066 > | Spacecraft yaw
+           | 0-10-081 > | Altitude of COG above reference ellipsoid
+           | 0-10-082   | Instantaneous altitude rate
+
+  3-40-021 | RDMGENV    ;     ; General radiometer values
+           | 0-40-012 > | Radiometer data quality flag
+           | 0-08-077 > | Radiometer sensed surface type
+           | 1-04-000 > | Delayed replication of 4 descriptors
+           | 0-31-001 > | Delayed descriptor replication factor
+           | 0-02-153 > | Satellite channel centre frequency
+           | 0-12-063 > | Brightness temperature
+           | 0-12-065 > | Standard deviation brightness temperature
+           | 0-40-013 > | Radiometer brightness temperature interpretation flag
+           | 0-07-002 > | Height or altitude
+           | 0-11-098   | Wind speed from radiometer
+
+  3-40-022 | ALTMMDVL   ;     ; Altimeter model values
+           | 0-08-029 > | Surface type
+           | 2-01-137 > | Change data width
+           | 2-02-129 > | Change scale
+           | 0-06-021 > | Distance
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 0-10-087 > | Ocean depth/land elevation
+           | 0-40-024 > | Meteorological map availability
+           | 0-07-002 > | Height or altitude
+           | 0-25-126 > | Model dry tropospheric correction
+           | 0-25-128 > | Model wet tropospheric correction
+           | 0-40-011 > | Interpolation flag
+           | 0-07-002 > | Height or altitude
+           | 0-11-095 > | u-component of the model wind vector
+           | 0-11-096 > | v-component of the model wind vector
+           | 0-10-088 > | Total geocentric ocean tide height (solution 1)
+           | 0-10-089 > | Total geocentric ocean tide height (solution 2)
+           | 0-10-090 > | Long period tide height
+           | 0-10-092 > | Solid Earth tide height
+           | 0-10-093 > | Geocentric pole tide height
+           | 0-10-098 > | Loading tide height geocentric ocean tide solution 1
+           | 0-10-099 > | Loading tide height geocentric ocean tide solution 2
+           | 0-10-100 > | Non-equilibrium long period tide height
+           | 0-25-127 > | Inverted barometer correction
+           | 0-40-014 > | High-frequency fluctuations of the sea-surface topography correction
+           | 0-01-030 > | Numerical model identifier
+           | 0-10-085 > | Mean sea-surface height
+           | 0-01-030 > | Numerical model identifier
+           | 0-10-085 > | Mean sea-surface height
+           | 0-10-086 > | Geoid's height
+           | 0-10-096 > | Mean dynamic topography
+           | 0-10-103 > | Mean dynamic topography accuracy
+           | 0-21-169 > | Ice presence indicator
+           | 0-13-055 > | Intensity of precipitation
+           | 0-25-165   | Ionospheric correction from model on specific band
+
+  3-40-023 | ALTMMNVL   ;     ; Altimeter main values
+           | 0-25-095 > | Altimeter state flag
+           | 0-40-023 > | Auxiliary altimeter state flags
+           | 0-08-074 > | Altimeter echo type
+           | 3-40-024 > | 1 Hz C and Ku band values
+           | 3-40-024 > | 1 Hz C and Ku band values
+           | 3-40-024 > | 1 Hz C and Ku band values
+           | 3-40-025   | 20 Hz C and Ku band values
+
+  3-40-024 | CKUBV1     ;     ; 1 Hz C and Ku band values
+           | 0-22-080 > | Waveband central frequency
+           | 0-08-076 > | Type of band
+           | 0-25-190 > | Altimeter echo processing mode
+           | 0-10-102 > | Sea-surface height anomaly
+           | 0-22-189 > | Specific band ocean range
+           | 0-22-191 > | RMS of specific band ocean range
+           | 0-22-130 > | Number of valid points for specific band
+           | 0-25-167 > | Specific band net instrumental correction
+           | 0-25-163 > | Altimeter ionospheric correction on Ku band
+           | 0-15-012 > | Total electron count per square metre
+           | 0-25-164 > | Radiometer wet tropospheric correction
+           | 0-13-090 > | Radiometer water vapour content
+           | 0-13-091 > | Radiometer liquid content
+           | 0-25-166 > | Sea state bias correction on specific band
+           | 0-07-002 > | Height or altitude
+           | 0-11-097 > | Wind speed from altimeter
+           | 0-21-183 > | Specific band corrected ocean backscatter coefficient
+           | 0-21-184 > | STD specific band corrected ocean backscatter coefficient
+           | 0-22-134 > | Number of valid points for specific band backscatter
+           | 0-21-122 > | Attenuation correction on sigma-0 (from tB)
+           | 0-21-186 > | Specific band automatic gain control
+           | 0-21-187 > | RMS specific band automatic gain control
+           | 0-21-188 > | Number of valid points for specific band automatic gain control
+           | 2-01-131 > | Change data width
+           | 0-21-185 > | Specific band net instrumental correction for AGC
+           | 2-01-000 > | Cancel change data width
+           | 0-22-179 > | Specific band significant wave height (negative reference)
+           | 0-22-131 > | RMS specific band significant wave height
+           | 0-22-132 > | Number of valid points for specific band significant wave height
+           | 0-22-133 > | Specific band net instrument correction for significant wave height
+           | 0-21-144 > | Altimeter rain flag
+           | 0-25-191 > | Altimeter tracking mode
+           | 0-21-143 > | Ku band rain attenuation
+           | 0-10-101 > | Squared off-nadir angle of the satellite from waveform data
+           | 0-25-112 > | Band specific altimeter data quality flag
+           | 0-25-113 > | Band specific altimeter correction quality flag
+           | 0-33-092   | Band specific ocean quality flag
+
+  3-40-025 | CKUBV2O    ;     ; 20 Hz C and Ku band values
+           | 0-08-049 > | Number of observations
+           | 0-22-080 > | Waveband central frequency
+           | 0-08-076 > | Type of band
+           | 0-25-190 > | Altimeter echo processing mode
+           | 1-46-021 > | Replicate 46 descriptors 21 times
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 0-04-007 > | Seconds within a minute (microsecond accuracy)
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-10-081 > | Altitude of COG above reference ellipsoid
+           | 0-10-082 > | Instantaneous altitude rate
+           | 0-08-029 > | Surface type
+           | 2-01-137 > | Change data width
+           | 2-02-129 > | Change scale
+           | 0-06-021 > | Distance
+           | 2-02-000 > | Cancel change scale
+           | 2-01-000 > | Cancel change data width
+           | 0-25-191 > | Altimeter tracking mode
+           | 0-21-071 > | Peakiness
+           | 0-01-030 > | Numerical model identifier
+           | 0-10-085 > | Mean sea-surface height
+           | 0-01-030 > | Numerical model identifier
+           | 0-10-085 > | Mean sea-surface height
+           | 0-40-011 > | Interpolation flag
+           | 0-10-088 > | Total geocentric ocean tide height (solution 1)
+           | 0-10-089 > | Total geocentric ocean tide height (solution 2)
+           | 0-25-164 > | Radiometer wet tropospheric correction
+           | 0-07-002 > | Height or altitude
+           | 0-25-126 > | Model dry tropospheric correction
+           | 0-25-128 > | Model wet tropospheric correction
+           | 0-10-102 > | Sea-surface height anomaly
+           | 0-22-189 > | Specific band ocean range
+           | 0-25-167 > | Specific band net instrumental correction
+           | 0-25-163 > | Altimeter ionospheric correction on Ku band
+           | 0-21-183 > | Specific band corrected ocean backscatter coefficient
+           | 2-01-131 > | Change data width
+           | 0-21-185 > | Specific band net instrumental correction for AGC
+           | 2-01-000 > | Cancel change data width
+           | 0-22-179 > | Specific band significant wave height (negative reference)
+           | 0-22-133 > | Specific band net instrument correction for significant wave height
+           | 0-22-146 > | OCOG range
+           | 0-21-189 > | Corrected OCOG backscatter coefficient
+           | 0-13-163 > | Snow water equivalent
+           | 2-02-126 > | Change scale
+           | 0-22-046 > | Sea ice fraction
+           | 2-02-000 > | Cancel change scale
+           | 0-13-117 > | Snow density (liquid water content)
+           | 0-13-013 > | Total snow depth
+           | 0-25-112 > | Band specific altimeter data quality flag
+           | 0-25-113 > | Band specific altimeter correction quality flag
+           | 0-33-092   | Band specific ocean quality flag
+
+  3-40-026 | SATLDOBS   ;     ; Lidar observations from satellite
+           | 0-01-007 > | Satellite identifier
+           | 0-02-019 > | Satellite instruments
+           | 0-01-033 > | Identification of originating/generating centre
+           | 0-01-034 > | Identification of originating/generating sub-centre
+           | 3-01-011 > | Year, month, day
+           | 3-01-013 > | Hour, minute, second
+           | 3-01-021 > | Latitude/longitude (high accuracy)
+           | 0-10-033 > | Altitude (platform to ellipsoid)
+           | 0-08-043 > | Atmospheric chemical or physical constituent type
+           | 0-25-139 > | Processing level
+           | 0-02-155 > | Satellite channel wavelength
+           | 1-12-000 > | Delayed replication of 12 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 0-07-071 > | Height (high resolution)
+           | 0-33-003 > | Quality information
+           | 2-01-136 > | Change data width
+           | 0-15-074 > | Particle backscatter coefficient
+           | 0-15-066 > | Uncertainty in particle backscatter coefficient
+           | 0-15-075 > | Particle extinction coefficient
+           | 0-15-068 > | Uncertainty in particle extinction coefficient
+           | 2-01-000 > | Cancel change data width
+           | 0-15-076 > | Particle lidar ratio
+           | 0-15-070 > | Uncertainty in lidar ratio
+           | 0-15-078 > | Particle depolarization ratio
+           | 0-15-072 > | Uncertainty in depolarization ratio
+           | 1-07-003 > | Replicate 7 descriptors 3 times
+           | 0-05-069 > | Receiver channel
+           | 1-04-000 > | Delayed replication of 4 descriptors
+           | 0-31-002 > | Extended delayed descriptor replication factor
+           | 2-01-135 > | Change data width
+           | 0-15-073 > | Attenuated backscatter
+           | 0-15-064 > | Uncertainty in attenuated backscatter
+           | 2-01-000   | Cancel change data width
 END


### PR DESCRIPTION
Fixes #237 

FYI, the removal of all of the various 3-35-YYY entries from prior versions of Table D is because they had been included by accident.  According to WMO, all of those sequences are valid for CREX, but not for BUFR, so they're now being correspondingly removed from our tables.