### PR TITLE
more doxygen: fortran files starting with the letter 'c'

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+# This is the CMake build file for the src directory of NCEPLIBS-bufr.
+#
+# Kyle Gerheiser, Jeff Ator
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 list(APPEND fortran_src

--- a/src/chekstab.f
+++ b/src/chekstab.f
@@ -1,41 +1,29 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
-      
-C> THIS SUBROUTINE CHECKS THAT AN INTERNAL BUFR TABLE
-C>   REPRESENTATION IS SELF-CONSISTENT AND FULLY DEFINED.  IF ANY ERRORS
-C>   ARE FOUND, THEN AN APPROPRIATE CALL IS MADE TO BUFR ARCHIVE LIBRARY
-C>   SUBROUTINE BORT.
+C> @brief Check that an internal bufr table
+C> representation is self-consistent and fully defined.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1995-06-28  J. WOOLLEN -- INCREASED THE SIZE OF INTERNAL BUFR TABLE
-C>                           ARRAYS IN ORDER TO HANDLE BIGGER FILES
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  J. ATOR    -- ADDED DOCUMENTATION
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED HISTORY
-C>                           DOCUMENTATION; OUTPUTS MORE COMPLETE
-C>                           DIAGNOSTIC INFO WHEN ROUTINE TERMINATES
-C>                           ABNORMALLY
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1995-06-28 | J. Woollen | Increased bufr table arrays to handle bigger files.
+C> 1998-07-08 | J. Woollen | Replaced cray routine "abort" with internal routine bort().
+C> 1999-11-18 | J. Woollen | Increased num open bufr files to 32 (for mpi).
+C> 2003-11-04 | J. Ator    | Added documentation.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; documentation; outputs more diagnostic info.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
-C> USAGE:    CALL CHEKSTAB (LUN)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
+C> @author Woollen @date 1994-01-06
+
+C> This subroutine checks that an internal bufr table
+C> representation is self-consistent and fully defined. If any errors
+C> are found, then an appropriate call is made to bufr archive library
+C> subroutine bort.
 C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     NEMTAB   NEMTBB   NEMTBD
-C>    THIS ROUTINE IS CALLED BY: MAKESTAB
-C>                               Normally not called by any application
-C>                               programs.
+C> @param LUN I/O stream index into internal memory arrays.
 C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE CHEKSTAB(LUN)
 
       USE MODA_TABABD

--- a/src/chekstab.f
+++ b/src/chekstab.f
@@ -1,5 +1,5 @@
 C> @file
-C> @brief Check that an internal bufr table
+C> @brief Check that an internal BUFR table
 C> representation is self-consistent and fully defined.
 C>
 C> ### Program History Log
@@ -16,10 +16,10 @@ C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
 C> @author Woollen @date 1994-01-06
 
-C> This subroutine checks that an internal bufr table
+C> This subroutine checks that an internal BUFR table
 C> representation is self-consistent and fully defined. If any errors
 C> are found, then an appropriate call is made to bufr archive library
-C> subroutine bort.
+C> subroutine bort().
 C>
 C> @param LUN I/O stream index into internal memory arrays.
 C>

--- a/src/chrtrna.f
+++ b/src/chrtrna.f
@@ -1,6 +1,14 @@
 C> @file
 C> @brief Copy a specified number of characters from an array into
 C> a string.
+C>      
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 2003-11-04 | J. Ator    | Added documentation.
+C>      
+C> @author J. Woollen @date 1994-01-06
 
 C> This subroutine copies a specified number of characters from an
 C> array of characters into a character string.
@@ -10,26 +18,18 @@ C> so for cases where the native machine is EBCDIC, an
 C> ASCII-to-EBCDIC translation is done on the final character string
 C> before it is output as STR.
 C>
-C> @author J. Woollen
-C> @date 1994-01-06
-C>
-C> @param[in] CHR    -- character(*): Array of characters in ASCII
-C> @param[in] N      -- integer: Number of characters to be copied
-C>                      from CHR, starting from the beginning of
-C>                      the array
-C> @param[out] STR   -- character*(*): Character string in ASCII or
-C>                      EBCDIC, depending on native machine
-C>
 C> @remarks
 C> - The determination as to whether the native machine is ASCII or
 C> EBCDIC is made via an internal call to subroutine wrdlen().
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 2003-11-04 | J. Ator    | Added documentation |
 C>
+C> @param[in] CHR - character(*): Array of characters in ASCII.
+C> @param[in] N - integer: Number of characters to be copied
+C> from CHR, starting from the beginning of the array.
+C> @param[out] STR- character*(*): Character string in ASCII or
+C> EBCDIC, depending on native machine.
+C>
+C> @author J. Woollen @date 1994-01-06
       SUBROUTINE CHRTRNA(STR,CHR,N)
 
       COMMON /CHARAC/ IASCII,IATOE(0:255),IETOA(0:255)

--- a/src/cktaba.f
+++ b/src/cktaba.f
@@ -6,7 +6,7 @@ C>
 C> ### Program History Log
 C> Date | Programmer | Comments
 C> -----|------------|----------
-C> 2000-09-19 | J. Woollen | Consolidated message decoding logic that had been replicated in readmg, readft, readerme, rdmemm and readibm (cktaba is now called by these codes); logic enhanced here to allow compressed and standard bufr messages to be read.
+C> 2000-09-19 | J. Woollen | Consolidated logic in readmg(), readft(), readerme(), rdmemm() and readibm(); allow compressed messages.
 C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
 C> 2003-11-04 | D. Keyser  | See below.
 C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.

--- a/src/cktaba.f
+++ b/src/cktaba.f
@@ -1,77 +1,56 @@
 C> @file
-C> @author WOOLLEN @date 2000-09-19
+C> @brief Parse the table A mnemonic and the date
+c> out of section 1 of a bufr message previously read from unit lunit
+c> using subroutine readmg() or equivalent.
+C>      
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2000-09-19 | J. Woollen | Consolidated message decoding logic that had been replicated in readmg, readft, readerme, rdmemm and readibm (cktaba is now called by these codes); logic enhanced here to allow compressed and standard bufr messages to be read.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | See below.
+C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
+C> 2005-11-29 | J. Ator    | Use iupbs01(), igetdate() and getlens().
+C> 2006-04-14 | J. Ator    | Allow "frtttsss" and "fntttsss" as possible table a mnemonics, where ttt is the bufr type and sss is the bufr subtype
+C> 2009-03-23 | J. Ator    | Add logic to allow section 3 decoding; use iupbs3() and errwrt().
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C>
+C> @note 2003-11-04 modifications included: Modified to not abort
+C> when the section 1 message subtype does not agree with the section
+C> 1 message subtype in the dictionary if the message type mnemonic
+C> is not of the form "nctttsss", where ttt is the bufr type and sss
+C> is the bufr subtype (e.g., in "prepbufr" files); modified date
+C> calculations to no longer use floating point arithmetic since this
+C> can lead to round off error and an improper resulting date on some
+C> machines (e.g., ncep ibm frost/snow), increases portability;
+C> unified/portable for wrf; added documentation (including history);
+C> outputs more complete diagnostic info when routine terminates
+C> abnormally or unusual things happen; subset defined as " " if iret
+C> returned as 11 (before was undefined).
+C>
+C> @author Woollen @date 2000-09-19
       
-C> THIS SUBROUTINE PARSES THE TABLE A MNEMONIC AND THE DATE
-C>   OUT OF SECTION 1 OF A BUFR MESSAGE PREVIOUSLY READ FROM UNIT LUNIT
-C>   USING BUFR ARCHIVE LIBRARY SUBROUTINE READMG OR EQUIVALENT (AND NOW
-C>   STORED IN THE INTERNAL MESSAGE BUFFER, ARRAY MBAY IN MODULE
-C>   BITBUF).  THE TABLE A MNEMONIC IS ASSOCIATED WITH THE BUFR
-C>   MESSAGE TYPE/SUBTYPE IN SECTION 1.  IT ALSO FILLS IN THE MESSAGE
-C>   CONTROL WORD PARTITION ARRAYS IN MODULE MSGCWD.
+C> This subroutine parses the table a mnemonic and the date
+c> out of section 1 of a bufr message previously read from unit lunit
+c> using bufr archive library subroutine readmg() or equivalent (and now
+c> stored in the internal message buffer, array mbay in module
+c> bitbuf). The table a mnemonic is associated with the bufr
+c> message type/subtype in section 1. It also fills in the message
+c> control word partition arrays in module msgcwd.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2000-09-19  J. WOOLLEN -- ORIGINAL AUTHOR - CONSOLIDATED MESSAGE
-C>                           DECODING LOGIC THAT HAD BEEN REPLICATED IN
-C>                           READMG, READFT, READERME, RDMEMM AND READIBM
-C>                           (CKTABA IS NOW CALLED BY THESE CODES);
-C>                           LOGIC ENHANCED HERE TO ALLOW COMPRESSED AND
-C>                           STANDARD BUFR MESSAGES TO BE READ
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MODIFIED TO NOT ABORT WHEN THE SECTION 1
-C>                           MESSAGE SUBTYPE DOES NOT AGREE WITH THE
-C>                           SECTION 1 MESSAGE SUBTYPE IN THE DICTIONARY
-C>                           IF THE MESSAGE TYPE MNEMONIC IS NOT OF THE
-C>                           FORM "NCtttsss", WHERE ttt IS THE BUFR TYPE
-C>                           AND sss IS THE BUFR SUBTYPE (E.G., IN
-C>                           "PREPBUFR" FILES); MODIFIED DATE
-C>                           CALCULATIONS TO NO LONGER USE FLOATING
-C>                           POINT ARITHMETIC SINCE THIS CAN LEAD TO
-C>                           ROUND OFF ERROR AND AN IMPROPER RESULTING
-C>                           DATE ON SOME MACHINES (E.G., NCEP IBM
-C>                           FROST/SNOW), INCREASES PORTABILITY;
-C>                           UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY OR UNUSUAL THINGS
-C>                           HAPPEN; SUBSET DEFINED AS "        " IF
-C>                           IRET RETURNED AS 11 (BEFORE WAS UNDEFINED)
-C> 2004-08-09  J. ATOR    -- MAXIMUM MESSAGE LENGTH INCREASED FROM
-C>                           20,000 TO 50,000 BYTES
-C> 2005-11-29  J. ATOR    -- USE IUPBS01, IGETDATE AND GETLENS
-C> 2006-04-14  J. ATOR    -- ALLOW "FRtttsss" AND "FNtttsss" AS POSSIBLE
-C>                           TABLE A MNEMONICS, WHERE ttt IS THE BUFR
-C>                           TYPE AND sss IS THE BUFR SUBTYPE
-C> 2009-03-23  J. ATOR    -- ADD LOGIC TO ALLOW SECTION 3 DECODING;
-C>                           USE IUPBS3 AND ERRWRT
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[out] SUBSET - character*8: table a mnemonic for type of bufr message
+C> being checked:
+C> "        " = IRET equal to 11 (see IRET below) and not using Section 3 decoding.
+C> @param[out] JDATE    - integer: date-time stored within section 1 of bufr
+c> message being checked, in format of either yymmddhh or
+c> yyyymmddhh, depending on datelen() value.
+C> @param[out] IRET - integer: return code:
+C> - 0 normal return
+C> - -1 unrecognized Table A (message type) value
+C> - 11 this is a BUFR table (dictionary) message
 C>
-C> USAGE:    CALL CKTABA (LUN, SUBSET, JDATE, IRET)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>
-C>   OUTPUT ARGUMENT LIST:
-C>     SUBSET   - CHARACTER*8: TABLE A MNEMONIC FOR TYPE OF BUFR MESSAGE
-C>                BEING CHECKED:
-C>                       "        " = IRET equal to 11 (see IRET below)
-C>                                    and not using Section 3 decoding
-C>     JDATE    - INTEGER: DATE-TIME STORED WITHIN SECTION 1 OF BUFR
-C>                MESSAGE BEING CHECKED, IN FORMAT OF EITHER YYMMDDHH OR
-C>                YYYYMMDDHH, DEPENDING ON DATELEN() VALUE 
-C>     IRET     - INTEGER: RETURN CODE:
-C>                       0 = normal return
-C>                      -1 = unrecognized Table A (message type) value
-C>                      11 = this is a BUFR table (dictionary) message
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     DIGIT    ERRWRT   GETLENS
-C>                               I4DY     IGETDATE IUPB     IUPBS01
-C>                               IUPBS3   NEMTBAX  NUMTAB   OPENBT
-C>                               RDUSDX
-C>    THIS ROUTINE IS CALLED BY: RDMEMM   READERME READMG
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 2000-09-19
       SUBROUTINE CKTABA(LUN,SUBSET,JDATE,IRET)
 
       USE MODA_MSGCWD

--- a/src/cktaba.f
+++ b/src/cktaba.f
@@ -1,56 +1,39 @@
 C> @file
-C> @brief Parse the table A mnemonic and the date
-c> out of section 1 of a bufr message previously read from unit lunit
-c> using subroutine readmg() or equivalent.
+C> @brief Parse the Table A mnemonic and date out of Section 1 of a
+C> BUFR message.
 C>      
 C> ### Program History Log
 C> Date | Programmer | Comments
 C> -----|------------|----------
 C> 2000-09-19 | J. Woollen | Consolidated logic in readmg(), readft(), readerme(), rdmemm() and readibm(); allow compressed messages.
 C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
-C> 2003-11-04 | D. Keyser  | See below.
+C> 2003-11-04 | D. Keyser  | Numerous updates.
 C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
 C> 2005-11-29 | J. Ator    | Use iupbs01(), igetdate() and getlens().
 C> 2006-04-14 | J. Ator    | Allow "frtttsss" and "fntttsss" as possible table a mnemonics, where ttt is the bufr type and sss is the bufr subtype
 C> 2009-03-23 | J. Ator    | Add logic to allow section 3 decoding; use iupbs3() and errwrt().
 C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
-C> @note 2003-11-04 modifications included: Modified to not abort
-C> when the section 1 message subtype does not agree with the section
-C> 1 message subtype in the dictionary if the message type mnemonic
-C> is not of the form "nctttsss", where ttt is the bufr type and sss
-C> is the bufr subtype (e.g., in "prepbufr" files); modified date
-C> calculations to no longer use floating point arithmetic since this
-C> can lead to round off error and an improper resulting date on some
-C> machines (e.g., ncep ibm frost/snow), increases portability;
-C> unified/portable for wrf; added documentation (including history);
-C> outputs more complete diagnostic info when routine terminates
-C> abnormally or unusual things happen; subset defined as " " if iret
-C> returned as 11 (before was undefined).
-C>
 C> @author Woollen @date 2000-09-19
       
-C> This subroutine parses the table a mnemonic and the date
-c> out of section 1 of a bufr message previously read from unit lunit
-c> using bufr archive library subroutine readmg() or equivalent (and now
-c> stored in the internal message buffer, array mbay in module
-c> bitbuf). The table a mnemonic is associated with the bufr
-c> message type/subtype in section 1. It also fills in the message
-c> control word partition arrays in module msgcwd.
+C> This subroutine parses the Table A mnemonic and date
+C> out of Section 1 of a BUFR message that was previously read from lun
+C> using one of the [message-reading subroutines](@ref hierarchy).
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[out] SUBSET - character*8: table a mnemonic for type of bufr message
-C> being checked:
-C> "        " = IRET equal to 11 (see IRET below) and not using Section 3 decoding.
-C> @param[out] JDATE    - integer: date-time stored within section 1 of bufr
-c> message being checked, in format of either yymmddhh or
-c> yyyymmddhh, depending on datelen() value.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
+C> @param[out] SUBSET - character*8: Table A mnemonic
+C>                      - "        " = IRET equal to 11 (see below) and not
+C>                                     using Section 3 decoding.
+C> @param[out] JDATE    - integer: date-time stored within Section 1 of BUFR
+C>                        in format of either YYMMDDHH or
+C>                        YYYYMMDDHH, depending on datelen() value.
 C> @param[out] IRET - integer: return code:
-C> - 0 normal return
-C> - -1 unrecognized Table A (message type) value
-C> - 11 this is a BUFR table (dictionary) message
+C>                      - 0 normal return
+C>                      - -1 unrecognized Table A (message type) value
+C>                      - 11 this is a BUFR table (dictionary) message
 C>
 C> @author Woollen @date 2000-09-19
+
       SUBROUTINE CKTABA(LUN,SUBSET,JDATE,IRET)
 
       USE MODA_MSGCWD

--- a/src/closbf.f
+++ b/src/closbf.f
@@ -1,15 +1,23 @@
 C> @file
 C> @brief Close a previously opened system file and disconnect it from
 C> the BUFRLIB software.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 2003-11-04 | J. Ator    | Don't close lunit if opened as a NULL file by openbf().
+C> 2003-11-04 | S. Bender  | Added remarks and routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added history documentation.
+C> 2012-09-15 | J. Woollen | Modified for C/I/O/BUFR interface; added call to closfb() to close C files.
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks.
+C> 2020-07-16 | J. Ator    | Add sanity check to ensure that openbf() was previously called (needed for GSI).
+C> 2022-08-04 | J. Woollen | Added 8-byte wrapper.
+C>
+C> @author J. Woollen, J. Ator @date 1994-01-06
 
 C> This subroutine closes the connection between logical unit
 C> LUNIT and the BUFRLIB software.
-C>
-C> @authors J. Woollen
-C> @authors J. Ator
-C> @date 1994-01-06
-C>
-C> @param[in] LUNIT   -- integer: Fortran logical unit number for BUFR file
 C>
 C> @remarks
 C> - This subroutine will execute a Fortran "CLOSE" on logical unit LUNIT,
@@ -20,17 +28,9 @@ C> opened to the software via openbf(); however, it's especially
 C> important to do so when writing/encoding a BUFR file, in order to
 C> ensure that all output is properly flushed to LUNIT.
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 2003-11-04 | J. Ator    | Don't close lunit if opened as a NULL file by openbf() |
-C> | 2003-11-04 | S. Bender  | Added remarks and routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added history documentation |
-C> | 2012-09-15 | J. Woollen | Modified for C/I/O/BUFR interface; added call to closfb() to close C files |
-C> | 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks |
-C> | 2020-07-16 | J. Ator    | Add sanity check to ensure that openbf() was previously called (needed for GSI) |
-C> | 2022-08-04 | J. Woollen | Added 8-byte wrapper |
+C> @param[in] LUNIT - integer: Fortran logical unit number for BUFR file.
+C>
+C> @author J. Woollen, J. Ator @date 1994-01-06
 
       RECURSIVE SUBROUTINE CLOSBF(LUNIT)
 

--- a/src/closmg.f
+++ b/src/closmg.f
@@ -1,42 +1,43 @@
 C> @file
 C> @brief Close and write the current message to a BUFR file that was
 C> previously opened for writing.
+C> <b>Program history log:</b>
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort(); modified to make Y2K compliant.
+C> 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32 (necessary in order to process multiple BUFR files under the MPI).
+C> 2000-09-19 | J. Woollen | Maximum message length increased from 10,000 to 20,000 bytes.
+C> 2003-05-19 | J. Woollen | Corrected a bug which prevented the dump center and initiation time messages from being written out.
+C> 2003-11-04 | J. Ator  | Added documentation.
+C> 2003-11-04 | S. Bender | Added remarks and routine interdependencies.
+C> 2003-11-04 | D. Keyser | Unified/portable for WRF; added history documentation; outputs more complete diagnostic info when routine terminates abnormally.
+C> 2004-08-09 | J. Ator | Maximum message length increased from 20,000 to 50,000 bytes.
+C> 2005-05-26 | D. Keyser | Add LUNIN < 0 option to suppress writing of all future zero-subset messsages to ABS(LUNIN).
+C> 2014-12-10 | J. Ator | Use modules instead of COMMON blocks.
+C> 2022-08-04 | J. Woollen | Added 8-byte wrapper.
+C>
+C> @author J. Woollen, D. Keyser @date 1994-01-06
       
 C> This subroutine closes the BUFR message that is currently open for
 C> writing within internal arrays associated with logical unit
 C> ABS(LUNIN), and it then writes the message to that logical unit.
 C>
-C> @authors J. Woollen
-C> @authors D. Keyser
-C> @date 1994-01-06
-C>
-C> @param[in] LUNIN -- integer: Absolute value is Fortran logical unit
-C>                     number for BUFR file
-C>
-C> <p>Logical unit ABS(LUNIN) should have already been opened for output
+C> Logical unit ABS(LUNIN) should have already been opened for output
 C> operations via a previous call to subroutine openbf().
 C>
-C> <p>If LUNIN < 0, then any message containing zero data subsets will
+C> If LUNIN < 0, then any message containing zero data subsets will
 C> not be written to logical unit ABS(LUNIN) for the remainder of the
 C> life of the application program.  This includes suppressing the
 C> writing of any "dummy" messages containing dump center and initiation
 C> times that normally appear in the first 2 messages of NCEP dump files.
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort(); modified to make Y2K compliant |
-C> | 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32 (necessary in order to process multiple BUFR files under the MPI) |
-C> | 2000-09-19 | J. Woollen | Maximum message length increased from 10,000 to 20,000 bytes |
-C> | 2003-05-19 | J. Woollen | Corrected a bug which prevented the dump center and initiation time messages from being written out |
-C> | 2003-11-04 | J. Ator  | Added documentation |
-C> | 2003-11-04 | S. Bender | Added remarks and routine interdependencies |
-C> | 2003-11-04 | D. Keyser | Unified/portable for WRF; added history documentation; outputs more complete diagnostic info when routine terminates abnormally |
-C> | 2004-08-09 | J. Ator | Maximum message length increased from 20,000 to 50,000 bytes |
-C> | 2005-05-26 | D. Keyser | Add LUNIN < 0 option to suppress writing of all future zero-subset messsages to ABS(LUNIN) |
-C> | 2014-12-10 | J. Ator | Use modules instead of COMMON blocks |
-C> | 2022-08-04 | J. Woollen | Added 8-byte wrapper |
+C> @param[in] LUNIN - integer: Absolute value is Fortran logical unit
+C> number for BUFR file
+C>
+C> @author J. Woollen, D. Keyser @date 1994-01-06
 
       RECURSIVE SUBROUTINE CLOSMG(LUNIN)
 

--- a/src/closmg.f
+++ b/src/closmg.f
@@ -1,7 +1,6 @@
 C> @file
 C> @brief Close and write the current message to a BUFR file that was
 C> previously opened for writing.
-C> <b>Program history log:</b>
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments

--- a/src/cmsgini.f
+++ b/src/cmsgini.f
@@ -1,6 +1,6 @@
 C> @file
 C> @brief Initialize a new bufr message for output
-c> in compressed bufr.
+C> in compressed bufr.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -17,19 +17,17 @@ C>
 C> @author Woollen @date 2002-05-14
 
 C> This subroutine initializes a new bufr message for output
-c> in compressed bufr. The actual length of section 4 (containing
-c> compressed data) is already known.
+C> in compressed bufr. The actual length of section 4 (containing
+C> compressed data) is already known.
 C>
 C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[out] MESG - integer: *-word packed binary array containing bufr message.
 C> @param[in] SUBSET - character*8: table a mnemonic for type of bufr message being written.
 C> @param[in] IDATE - integer: date-time stored within section 1 of bufr message being written,
 C> in format of either yymmddhh or yyyymmddhh, depending on datelen() value.
 C> @param[in] NSUB - integer: number of subsets, stored in section 3 of bufr message being written.
-C> @param[in] NBYT - integer: actual length (in bytes) of "compressed data portion" of section 4
+C> @param[inout] NBYT - integer: actual length (in bytes) of "compressed data portion" of section 4
 C> (i.e. all of section 4 except for the first four bytes).
-C> @param[out] MESG - integer: *-word packed binary array containing bufr message.
-C> @param[out] NBYT - integer: actual length of bufr message (in bytes) up to the point in
-C> section 4 where compressed data are to be written.
 C>
 C> @author Woollen @date 2002-05-14
       SUBROUTINE CMSGINI(LUN,MESG,SUBSET,IDATE,NSUB,NBYT)

--- a/src/cmsgini.f
+++ b/src/cmsgini.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Initialize a new bufr message for output
-C> in compressed bufr.
+C> @brief Initialize a new BUFR message for output using compression.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -16,20 +15,22 @@ C> 2021-05-14 | J. Ator    | Changed default master table version to 36.
 C>
 C> @author Woollen @date 2002-05-14
 
-C> This subroutine initializes a new bufr message for output
-C> in compressed bufr. The actual length of section 4 (containing
-C> compressed data) is already known.
+C> This subroutine initializes a new BUFR message for output in compressed format.
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[out] MESG - integer: *-word packed binary array containing bufr message.
-C> @param[in] SUBSET - character*8: table a mnemonic for type of bufr message being written.
-C> @param[in] IDATE - integer: date-time stored within section 1 of bufr message being written,
-C> in format of either yymmddhh or yyyymmddhh, depending on datelen() value.
-C> @param[in] NSUB - integer: number of subsets, stored in section 3 of bufr message being written.
-C> @param[inout] NBYT - integer: actual length (in bytes) of "compressed data portion" of section 4
-C> (i.e. all of section 4 except for the first four bytes).
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
+C> @param[out] MESG - integer(*): BUFR message.
+C> @param[in] SUBSET - character*8: Table A mnemonic for type of BUFR message being written.
+C> @param[in] IDATE - integer: date-time stored within Section 1 of BUFR message being written,
+C>                    in format of either YYMMDDHH or YYYYMMDDHH, depending on datelen() value.
+C> @param[in] NSUB - integer: number of subsetsa in MESG
+C> @param[inout] NBYT - integer:
+C>                      - On input, contains the length (in bytes) of Section 4, except for
+C>                        the first 4 bytes
+C>                      - On output, contains the length (in bytes) of the entire BUFR message, up
+C>                        to the point in Section 4 where compressed data are to be written
 C>
 C> @author Woollen @date 2002-05-14
+
       SUBROUTINE CMSGINI(LUN,MESG,SUBSET,IDATE,NSUB,NBYT)
 
       CHARACTER*128 BORT_STR

--- a/src/cmsgini.f
+++ b/src/cmsgini.f
@@ -1,59 +1,37 @@
 C> @file
-C> @author WOOLLEN @date 2002-05-14
-      
-C> THIS SUBROUTINE INITIALIZES A NEW BUFR MESSAGE FOR OUTPUT
-C>   IN COMPRESSED BUFR.  THE ACTUAL LENGTH OF SECTION 4 (CONTAINING
-C>   COMPRESSED DATA) IS ALREADY KNOWN.
+C> @brief Initialize a new bufr message for output
+c> in compressed bufr.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2002-05-14  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY; LEN3 INITIALIZED AS
-C>                           ZERO (BEFORE WAS UNDEFINED WHEN FIRST
-C>                           REFERENCED)
-C> 2004-08-18  J. ATOR    -- ADDED COMMON /MSGSTD/ AND OTHER LOGIC TO
-C>                           ALLOW OPTION OF CREATING A SECTION 3 THAT IS
-C>                           FULLY WMO-STANDARD; IMPROVED DOCUMENTATION;
-C>                           MAXIMUM MESSAGE LENGTH INCREASED FROM
-C>                           20,000 TO 50,000 BYTES
-C> 2005-11-29  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 12
-C> 2009-05-07  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 13;
-C>                           REMOVED STANDARDIZATION LOGIC FOR SECTION 3
-C> 2019-05-21  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 29
-C> 2021-05-14  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 36
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2002-05-14 | J. Woollen | Original author.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; documentation; more diagnostic info; len3 initialized as zero.
+C> 2004-08-18 | J. Ator    | Added common /msgstd/ and other logic to create a wmo-standard section 3; max msg len increased to 50,000 bytes.
+C> 2005-11-29 | J. Ator    | Changed default master table version to 12.
+C> 2009-05-07 | J. Ator    | Changed default master table version to 13; removed standardization logic for section 3.
+C> 2019-05-21 | J. Ator    | Changed default master table version to 29.
+C> 2021-05-14 | J. Ator    | Changed default master table version to 36.
 C>
-C> USAGE:    CALL CMSGINI (LUN, MESG, SUBSET, IDATE, NSUB, NBYT)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     SUBSET   - CHARACTER*8: TABLE A MNEMONIC FOR TYPE OF BUFR MESSAGE
-C>                BEING WRITTEN 
-C>     IDATE    - INTEGER: DATE-TIME STORED WITHIN SECTION 1 OF BUFR
-C>                MESSAGE BEING WRITTEN, IN FORMAT OF EITHER YYMMDDHH OR
-C>                YYYYMMDDHH, DEPENDING ON DATELEN() VALUE
-C>     NSUB     - INTEGER: NUMBER OF SUBSETS, STORED IN SECTION 3 OF
-C>                BUFR MESSAGE BEING WRITTEN
-C>     NBYT     - INTEGER: ACTUAL LENGTH (IN BYTES) OF "COMPRESSED DATA
-C>                PORTION" OF SECTION 4 (I.E. ALL OF SECTION 4 EXCEPT
-C>                FOR THE FIRST FOUR BYTES)
+C> @author Woollen @date 2002-05-14
+
+C> This subroutine initializes a new bufr message for output
+c> in compressed bufr. The actual length of section 4 (containing
+c> compressed data) is already known.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     MESG     - INTEGER: *-WORD PACKED BINARY ARRAY CONTAINING BUFR
-C>                MESSAGE
-C>     NBYT     - INTEGER: ACTUAL LENGTH OF BUFR MESSAGE (IN BYTES) UP
-C>                TO THE POINT IN SECTION 4 WHERE COMPRESSED DATA ARE
-C>                TO BE WRITTEN 
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] SUBSET - character*8: table a mnemonic for type of bufr message being written.
+C> @param[in] IDATE - integer: date-time stored within section 1 of bufr message being written,
+C> in format of either yymmddhh or yyyymmddhh, depending on datelen() value.
+C> @param[in] NSUB - integer: number of subsets, stored in section 3 of bufr message being written.
+C> @param[in] NBYT - integer: actual length (in bytes) of "compressed data portion" of section 4
+C> (i.e. all of section 4 except for the first four bytes).
+C> @param[out] MESG - integer: *-word packed binary array containing bufr message.
+C> @param[out] NBYT - integer: actual length of bufr message (in bytes) up to the point in
+C> section 4 where compressed data are to be written.
 C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     I4DY     NEMTAB   NEMTBA
-C>                               PKB      PKC
-C>    THIS ROUTINE IS CALLED BY: WRCMPS
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 2002-05-14
       SUBROUTINE CMSGINI(LUN,MESG,SUBSET,IDATE,NSUB,NBYT)
 
       CHARACTER*128 BORT_STR

--- a/src/cpbfdx.f
+++ b/src/cpbfdx.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Copy bufr table (dictionary) messages
-C> from one location to another within internal memory.
+C> @brief Copy BUFR DX table information within internal memory.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -14,16 +13,16 @@ C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
 C> @author Woollen @date 1994-01-06
 
-C> This subroutine copies bufr table (dictionary) messages
-C> from one location to another within internal memory (arrays in
-C> module msgcwd and tababd).
+C> This subroutine copies all of the BUFR DX table information from
+C> one unit to another within internal memory.
 C>
-C> @param[in] LUD - integer: i/o stream index into internal memory
-C> arrays for input table location.
-C> @param[in] LUN - integer: i/o stream index into internal memory
-C> arrays for output table location.
+C> @param[in] LUD - integer: I/O stream index into internal memory
+C>                  arrays for input unit.
+C> @param[in] LUN - integer: I/O stream index into internal memory
+C>                  arrays for output unit.
 C>
 C> @author Woollen @date 1994-01-06
+
       SUBROUTINE CPBFDX(LUD,LUN)
 
       USE MODA_MSGCWD

--- a/src/cpbfdx.f
+++ b/src/cpbfdx.f
@@ -1,37 +1,29 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
-      
-C> THIS SUBROUTINE COPIES BUFR TABLE (DICTIONARY) MESSAGES
-C>   FROM ONE LOCATION TO ANOTHER WITHIN INTERNAL MEMORY (ARRAYS IN
-C>   MODULE MSGCWD AND TABABD).
+C> @brief Copy bufr table (dictionary) messages
+C> from one location to another within internal memory.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1995-06-28  J. WOOLLEN -- INCREASED THE SIZE OF INTERNAL BUFR TABLE
-C>                           ARRAYS IN ORDER TO HANDLE BIGGER FILES
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY)
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1995-06-28 | J. Woollen | Increased the size of internal bufr table arrays in order to handle bigger files.
+C> 1999-11-18 | J. Woollen | Increased open files from 10 to 32 (necessary for mpi).
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; added documentation (including history).
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
-C> USAGE:    CALL CPBFDX (LUD, LUN)
-C>   INPUT ARGUMENT LIST:
-C>     LUD      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>                FOR INPUT TABLE LOCATION
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>                FOR OUTPUT TABLE LOCATION
+C> @author Woollen @date 1994-01-06
+
+C> This subroutine copies bufr table (dictionary) messages
+C> from one location to another within internal memory (arrays in
+C> module msgcwd and tababd).
 C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        DXINIT
-C>    THIS ROUTINE IS CALLED BY: MAKESTAB READDX   WRDXTB
-C>                               Normally not called by any application
-C>                               programs.
+C> @param[in] LUD - integer: i/o stream index into internal memory
+C> arrays for input table location.
+C> @param[in] LUN - integer: i/o stream index into internal memory
+C> arrays for output table location.
 C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE CPBFDX(LUD,LUN)
 
       USE MODA_MSGCWD

--- a/src/cpyupd.f
+++ b/src/cpyupd.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Copy a subset from one message buffer
-C> (array mbay in module bitbuf) to another and/or resets the
+C> @brief Copy a BUFR data subset.
 C> pointers. 
 C>
 C> ### Program History Log
@@ -22,9 +21,9 @@ C> 2015-09-24 | D. Stokes  | Fix missing declaration OF COMMON QUIET.
 C>
 C> @author Woollen @date 1994-01-06
       
-C> This subroutine copies a subset from one message buffer
-C> (array mbay in module bitbuf) to another and/or resets the
-C> pointers. If the subset will not fit into the output message, or
+C> This subroutine copies a BUFR data subset from one unit
+C> to another within internal memory and resets the pointers.
+C> If the subset will not fit into the output message, or
 C> if the subset byte count exceeds 65530 (sufficiently close to the
 C> 16-bit byte counter upper limit of 65535), then that message is
 C> flushed to lunit and a new one is created in order to hold the
@@ -33,14 +32,16 @@ C> into its own one-subset message. If the subset to be copied is
 C> larger than the maximum message length, then a call is issued to
 C> subroutine bort().
 C>
-C> @param[in] LUNIT - integer: fortran logical unit number for bufr file.
-C> @param[in] LIN - integer: i/o stream index into internal memory arrays
-C> for input message location.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays
-C> for output message location.
-C> @param[in] IBYT - integer: number of bytes occupied by this subset.
+C> @param[in] LUNIT - integer: Fortran logical unit number for BUFR file
+C>                    associated with output unit.
+C> @param[in] LIN - integer: I/O stream index into internal memory arrays
+C>                  for input unit
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays
+C>                  for output unit.
+C> @param[in] IBYT - integer: length (in bytes) of data subset
 C>
 C> @author Woollen @date 1994-01-06
+
       SUBROUTINE CPYUPD(LUNIT,LIN,LUN,IBYT)
 
       USE MODA_MSGCWD

--- a/src/cpyupd.f
+++ b/src/cpyupd.f
@@ -17,8 +17,8 @@ C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,
 C> 2009-03-23 | J. Ator    | Use msgfull.
 C> 2014-10-27 | J. Woollen | Account for subsets with byte count > 65530 (these must be written into their own one-subset message).
 C> 2014-10-27 | D. Keyser  | For case above, do not write "current" message if it contains zero subsets.
-C> 2014-12-10 | J. ATOR    | Use modules instead of common blocks.
-C> 2015-09-24 | D. STOKES  | Fix missing declaration OF COMMON QUIET.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C> 2015-09-24 | D. Stokes  | Fix missing declaration OF COMMON QUIET.
 C>
 C> @author Woollen @date 1994-01-06
       

--- a/utils/split_by_subset.f90
+++ b/utils/split_by_subset.f90
@@ -1,10 +1,14 @@
 !> @file
-!> @brief Split a BUFR file into separate BUFR files by subset type
-!> @author WOOLLEN
-!> @date 2000-01-01
+!> @brief Split a BUFR file into separate BUFR files by subset type.
+!>
+!> @author Woollen @date 2000-01-01
 
-!> Read BUFR file messages, collating them into output files by message type/subtype (eg NC001002, aka subset type)
-!> This is the opposite of combfr.f, which concatenates BUFR messages from listed input files
+!> Read BUFR file messages, collating them into output files by
+!> message type/subtype (eg NC001002, aka subset type). This is the
+!> opposite of combfr.f, which concatenates BUFR messages from listed
+!> input files.
+!>
+!> @author Woollen @date 2000-01-01
 
 program split_by_subset
 


### PR DESCRIPTION
Part of https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/246

Some more documentation fixes.

This PR fixes all doxygen warnings for fortran files starting with the letter 'c'. 