### PR TITLE
More doxygen: fixing doxygen warnings in fortran files starting with letters 'd' thru 'g'

### DIFF
--- a/src/drstpl.f
+++ b/src/drstpl.f
@@ -1,59 +1,45 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
-      
-C> THIS SUBROUTINE IS CALLED BY BUFR ARCHIVE LIBRARY SUBROUTINE
-C>   UFBRW WHENEVER IT CAN'T FIND A MNEMONIC IT WANTS TO WRITE WITHIN THE
-C>   CURRENT SUBSET BUFFER.  IT LOOKS FOR THE MNEMONIC WITHIN ANY
-C>   UNEXPANDED "DRS" (STACK) OR "DRB" (1-BIT DELAYED REPLICATION)
-C>   SEQUENCES INSIDE OF THE PORTION OF THE SUBSET BUFFER BOUNDED BY THE
-C>   INDICES INV1 AND INV2.  IF FOUND, IT EXPANDS THE APPLICABLE "DRS" OR
-C>   "DRB" SEQUENCE TO THE POINT WHERE THE MNEMONIC IN QUESTION NOW
-C>   APPEARS IN THE SUBSET BUFFER, AND IN DOING SO IT WILL ALSO RETURN
-C>   A NEW VALUE FOR INV2.
+C> @brief Called by subroutine ufbrw() whenever it can't find a mnemonic it wants to write within the
+C> current subset buffer.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT" (LATER REMOVED, UNKNOWN
-C>                           WHEN)
-C> 2002-05-14  J. WOOLLEN -- REMOVED OLD CRAY COMPILER DIRECTIVES
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MAXJL (MAXIMUM NUMBER OF JUMP/LINK ENTRIES)
-C>                           INCREASED FROM 15000 TO 16000 (WAS IN
-C>                           VERIFICATION VERSION); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED DOCUMENTATION (INCLUDING
-C>                           HISTORY) 
-C> 2009-03-31  J. WOOLLEN -- ADDED ADDITIONAL DOCUMENTATION
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced cray "abort" with routine bort() (later removed, unknown when).
+C> 2002-05-14 | J. Woollen | Removed old cray compiler directives.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | maxjl (maximum jump/link entries) increased to 16000; unified/portable for wrf.
+C> 2009-03-31 | J. Woollen | Added additional documentation.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C>
-C> USAGE:    CALL DRSTPL (INOD, LUN, INV1, INV2, INVN)
+C> @author Woollen @date 1994-01-06
+
+C> This subroutine is called by subroutine
+C> ufbrw() whenever it can't find a mnemonic it wants to write within the
+C> current subset buffer. It looks for the mnemonic within any
+C> unexpanded "drs" (stack) or "drb" (1-bit delayed replication)
+C> sequences inside of the portion of the subset buffer bounded by the
+C> indices inv1 and inv2. If found, it expands the applicable "drs" or
+C> "drb" sequence to the point where the mnemonic in question now
+C> appears in the subset buffer, and in doing so it will also return
+C> a new value for inv2.
 C>
-C>   INPUT ARGUMENT LIST:
-C>     INOD     - INTEGER: JUMP/LINK TABLE INDEX OF MNEMONIC TO LOOK FOR 
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     INV1     - INTEGER: STARTING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER CURRENTLY BEING PROCESSED BY UFBRW
-C>     INV2     - INTEGER: ENDING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER CURRENTLY BEING PROCESSED BY UFBRW
+C> @param[in] INOD - integer: jump/link table index of mnemonic to look for.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] INV1 - integer: starting index of the portion of the subset
+C> buffer currently being processed by ufbrw.
+C> @param[inout] INV2 - integer: on input, ending index of the portion
+C> of the subset buffer currently being processed by ufbrw. Onn output:
+C> if invn = 0, then inv2 is unchanged from its.  input value. Otherwise,
+C> it contains the redefined ending index of the portion of the subset
+C> buffer currently being processed by ufbrw, since expanding a delayed
+C> replication sequence will have necessarily increased the size of this
+C> buffer.
+C> @param[out] INVN - integer: location index of inod within subset buffer:.
+C> 0 not found.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     INVN     - INTEGER: LOCATION INDEX OF INOD WITHIN SUBSET BUFFER:
-C>                  0 = NOT FOUND
-C>     INV2     - INTEGER: IF INVN = 0, THEN INV2 IS UNCHANGED FROM ITS
-C>                INPUT VALUE.  OTHERWISE, IT CONTAINS THE REDEFINED
-C>                ENDING INDEX OF THE PORTION OF THE SUBSET BUFFER
-C>                CURRENTLY BEING PROCESSED BY UFBRW, SINCE EXPANDING A
-C>                DELAYED REPLICATION SEQUENCE WILL HAVE NECESSARILY
-C>                INCREASED THE SIZE OF THIS BUFFER.
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        INVWIN   NEWWIN   USRTPL
-C>    THIS ROUTINE IS CALLED BY: UFBRW
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE DRSTPL(INOD,LUN,INV1,INV2,INVN)
 
       USE MODA_TABLES

--- a/src/dxinit.f
+++ b/src/dxinit.f
@@ -1,42 +1,30 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C> @brief Initialize the internal arrays (in module tababd) holding the dictionary table.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1995-06-28 | J. Woollen | Increased the size of internal bufr table arrays in order to handle bigger files.
+C> 1999-11-18 | J. Woollen | The number of bufr files which can be opened at one time increased from 10 to 32 (necessary for mpi).
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; added documentation (including history).
+C> 2009-03-23 | J. Ator    | Remove initialization of common msgcwd.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS SUBROUTINE INITIALIZES THE INTERNAL ARRAYS
-C>   (IN MODULE TABABD) HOLDING THE DICTIONARY TABLE.  IT THEN
-C>   INITIALIZES THE TABLE WITH APRIORI TABLE B AND D ENTRIES
-C>   (OPTIONAL).
+C> This subroutine initializes the internal arrays
+c> (in module tababd) holding the dictionary table. It then
+c> initializes the table with apriori table b and d entries
+c> (optional).
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1995-06-28  J. WOOLLEN -- INCREASED THE SIZE OF INTERNAL BUFR TABLE
-C>                           ARRAYS IN ORDER TO HANDLE BIGGER FILES
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY)
-C> 2009-03-23  J. ATOR    -- REMOVE INITIALIZATION OF COMMON /MSGCWD/
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] IOI - integer: switch:.
+C> - 0 do not initialize the table with apriori Table B and D entries.
+C> - else initialize the table with apriori Table B and D entries.
 C>
-C> USAGE:    CALL DXINIT (LUN, IOI)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     IOI      - INTEGER: SWITCH:
-C>                       0 = do not initialize the table with apriori
-C>                           Table B and D entries
-C>                    else = initialize the table with apriori Table B
-C>                           and D entries
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        ADN30    IFXY     PKTDD
-C>    THIS ROUTINE IS CALLED BY: CPBFDX   OPENBF   RDBFDX   RDUSDX
-C>                               READERME READS3
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE DXINIT(LUN,IOI)
 
       USE MODA_TABABD

--- a/src/dxmini.f
+++ b/src/dxmini.f
@@ -1,59 +1,39 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1997-07-29 | J. Woollen | Modified to update the current bufr version written in section 0 from 2 to 3.
+C> 1998-07-08 | J. Woollen | Replaced call to cray library routine "abort" with call to new internal bufrlib routine bort().
+C> 2000-09-19 | J. Woollen | Maximum message length increased from 10,000 to 20,000 bytes.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; added documentation (including history); more diagnostic info.
+C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
+C> 2005-11-29 | J. Ator    | Changed default master table version to 12.
+C> 2009-05-07 | J. Ator    | Changed default master table version to 13.
+C> 2019-05-21 | J. Ator    | Changed default master table version to 29.
+C> 2021-05-14 | J. Ator    | Changed default master table version to 36.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS SUBROUTINE INITIALIZES A BUFR TABLE (DICTIONARY)
-C>   MESSAGE, WRITING ALL THE PRELIMINARY INFORMATION INTO SECTIONS 0,
-C>   1, 3, 4.  BUFR ARCHIVE LIBRARY SUBROUTINE WRDXTB WILL WRITE THE
-C>   ACTUAL TABLE INFORMATION INTO THE MESSAGE.
+C> This subroutine initializes a bufr table (dictionary)
+C> message, writing all the preliminary information into sections 0,
+C> 1, 3, 4.  Subroutine wrdxtb() will write the
+C> actual table information into the message.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1997-07-29  J. WOOLLEN -- MODIFIED TO UPDATE THE CURRENT BUFR VERSION
-C>                           WRITTEN IN SECTION 0 FROM 2 TO 3
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 2000-09-19  J. WOOLLEN -- MAXIMUM MESSAGE LENGTH INCREASED FROM
-C>                           10,000 TO 20,000 BYTES
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY
-C> 2004-08-09  J. ATOR    -- MAXIMUM MESSAGE LENGTH INCREASED FROM
-C>                           20,000 TO 50,000 BYTES
-C> 2005-11-29  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 12
-C> 2009-05-07  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 13
-C> 2019-05-21  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 29 
-C> 2021-05-14  J. ATOR    -- CHANGED DEFAULT MASTER TABLE VERSION TO 36
+C> @note: Argument LUN is not referenced in this subroutine. It is left
+C> here in case an application program calls this subroutine.
 C>
-C> USAGE:    CALL DXMINI (LUN, MBAY, MBYT, MB4, MBA, MBB, MBD)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[out] MBAY - integer: (mxmsgld4)-word packed binary array containing bufr message.
+C> @param[out] MBYT - integer: length of bufr message (bytes).
+C> @param[out] MB4 - integer: byte number in message of first byte in section 4.
+C> @param[out] MBA - integer: byte number in message of fourth byte in section 4.
+C> @param[out] MBB - integer: byte number in message of fifth byte in section 4.
+C> @param[out] MBD - integer: byte number in message of sixth byte in section 4.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     MBAY     - INTEGER: (MXMSGLD4)-WORD PACKED BINARY ARRAY
-C>                CONTAINING BUFR MESSAGE
-C>     MBYT     - INTEGER: LENGTH OF BUFR MESSAGE (BYTES)
-C>     MB4      - INTEGER: BYTE NUMBER IN MESSAGE OF FIRST BYTE IN
-C>                SECTION 4
-C>     MBA      - INTEGER: BYTE NUMBER IN MESSAGE OF FOURTH BYTE IN
-C>                SECTION 4
-C>     MBB      - INTEGER: BYTE NUMBER IN MESSAGE OF FIFTH BYTE IN
-C>                SECTION 4
-C>     MBD      - INTEGER: BYTE NUMBER IN MESSAGE OF SIXTH BYTE IN
-C>                SECTION 4
-C>
-C> REMARKS:
-C>    ARGUMENT LUN IS NOT REFERENCED IN THIS SUBROUTINE.  IT IS LEFT
-C>    HERE IN CASE AN APPLICATION PROGRAM CALLS THIS SUBROUTINE.
-C>
-C>    THIS ROUTINE CALLS:        BORT     IUPM     PKB      PKC
-C>    THIS ROUTINE IS CALLED BY: WRDXTB
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE DXMINI(LUN,MBAY,MBYT,MB4,MBA,MBB,MBD)
 
       USE MODV_MXMSGL

--- a/src/elemdx.f
+++ b/src/elemdx.f
@@ -1,49 +1,38 @@
 C> @file
+C> @brief Decode the scale factor, reference value,
+c> bit width and units (i.e., the "elements") from a table b mnemonic
+c> definition card that was previously read from a user-supplied bufr
+c> dictionary table file in character format by subroutine rdusdx().
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1995-06-28 | J. Woollen | Increased the size of internal bufr table arrays in order to handle bigger files.
+C> 1998-07-08 | J. Woollen | Replaced call to cray library routine "abort" with call to routine bort(0.
+C> 1999-11-18 | J. Woollen | The number of bufr files which can be opened at one time increased from 10 to 32 (necessary for mpi).
+C> 2003-11-04 | J. Ator    | Added documentation.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; documentation; outputs more info when routine terminates; changed  bort() to bort2().
+C> 2007-01-19 | J. Ator    | Added extra argument for call to jstchr().
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C> 2021-09-30 | J. Ator    | Replace jstchr with Fortran intrinsic adjustl.
+C>
 C> @author WOOLLEN @date 1994-01-06
       
-C> THIS SUBROUTINE DECODES THE SCALE FACTOR, REFERENCE VALUE,
-C>   BIT WIDTH AND UNITS (I.E., THE "ELEMENTS") FROM A TABLE B MNEMONIC
-C>   DEFINITION CARD THAT WAS PREVIOUSLY READ FROM A USER-SUPPLIED BUFR
-C>   DICTIONARY TABLE FILE IN CHARACTER FORMAT BY BUFR ARCHIVE LIBRARY
-C>   SUBROUTINE RDUSDX.  THESE DECODED VALUES ARE THEN ADDED TO THE
-C>   ALREADY-EXISTING ENTRY FOR THAT MNEMONIC WITHIN THE INTERNAL BUFR
-C>   TABLE B ARRAY TABB(*,LUN) IN MODULE TABABD.
+C> This subroutine decodes the scale factor, reference value,
+c> bit width and units (i.e., the "elements") from a table b mnemonic
+c> definition card that was previously read from a user-supplied bufr
+c> dictionary table file in character format by subroutine rdusdx().
+C> These decoded values are then added to the
+c> already-existing entry for that mnemonic within the internal bufr
+c> table B array TABB(*,LUN) in module tababd.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1995-06-28  J. WOOLLEN -- INCREASED THE SIZE OF INTERNAL BUFR TABLE
-C>                           ARRAYS IN ORDER TO HANDLE BIGGER FILES
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  J. ATOR    -- ADDED DOCUMENTATION
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED HISTORY
-C>                           DOCUMENTATION; OUTPUTS MORE COMPLETE
-C>                           DIAGNOSTIC INFO WHEN ROUTINE TERMINATES
-C>                           ABNORMALLY; CHANGED CALL FROM BORT TO BORT2
-C> 2007-01-19  J. ATOR    -- ADDED EXTRA ARGUMENT FOR CALL TO JSTCHR
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
-C> - 2021-09-30  J. Ator    -- Replace jstchr with Fortran intrinsic
-C>                             adjustl
+C> @param[in] CARD - character*80: mnemonic definition card that was read
+C> from a user-supplied bufr dictionary table.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays .
 C>
-C> USAGE:    CALL ELEMDX (CARD, LUN)
-C>   INPUT ARGUMENT LIST:
-C>     CARD     - CHARACTER*80: MNEMONIC DEFINITION CARD THAT WAS READ
-C>                FROM A USER-SUPPLIED BUFR DICTIONARY TABLE
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS 
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT2    CAPIT    JSTNUM    NEMTAB
-C>    THIS ROUTINE IS CALLED BY: RDUSDX   STSEQ
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author WOOLLEN @date 1994-01-06
       SUBROUTINE ELEMDX(CARD,LUN)
 
       USE MODA_TABABD

--- a/src/fstag.f
+++ b/src/fstag.f
@@ -1,42 +1,31 @@
 C> @file
-C> @author J @date 2014-10-02
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2014-10-02 | J. Ator | Original author.
+C> 2014-12-10 | J. Ator | Use modules instead of common blocks.
+C>
+C> @author J Ator @date 2014-10-02
 	
-C> THIS SUBROUTINE FINDS THE (NUTAG)th OCCURRENCE OF MNEMONIC
-C>  UTAG WITHIN THE CURRENT OVERALL SUBSET DEFINITION, STARTING FROM
-C>  PARAMETER #(NIN) WITHIN THE SUBSET.  THE SUBROUTINE SEARCHES FORWARD
-C>  FROM NIN IF NUTAG IS POSITIVE OR ELSE BACKWARD IF NUTAG IS NEGATIVE.
+C> This subroutine finds the (nutag)th occurrence of mnemonic
+C> utag within the current overall subset definition, starting from
+C> parameter #(nin) within the subset. The subroutine searches forward
+C> from nin if nutag is positive or else backward if nutag is negative.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2014-10-02  J. ATOR    -- ORIGINAL AUTHOR
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] UTAG - character*(*): mnemonic.
+C> @param[in] NUTAG - integer: ordinal occurrence of utag to search for within
+C> the overall subset definition, counting from parameter #(nin) within the subset.
+C> The subroutine will search in a forward direction from parameter #(nin) if
+C> nutag is positive or else in a backward direction if nutag is negative..
+C> @param[in] NIN - integer: location within the overall subset definition from which to begin searching for utag..
+C> @param[out] NOUT - integer: location of (nutag)th occurrence of utag.
+C> @param[out] IRET - integer: return code.
+C> - 0 Normal return.
+C> - -1 Requested mnemonic could not be found, or some other error occurred.
 C>
-C> USAGE:    CALL FSTAG (LUN, UTAG, NUTAG, NIN, NOUT, IRET)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     UTAG     - CHARACTER*(*): MNEMONIC
-C>     NUTAG    - INTEGER: ORDINAL OCCURRENCE OF UTAG TO SEARCH FOR
-C>                WITHIN THE OVERALL SUBSET DEFINITION, COUNTING FROM
-C>                PARAMETER #(NIN) WITHIN THE SUBSET.  THE SUBROUTINE
-C>                WILL SEARCH IN A FORWARD DIRECTION FROM PARAMETER
-C>                #(NIN) IF NUTAG IS POSITIVE OR ELSE IN A BACKWARD
-C>                DIRECTION IF NUTAG IS NEGATIVE.
-C>     NIN      - INTEGER: LOCATION WITHIN THE OVERALL SUBSET DEFINITION
-C>                FROM WHICH TO BEGIN SEARCHING FOR UTAG.
-C>
-C>   OUTPUT ARGUMENT LIST:
-C>     NOUT     - INTEGER: LOCATION OF (NUTAG)th OCCURRENCE OF UTAG
-C>     IRET     - INTEGER: RETURN CODE
-C>                   0 = NORMAL RETURN
-C>                  -1 = REQUESTED MNEMONIC COULD NOT BE FOUND, OR SOME
-C>                       OTHER ERROR OCCURRED
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        PARSTR
-C>    THIS ROUTINE IS CALLED BY: GETTAGPR GETTAGRE GETVALNB NEMSPECS
-C>                               SETVALNB UFDUMP
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author J Ator @date 2014-10-02
 	SUBROUTINE FSTAG ( LUN, UTAG, NUTAG, NIN, NOUT, IRET )
 
 	USE MODA_USRINT

--- a/utils/gettab.f90
+++ b/utils/gettab.f90
@@ -1,8 +1,15 @@
 !> @file
 !> @brief Read BUFR file containing embedded DX BUFR tables,
-!> and print the tables to stdout
-!> @author WOOLLEN @date 2000-01-01
+!> and print the tables to stdout.
+!>
+!> @author Woollen @date 2000-01-01
 
+!> Read BUFR file containing embedded DX BUFR tables,
+!> and print the tables to stdout.
+!>
+!> @return 0 for success, error code otherwise.
+!>
+!> @author Woollen @date 2000-01-01
 program gettab
 
   implicit none


### PR DESCRIPTION
Part of #246

More doxygen.

