### PR TITLE
more doxygen: fixing doxygen warnings in Fortran files starting with 'i'

### DIFF
--- a/src/ichkstr.f
+++ b/src/ichkstr.f
@@ -1,34 +1,27 @@
 C> @file
-C> @author ATOR @date 2005-11-29
+C> @brief Compare a specified number of characters
+c> from an input character array against the same number of characters
+c> from an input character string and determines whether the two are
+c> equivalent. 	
+C> @author Ator @date 2005-11-29
 	
-C> THIS FUNCTION COMPARES A SPECIFIED NUMBER OF CHARACTERS
-C>   FROM AN INPUT CHARACTER ARRAY AGAINST THE SAME NUMBER OF CHARACTERS
-C>   FROM AN INPUT CHARACTER STRING AND DETERMINES WHETHER THE TWO ARE
-C>   EQUIVALENT.  THE CHARACTER ARRAY IS ASSUMED TO BE IN ASCII, WHEREAS
-C>   THE CHARACTER STRING IS ASSUMED TO BE IN THE NATIVE CHARACTER SET
-C>   (I.E. ASCII OR EBCDIC) OF THE LOCAL MACHINE.
+C> This function compares a specified number of characters
+c> from an input character array against the same number of characters
+c> from an input character string and determines whether the two are
+c> equivalent. The character array is assumed to be in ASCII, whereas
+c> the character string is assumed to be in the native character set
+c> (i.e. ASCII or EBCDIC) of the local machine.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2005-11-29  J. ATOR    -- ORIGINAL AUTHOR
+C> @param[in] STR - character*(*): n-character string in ASCII or
+C> EBCDIC, depending on the native machine.
+C> @param[in] CHR - character*1: array of n characters in ASCII.
+C> @param[in] N - integer: number of characters to be compared.
 C>
-C> USAGE:    ICHKSTR (STR, CHR, N)
-C>   INPUT ARGUMENT LIST:
-C>     STR      - CHARACTER*(*): N-CHARACTER STRING IN ASCII OR EBCDIC,
-C>                DEPENDING ON THE NATIVE MACHINE
-C>     CHR      - CHARACTER*1: ARRAY OF N CHARACTERS IN ASCII
-C>     N        - INTEGER: NUMBER OF CHARACTERS TO BE COMPARED
+C> @return
+C> - 0 STR(1:N) and (CHR(I),I=1,N) are equivalent.
+C> - 1 STR(1:N) and (CHR(I),I=1,N) are not equivalent.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     ICHKSTR  - INTEGER: RETURN VALUE:
-C>                  0 = STR(1:N) AND (CHR(I),I=1,N) ARE EQUIVALENT
-C>                  1 = STR(1:N) AND (CHR(I),I=1,N) ARE NOT EQUIVALENT
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        CHRTRNA
-C>    THIS ROUTINE IS CALLED BY: CRBMG    READERME
-C>                               Normally not called by any application
-C>                               programs. 
-C>
+C> @author Ator @date 2005-11-29
 	FUNCTION ICHKSTR(STR,CHR,N)
 
 

--- a/src/igetfxy.f
+++ b/src/igetfxy.f
@@ -1,32 +1,28 @@
 C> @file
-C> @author ATOR @date 2007-01-19
+C> @brief looks for and returns a valid fxy number
+C> from within the given input string.	
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2007-01-19 | J. Ator | Original author.
+C> 2021-09-30 | J. Ator | Replace jstchr with Fortran intrinsic adjustl.
+C>
+C> @author Ator @date 2007-01-19
 	
-C> THIS FUNCTION LOOKS FOR AND RETURNS A VALID FXY NUMBER
-C>   FROM WITHIN THE GIVEN INPUT STRING.  THE FXY NUMBER MAY BE IN
-C>   FORMAT OF EITHER FXXYYY OR F-XX-YYY WITHIN THE INPUT STRING, BUT
-C>   IT IS ALWAYS RETURNED IN FORMAT FXXYYY UPON OUTPUT.
+C> This function looks for and returns a valid fxy number
+C> from within the given input string. The FXY number may be in
+C> format of either FXXYYY or F-XX-YYY within the input string, but
+C> it is always returned in format FXXYYY upon output.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2007-01-19  J. ATOR    -- ORIGINAL AUTHOR
-C> - 2021-09-30  J. Ator    -- Replace jstchr with Fortran intrinsic
-C>                             adjustl
+C> @param[in] STR - character*(*): input string.
+C> @param[in] CFXY - character*6: FXY number in format FXXYYY.
 C>
-C> USAGE:    IGETFXY ( STR, CFXY )
-C>   INPUT ARGUMENT LIST:
-C>     STR      - CHARACTER*(*): INPUT STRING
+C> @return
+C> - 0 normal return.
+C> - -1 could not find a valid FXY number in STR.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     CFXY     - CHARACTER*6: FXY NUMBER IN FORMAT FXXYYY
-C>     IGETFXY  - INTEGER: RETURN CODE:
-C>                       0 = normal return
-C>                      -1 = could not find a valid FXY number in STR
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        NUMBCK
-C>    THIS ROUTINE IS CALLED BY: GETNTBE  SNTBDE   SNTBFE
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Ator @date 2007-01-19
 	FUNCTION IGETFXY ( STR, CFXY )
 
 

--- a/src/igetrfel.f
+++ b/src/igetrfel.f
@@ -1,37 +1,30 @@
 C> @file
-C> @author J @date 2016-05-27
+C> @brief Check whether the input element refers to
+c> a previous element within the same subset via an internal bitmap.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2016-05-27 | J. Ator | Original author.
+C> 2017-04-03 | J. Ator | Add a dimension to all tco arrays so each subset definition in the jump/link table has its own set of table c operators.
+C>
+C> @author J Ator @date 2016-05-27
 	
-C> THIS FUNCTION CHECKS WHETHER THE INPUT ELEMENT REFERS TO
-C>   A PREVIOUS ELEMENT WITHIN THE SAME SUBSET VIA AN INTERNAL BITMAP.
-C>   IF SO, THEN THE REFERENCED ELEMENT IS RETURNED.  IN ADDITION, IF
-C>   THE INPUT ELEMENT IS A 2-XX-255 MARKER OPERATOR, ITS SCALE FACTOR,
-C>   BIT WIDTH AND REFERENCE VALUE ARE SET INTERNALLY TO MATCH THOSE
-C>   OF THE REFERENCED ELEMENT.
+C> This function checks whether the input element refers to
+c> a previous element within the same subset via an internal bitmap.
+C> If so, then the referenced element is returned. In addition, if
+c> the input element is a 2-xx-255 marker operator, its scale factor,
+c> bit width and reference value are set internally to match those
+c> of the referenced element.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2016-05-27  J. ATOR    -- ORIGINAL AUTHOR
-C> 2017-04-03  J. ATOR    -- ADD A DIMENSION TO ALL TCO ARRAYS SO THAT
-C>                           EACH SUBSET DEFINITION IN THE JUMP/LINK
-C>                           TABLE HAS ITS OWN SET OF TABLE C OPERATORS
+C> @param[in] N - integer: subset element.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
 C>
-C> USAGE:    CALL IGETRFEL ( N, LUN )
-C>   INPUT ARGUMENT LIST:
-C>     N        - INTEGER: SUBSET ELEMENT
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
+C> @return Subset element referenced by element n
+c> within the same subset. 0 = input element does not refer to a previous
+c> element, or referenced element not found.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     IGETRFEL - INTEGER: SUBSET ELEMENT REFERENCED BY ELEMENT N
-C>                WITHIN THE SAME SUBSET
-C>                  0 = INPUT ELEMENT DOES NOT REFER TO A PREVIOUS
-C>                      ELEMENT, OR REFERENCED ELEMENT NOT FOUND
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        ADN30    BORT     IBFMS    IMRKOPR
-C>                               LSTJPB   NEMTAB
-C>    THIS ROUTINE IS CALLED BY: RCSTPL   RDCMPS
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author J Ator @date 2016-05-27
 	INTEGER FUNCTION IGETRFEL ( N, LUN )
 
 	USE MODA_MSGCWD


### PR DESCRIPTION
Part of https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/246

More doxygen.