### PR TITLE
follow up to fill in missing documentation

### DIFF
--- a/src/arallocc.c
+++ b/src/arallocc.c
@@ -11,6 +11,7 @@
 */
 
 #include "bufrlib.h"
+/** Macro to control whether certain variables are explicitly declared or referenced as extern. */
 #define IN_ARALLOCC
 #include "cread.h"
 #include "mstabs.h"

--- a/src/arallocc.c
+++ b/src/arallocc.c
@@ -6,6 +6,7 @@
  * -----|------------|----------
  * 2014-12-04 | J. Ator | Original author.
  * 2021-05-17 | J. Ator | Allow up to 24 characters in cbunit.
+ * 2023-01-18 | J. Ator | Remove MSTABS_BASE macro.
  *
  * @author J. Ator @date 2014-12-04
 */
@@ -70,62 +71,62 @@ void arallocc( void )
     mxmtbd = igetprm( "MXMTBD", 6 );
     maxcd = igetprm( "MAXCD", 5 );
 
-    if ( ( MSTABS_BASE(ibfxyn) = malloc( mxmtbb * sizeof(f77int) ) ) == NULL ) {
+    if ( ( ibfxyn_c = malloc( mxmtbb * sizeof(f77int) ) ) == NULL ) {
 	strcat( brtstr, "IBFXYN" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbscl) = malloc( mxmtbb * 4 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbscl_c = malloc( mxmtbb * 4 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBSCL" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbsref) = malloc( mxmtbb * 12 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbsref_c = malloc( mxmtbb * 12 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBSREF" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbbw) = malloc( mxmtbb * 4 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbbw_c = malloc( mxmtbb * 4 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBBW" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbunit) = malloc( mxmtbb * 24 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbunit_c = malloc( mxmtbb * 24 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBUNIT" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbmnem) = malloc( mxmtbb * 8 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbmnem_c = malloc( mxmtbb * 8 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBMNEM" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cbelem) = malloc( mxmtbb * 120 * sizeof(char) ) ) == NULL ) {
+    if ( ( cbelem_c = malloc( mxmtbb * 120 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CBELEM" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(idfxyn) = malloc( mxmtbd * sizeof(f77int) ) ) == NULL ) {
+    if ( ( idfxyn_c = malloc( mxmtbd * sizeof(f77int) ) ) == NULL ) {
 	strcat( brtstr, "IDFXYN" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cdseq) = malloc( mxmtbd * 120 * sizeof(char) ) ) == NULL ) {
+    if ( ( cdseq_c = malloc( mxmtbd * 120 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CDSEQ" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(cdmnem) = malloc( mxmtbd * 8 * sizeof(char) ) ) == NULL ) {
+    if ( ( cdmnem_c = malloc( mxmtbd * 8 * sizeof(char) ) ) == NULL ) {
 	strcat( brtstr, "CDMNEM" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(ndelem) = malloc( mxmtbd * sizeof(f77int) ) ) == NULL ) {
+    if ( ( ndelem_c = malloc( mxmtbd * sizeof(f77int) ) ) == NULL ) {
 	strcat( brtstr, "NDELEM" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }
 
-    if ( ( MSTABS_BASE(idefxy) = malloc( mxmtbd * maxcd * sizeof(f77int) ) ) == NULL ) {
+    if ( ( idefxy_c = malloc( mxmtbd * maxcd * sizeof(f77int) ) ) == NULL ) {
 	strcat( brtstr, "IDEFXY" );
         bort( brtstr, ( f77int ) strlen( brtstr ) );
     }

--- a/src/ardllocc.c
+++ b/src/ardllocc.c
@@ -6,6 +6,7 @@
  * Date | Programmer | Comments
  * -----|------------|----------
  * 2014-12-04 | J. Ator | Original author.
+ * 2023-01-18 | J. Ator | Remove MSTABS_BASE macro.
  *
  * @author J. Ator @date 2014-12-04
  */
@@ -35,18 +36,18 @@ void ardllocc( void )
 **  mstabs arrays
 */
 
-    free( MSTABS_BASE(ibfxyn) );
-    free( MSTABS_BASE(cbscl) );
-    free( MSTABS_BASE(cbsref) );
-    free( MSTABS_BASE(cbbw) );
-    free( MSTABS_BASE(cbunit) );
-    free( MSTABS_BASE(cbmnem) );
-    free( MSTABS_BASE(cbelem) );
-    free( MSTABS_BASE(idfxyn) );
-    free( MSTABS_BASE(cdseq) );
-    free( MSTABS_BASE(cdmnem) );
-    free( MSTABS_BASE(ndelem) );
-    free( MSTABS_BASE(idefxy) );
+    free( ibfxyn_c );
+    free( cbscl_c );
+    free( cbsref_c );
+    free( cbbw_c );
+    free( cbunit_c );
+    free( cbmnem_c );
+    free( cbelem_c );
+    free( idfxyn_c );
+    free( cdseq_c );
+    free( cdmnem_c );
+    free( ndelem_c );
+    free( idefxy_c );
 
 }
 

--- a/src/bufr_interface.f90
+++ b/src/bufr_interface.f90
@@ -144,7 +144,7 @@ end subroutine close_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "openbf" subroutine.
+!> @brief Wraps BUFRLIB openbf() subroutine.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number
 !> @param[in] cio - c_char: cio string
@@ -162,7 +162,7 @@ end subroutine openbf_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "closbf" subroutine.
+!> @brief Wraps BUFRLIB closbf() subroutine.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number to close
 !>
@@ -176,7 +176,7 @@ end subroutine closbf_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "exitbufr" subroutine. Closes
+!> @brief Wraps BUFRLIB exitbufr() subroutine. Closes
 !>        all open file units used by BUFRLIB.
 !>
 subroutine exitbufr_c() bind(C, name='exitbufr_f')
@@ -187,7 +187,7 @@ end subroutine exitbufr_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "ireadmg" subroutine.
+!> @brief Wraps BUFRLIB ireadmg() function.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number to read from
 !> @param[out] c_subset - c_char: the subset string
@@ -214,7 +214,7 @@ end function ireadmg_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "ireadsb" function.
+!> @brief Wraps BUFRLIB ireadsb() function.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number to read from
 !>
@@ -230,7 +230,7 @@ end function ireadsb_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "ufbint" function.
+!> @brief Wraps BUFRLIB ufbint() subroutine.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number to read from
 !> @param[inout] c_data - c_ptr: c style pointer to a pre-allocated buffer
@@ -254,7 +254,7 @@ end subroutine ufbint_c
 !> @author Ronald McLaren
 !> @date 2020-07-29
 !>
-!> @brief Wraps BUFRLIB "ufbrep" function.
+!> @brief Wraps BUFRLIB ufbrep() subroutine.
 !>
 !> @param[in] bufr_unit - c_int: the fortran file unit number to read from
 !> @param[inout] c_data - c_ptr: c style pointer to a pre-allocated buffer
@@ -278,7 +278,7 @@ end subroutine ufbrep_c
 !> @author Ronald McLaren
 !> @date 2021-02-24
 !>
-!> @brief Wraps BUFRLIB "mtinfo" function.
+!> @brief Wraps BUFRLIB mtinfo() subroutine.
 !>
 !> @param[in] path - c_char: the path where the WMO tables are stored
 !> @param[in] file_unit_1 - c_int: number to use for first file unit
@@ -293,14 +293,10 @@ subroutine mtinfo_c(path, file_unit_1, file_unit_2) bind(C, name='mtinfo_f')
 end subroutine mtinfo_c
 
 
-! ----------------------------------------------------------------------
-!> Get Raw BUFR data functions
-! ----------------------------------------------------------------------
-
 !>  @author Ronald McLaren
 !>  @date 2022-03-23
 !>
-!>  @brief Wraps BUFRLIB "status" function.
+!>  @brief Wraps BUFRLIB status() subroutine.
 !>
 !>  @param[in] file_unit - c_int: the fortran file unit number to read from
 !>  @param[out] lun - c_int: pointer for the file stream
@@ -320,8 +316,8 @@ end subroutine status_c
 !>  @author Ronald McLaren
 !>  @date 2022-08-08
 !>
-!>  @brief Gets Table B Unit and Description strings for a mnemonic. Wraps BUFRLIB "nemdefs".
-!>
+!>  @brief Gets Table B Unit and Description strings for a mnemonic. Wraps BUFRLIB nemdefs() subroutine.
+!
 !>  @param[in] file_unit - c_int: Fortran file unit for the open file
 !>  @param[in] mnemonic - c_char: mnemonic
 !>  @param[out] unit_c - c_char: unit str
@@ -358,7 +354,7 @@ end subroutine nemdefs_c
 !>  @author Ronald McLaren
 !>  @date 2022-08-08
 !>
-!>  @brief Gets Table B scale, reference, and bits values. Wraps BUFRLIB "nemspecs".
+!>  @brief Gets Table B scale, reference, and bits values. Wraps BUFRLIB nemspecs() subroutine.
 !>
 !>  @param[in] file_unit - c_int: Fortran file unit for the open file
 !>  @param[in] mnemonic - c_char: mnemonic
@@ -388,7 +384,7 @@ end subroutine nemspecs_c
 !>  @date 2022-08-16
 !>
 !>  @brief This subroutine returns information about a descriptor from the internal DX BUFR tables,
-!>         based on the mnemonic associated with that descriptor.  Wraps BUFRLIB "nemtab".
+!>         based on the mnemonic associated with that descriptor.  Wraps BUFRLIB nemtab() subroutine.
 !>
 !>  @param[in] bufr_unit - c_int: the bufr file pointer
 !>  @param[in] mnemonic - c_char: mnemonic
@@ -416,7 +412,7 @@ end subroutine nemtab_c
 !>  @author Ronald McLaren
 !>  @date 2022-08-16
 !>
-!>  @brief Get information about a Table B descriptor. Wraps BUFRLIB "nemtbb".
+!>  @brief Get information about a Table B descriptor. Wraps BUFRLIB nemtbb() subroutine.
 !>
 !>  @param[in] bufr_unit - c_int: the bufr file pointer
 !>  @param[in] table_idx - c_int: Table B index

--- a/src/cfe.h
+++ b/src/cfe.h
@@ -5,7 +5,9 @@
  *  @author J. Ator
  *  @date 2017-11-16
  */
-#define MAX_MEANING_LEN 150 /**< ??? */
+
+/** Maximum length of a meaning string for a Code/Flag table entry. */
+#define MAX_MEANING_LEN 150
 
 #ifdef UNDERSCORE
 #define cmpstia1   cmpstia1_

--- a/src/cobfl.c
+++ b/src/cobfl.c
@@ -11,10 +11,12 @@
  *  @author J. Ator @date 2005-11-29
  */
 #include "bufrlib.h"
-#define IN_COBFL /**< ??? */
+/** Macro to control whether certain variables are explicitly declared or referenced as extern. */
+#define IN_COBFL
 #include "cobfl.h"
 
-#define MXFNLEN 200 /**< ??? */
+/** Maximum length of a system file, including any directory prefixes or other local filesystem notation. */
+#define MXFNLEN 200
 
 /**
  *  This subroutine opens a new file for reading or writing BUFR
@@ -72,7 +74,7 @@
  *  @param bfl - System file to be opened. Inclusion of directory
  *  prefixes or other local filesystem notation is allowed, up to 200
  *  total characters.
- *  @param[in] io - Flag indicating how bfl is to be opened:
+ *  @param io - Flag indicating how bfl is to be opened:
  * - 'r' input (for reading BUFR messages) 
  * - 'w' output (for writing BUFR messages)
  *
@@ -85,8 +87,7 @@ void cobfl( char *bfl, char *io )
 
     char errstr[MXFNLEN+50];
 
-    char foparg[3] = " b";  /* 3rd character will automatically
-			       initialize to NULL */
+    char foparg[3] = " b";  /* 3rd character will automatically initialize to NULL */
     unsigned short i, j;
 
 /*
@@ -120,8 +121,7 @@ void cobfl( char *bfl, char *io )
     }
 
 /*
-**  If a file of this type is already open, then close it before
-**  opening the new one.
+**  If a file of this type is already open, then close it before opening the new one.
 */
     if ( pbf[j] != NULL ) fclose( pbf[j] );
 

--- a/src/cpmstabs.c
+++ b/src/cpmstabs.c
@@ -15,7 +15,7 @@
 /**
  *  This subroutine copies relevant information from the Fortran
  *  module MODA_MSTABS arrays to new arrays within C, for use
- *  whenever arrays are dynamically allocated at run time and in
+ *  whenever arrays are dynamically allocated at run time, and in
  *  which case we can't directly access the Fortran module
  *  MODA_MSTABS arrays from within C.
  *

--- a/src/cpmstabs.c
+++ b/src/cpmstabs.c
@@ -1,6 +1,13 @@
 /** @file
  *  @brief Copy master Table B and Table D information from
  *  Fortran arrays to C arrays within internal memory.
+ *
+ * ### Program history log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2014-12-04 | J. Ator | Original author.
+ * 2021-05-17 | J. Ator | Allow up to 24 characters in cbunit.
+ * 2023-01-18 | J. Ator | Remove MSTABS_BASE macro.
  */
 #include "bufrlib.h"
 #include "mstabs.h"
@@ -12,37 +19,26 @@
  *  which case we can't directly access the Fortran module
  *  MODA_MSTABS arrays from within C.
  *
+ *  All arguments to this subroutine are input.
+ *
  *  @author J. Ator
  *  @date 2014-12-04
  *
- *  @param[in] pnmtb -- f77int*: Number of master Table B entries
- *  @param[in] pibfxyn -- f77int*: Bit-wise representations of
- *                        master Table B FXY numbers
- *  @param[in] pcbscl -- char(*)[4]: Master Table B scale factors
- *  @param[in] pcbsref -- char(*)[12]: Master Table B reference
- *                        values
- *  @param[in] pcbbw -- char(*)[4]: Master Table B bit widths
- *  @param[in] pcbunit -- char(*)[24]: Master Table B units
- *  @param[in] pcbmnem -- char(*)[8]: Master Table B mnemonics
- *  @param[in] pcbelem -- char(*)[120]: Master Table B element names
- *  @param[in] pnmtd -- f77int*: Number of master Table D entries
- *  @param[in] pidfxyn -- f77int*: Bit-wise representations of
- *                        master Table D FXY numbers
- *  @param[in] pcdseq -- char(*)[120]: Master Table D sequence names
- *  @param[in] pcdmnem -- char(*)[8]: Master Table D mnemonics
- *  @param[in] pndelem -- f77int*: Number of child descriptors for
- *                        master Table D sequence
- *  @param[in] pidefxy -- f77int*: Bit-wise representations of
- *                        child descriptors for master Table D
- *                        sequence
- *  @param[in] maxcd -- f77int*: Maximum number of child descriptors
- *                      for a master Table D sequence
- *
- * <b>Program history log:</b>
- * | Date | Programmer | Comments |
- * | -----|------------|----------|
- * | 2014-12-04 | J. Ator | Original author |
- * | 2021-05-17 | J. Ator | Allow up to 24 characters in cbunit |
+ *  @param pnmtb - Number of master Table B entries
+ *  @param pibfxyn - Bit-wise representations of master Table B FXY numbers
+ *  @param pcbscl - Master Table B scale factors
+ *  @param pcbsref - Master Table B reference values
+ *  @param pcbbw - Master Table B bit widths
+ *  @param pcbunit - Master Table B units
+ *  @param pcbmnem - Master Table B mnemonics
+ *  @param pcbelem - Master Table B element names
+ *  @param pnmtd - Number of master Table D entries
+ *  @param pidfxyn - Bit-wise representations of master Table D FXY numbers
+ *  @param pcdseq - Master Table D sequence names
+ *  @param pcdmnem - Master Table D mnemonics
+ *  @param pndelem - Number of child descriptors for master Table D sequence
+ *  @param pidefxy - Bit-wise representations of child descriptors for master Table D sequence
+ *  @param maxcd - Maximum number of child descriptors for a master Table D sequence
 */
 void cpmstabs(  f77int *pnmtb,
 		f77int *pibfxyn, char (*pcbscl)[4],
@@ -57,40 +53,40 @@ void cpmstabs(  f77int *pnmtb,
 
     f77int ii, jj, idx;
 
-    MSTABS_BASE(nmtb) = *pnmtb;
+    nmtb_c = *pnmtb;
     for ( ii = 0; ii < *pnmtb; ii++ ) {
-	MSTABS_BASE(ibfxyn)[ii] = pibfxyn[ii];
+	ibfxyn_c[ii] = pibfxyn[ii];
 	for ( jj = 0; jj < 4; jj++ ) {
-	    MSTABS_BASE(cbscl)[ii][jj] = pcbscl[ii][jj];
-	    MSTABS_BASE(cbbw)[ii][jj] = pcbbw[ii][jj];
+	    cbscl_c[ii][jj] = pcbscl[ii][jj];
+	    cbbw_c[ii][jj] = pcbbw[ii][jj];
 	}
 	for ( jj = 0; jj < 8; jj++ ) {
-	    MSTABS_BASE(cbmnem)[ii][jj] = pcbmnem[ii][jj];
+	    cbmnem_c[ii][jj] = pcbmnem[ii][jj];
 	}
 	for ( jj = 0; jj < 12; jj++ ) {
-	    MSTABS_BASE(cbsref)[ii][jj] = pcbsref[ii][jj];
+	    cbsref_c[ii][jj] = pcbsref[ii][jj];
 	}
 	for ( jj = 0; jj < 24; jj++ ) {
-	    MSTABS_BASE(cbunit)[ii][jj] = pcbunit[ii][jj];
+	    cbunit_c[ii][jj] = pcbunit[ii][jj];
 	}
 	for ( jj = 0; jj < 120; jj++ ) {
-	    MSTABS_BASE(cbelem)[ii][jj] = pcbelem[ii][jj];
+	    cbelem_c[ii][jj] = pcbelem[ii][jj];
 	}
     }
 
-    MSTABS_BASE(nmtd) = *pnmtd;
+    nmtd_c = *pnmtd;
     for ( ii = 0; ii < *pnmtd; ii++ ) {
-	MSTABS_BASE(idfxyn)[ii] = pidfxyn[ii];
-	MSTABS_BASE(ndelem)[ii] = pndelem[ii];
+	idfxyn_c[ii] = pidfxyn[ii];
+	ndelem_c[ii] = pndelem[ii];
 	for ( jj = 0; jj < pndelem[ii]; jj++ ) {
 	    idx = icvidx( &ii, &jj, maxcd );
-	    MSTABS_BASE(idefxy)[idx] = pidefxy[idx];
+	    idefxy_c[idx] = pidefxy[idx];
 	}
 	for ( jj = 0; jj < 8; jj++ ) {
-	    MSTABS_BASE(cdmnem)[ii][jj] = pcdmnem[ii][jj];
+	    cdmnem_c[ii][jj] = pcdmnem[ii][jj];
 	}
 	for ( jj = 0; jj < 120; jj++ ) {
-	    MSTABS_BASE(cdseq)[ii][jj] = pcdseq[ii][jj];
+	    cdseq_c[ii][jj] = pcdseq[ii][jj];
 	}
     }
 

--- a/src/moda_msgmem.F
+++ b/src/moda_msgmem.F
@@ -39,10 +39,12 @@ C>        Number of DX BUFR tables represented by the
 C>        messages within mdx (up to a maximum of MXDXTS).
 	  INTEGER :: NDXTS
 
-C>        ???	  
+C>        Maximum number of DX BUFR table messages that can
+C>        be stored within mdx.
 	  INTEGER :: MXDXM
 
-C>        ???	  
+C>        Maximum number of entries that can be stored
+C>        within mdx.
 	  INTEGER :: MXDXW
 
 C>        Pointers to the beginning of each message within

--- a/src/moda_tables.F
+++ b/src/moda_tables.F
@@ -12,17 +12,16 @@ C> @author J. Ator @date 2014-12-10
 
 	MODULE MODA_TABLES
 
-C>        @var maxtab
 C>        Maximum number of entries in the jump/link table;
 C>        equivalent to MAXJL.
-C>
-C>        @var ntab
+	  INTEGER :: MAXTAB 
+
 C>        Number of entries in the jump/link table.
-C>
-C>        @var tag
+	  INTEGER :: NTAB
+
 C>        Mnemonics in the jump/link table.
-C>
-C>        @var typ
+	  CHARACTER*10, ALLOCATABLE :: TAG(:)
+
 C>        Type indicators corresponding to tag:
 C>        - "SUB", if corresponding tag entry is a Table A mnemonic
 C>        - "SEQ", if corresponding tag entry is a Table D mnemonic
@@ -45,8 +44,11 @@ C>        - "CHR", if corresponding tag entry is a Table B mnemonic
 C>          with units of CCITT IA5
 C>        - "NUM", if corresponding tag entry is a Table B mnemonic
 C>          with any units other than CCITT IA5
-C>
-C>        @var jump
+	  CHARACTER*3, ALLOCATABLE :: TYP(:)
+
+C> ???
+	  INTEGER, ALLOCATABLE :: KNT(:)
+
 C>        Jump forward indices corresponding to tag and typ:
 C>        - 0, if corresponding typ entry is "CHR" or "NUM"
 C>        - Jump/link table entry for Table D mnemonic whose replication
@@ -55,20 +57,8 @@ C>          entry is "DRB", "DRP" or "REP"
 C>        - Jump/link table entry for Table B or D mnemonic which is
 C>          the first sequential child descriptor of the corresponding
 C>          tag entry, otherwise
-C>
-C>        @var jmpb
-C>        Jump backward indices corresponding to tag and typ:
-C>        - 0, if corresponding typ entry is "SUB"
-C>        - Jump/link table entry denoting the replication of
-C>          corresponding tag entry, if corresponding typ entry is
-C>          "RPC", or if corresponding typ entry is "SEQ" and 
-C>          corresponding tag entry uses either short (1-bit) or
-C>          regular (non-delayed) replication
-C>        - Jump/link table entry for Table A or D mnemonic of
-C>          which corresponding tag entry is a child descriptor,
-C>          otherwise
-C>
-C>        @var link
+	  INTEGER, ALLOCATABLE :: JUMP(:) 
+
 C>        Link indices corresponding to tag, typ and jmpb:
 C>        - 0, if corresponding typ entry is "SUB" or "RPC", or if
 C>          corresponding typ entry is "SEQ" and corresponding tag
@@ -80,14 +70,26 @@ C>        - Jump/link table entry for Table B or D mnemonic which
 C>          follows the corresponding tag entry as the next sequential
 C>          child descriptor of the Table A or D mnemonic referenced 
 C>          by corresponding jmpb entry, otherwise
-C>          
-C>        @var ibt
+	  INTEGER, ALLOCATABLE :: LINK(:)
+
+C>        Jump backward indices corresponding to tag and typ:
+C>        - 0, if corresponding typ entry is "SUB"
+C>        - Jump/link table entry denoting the replication of
+C>          corresponding tag entry, if corresponding typ entry is
+C>          "RPC", or if corresponding typ entry is "SEQ" and 
+C>          corresponding tag entry uses either short (1-bit) or
+C>          regular (non-delayed) replication
+C>        - Jump/link table entry for Table A or D mnemonic of
+C>          which corresponding tag entry is a child descriptor,
+C>          otherwise
+	  INTEGER, ALLOCATABLE :: JMPB(:)
+
 C>        Bit widths corresponding to tag and typ:
 C>        - Bit width of corresponding tag entry, if corresponding
 C>          typ entry is "CHR", "NUM", "DRB" or "DRP"
 C>        - 0, otherwise
-C>
-C>        @var irf
+	  INTEGER, ALLOCATABLE :: IBT(:)
+
 C>        Reference values corresponding to tag and typ:
 C>        - Reference value of corresponding tag entry, if
 C>          corresponding typ entry is "NUM"
@@ -95,8 +97,8 @@ C>        - Number of regular (non-delayed) replications of Table D
 C>          mnemonic referenced by corresponding jump entry, if
 C>          corresponding typ entry is "REP"
 C>        - 0, otherwise
-C>
-C>        @var isc
+	  INTEGER, ALLOCATABLE :: IRF(:)
+
 C>        Scale factors corresponding to tag and typ:
 C>        - Scale factor of corresponding tag entry, if
 C>          corresponding typ entry is "NUM"
@@ -105,68 +107,27 @@ C>          which is the last sequential child descriptor of the
 C>          corresponding tag entry, if the corresponding typ entry
 C>          is "SUB"
 C>        - 0, otherwise
-C>
-C>        @var itp
+	  INTEGER, ALLOCATABLE :: ISC(:)
+
 C>        Integer type values corresponding to typ:
 C>        - 1, if corresponding typ entry is "DRS", "DRP" or "DRB"
 C>        - 2, if corresponding typ entry is "NUM"
 C>        - 3, if corresponding typ entry is "CHR"
 C>        - 0, otherwise
-C>
-C>        @var vali
+	  INTEGER, ALLOCATABLE :: ITP(:)
+
 C>        Initialized data values corresponding to typ:
 C>        - Current placeholder value for "missing" data, if
 C>          corresponding typ entry is "REP", "NUM" or "CHR"
 C>        - 0, otherwise
-C>
-C>        @var knti
+	  REAL*8, ALLOCATABLE :: VALI(:)
+
 C>        Initialized replication counts corresponding to typ and jump:
 C>        - 0, if corresponding typ entry is "RPC", "RPS" or "DRB"
 C>        - Number of regular (non-delayed) replications of Table D
 C>          mnemonic referenced by corresponding jump entry, if
 C>          corresponding typ entry is "REP"
 C>        - 1, otherwise
-
-C> ???
-	  INTEGER :: MAXTAB 
-
-C> ???
-	  INTEGER :: NTAB
-
-C> ???
-	  CHARACTER*10, ALLOCATABLE :: TAG(:)
-
-C> ???
-	  CHARACTER*3, ALLOCATABLE :: TYP(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: KNT(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: JUMP(:) 
-
-C> ???
-	  INTEGER, ALLOCATABLE :: LINK(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: JMPB(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: IBT(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: IRF(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: ISC(:)
-
-C> ???
-	  INTEGER, ALLOCATABLE :: ITP(:)
-
-C> ???
-	  REAL*8, ALLOCATABLE :: VALI(:)
-
-C> ???
 	  INTEGER, ALLOCATABLE :: KNTI(:)
 
 C> ???

--- a/src/mstabs.h
+++ b/src/mstabs.h
@@ -17,19 +17,15 @@
 #define cpmstabs   cpmstabs_
 #endif
 
+/** Function prototype. */
 void cpmstabs( f77int *, f77int *, char (*)[4], char (*)[12], char (*)[4],
         char (*)[24], char (*)[8], char (*)[120], f77int *, f77int *,
         char (*)[120], char (*)[8], f77int *, f77int *, f77int * );
 
-/** ??? @return ??? */
+/** Macro for text substitution within this file. */
 #define MSTABS_BASE(var) mstabs_newCarr_ ## var 
 
 #ifdef IN_ARALLOCC
-/**
- * ???
- *
- * @return ???
- */
 	f77int MSTABS_BASE(nmtb); 
 	f77int *MSTABS_BASE(ibfxyn); /**< ??? */
 	char   (*MSTABS_BASE(cbscl))[4]; /**< ??? */
@@ -45,11 +41,6 @@ void cpmstabs( f77int *, f77int *, char (*)[4], char (*)[12], char (*)[4],
 	f77int *MSTABS_BASE(ndelem); /**< ??? */
 	f77int *MSTABS_BASE(idefxy); /**< ??? */
 #else
-/**
- * ???
- *
- * @return ???
- */
 	extern f77int MSTABS_BASE(nmtb); /**< ??? */
 	extern f77int *MSTABS_BASE(ibfxyn); /**< ???  @return ???*/
 	extern char   (*MSTABS_BASE(cbscl))[4]; /**< ???  @return ???*/

--- a/src/mstabs.h
+++ b/src/mstabs.h
@@ -1,6 +1,5 @@
 /** @file
- *  @brief Define signatures and declare variables for internal storage
- *  of master Table B and Table D entries.
+ *  @brief Declare variables for internal storage of master Table B and Table D entries.
  *
  *  Since the arrays in Fortran module MODA_MSTABS are dynamically
  *  allocated and their size isn't known at compile time, then we can't
@@ -17,7 +16,6 @@
 #define cpmstabs   cpmstabs_
 #endif
 
-/** Function prototype. */
 void cpmstabs( f77int *pnmtb, f77int *pibfxyn, char (*pcbscl)[4], char (*pcbsref)[12], char (*pcbbw)[4],
         char (*pcbunit)[24], char (*pcbmnem)[8], char (*pcbelem)[120], f77int *pnmtd, f77int *pidfxyn,
         char (*pcdseq)[120], char (*pcdmnem)[8], f77int *pndelem, f77int *pidefxy, f77int *maxcd );
@@ -52,18 +50,32 @@ void cpmstabs( f77int *pnmtb, f77int *pibfxyn, char (*pcbscl)[4], char (*pcbsref
         /** Bit-wise representations of child descriptors for master Table D sequence; copied from Fortran idefxy array. */
 	f77int *idefxy_c;
 #else
+        /** Number of master Table B entries; copied from Fortran nmtb variable. */
 	extern f77int nmtb_c;
+        /** Bit-wise representations of master Table B FXY numbers; copied from Fortran ibfxyn array. */
 	extern f77int *ibfxyn_c;
+        /** Master Table B scale factors; copied from Fortran cbscl array. */
 	extern char   (*cbscl_c)[4];
+        /** Master Table B reference value; copied from Fortran cbsref array. */
 	extern char   (*cbsref_c)[12];
+        /** Master Table B bit widths; copied from Fortran cbbw array. */
 	extern char   (*cbbw_c)[4];
+        /** Master Table B units; copied from Fortran cbunit array. */
 	extern char   (*cbunit_c)[24];
+        /** Master Table B mnemonics; copied from Fortran cbmnem array. */
 	extern char   (*cbmnem_c)[8];
+        /** Master Table B element names; copied from Fortran cbelem array. */
 	extern char   (*cbelem_c)[120];
+        /** Number of master Table D entries; copied from Fortran nmtd variable. */
 	extern f77int nmtd_c;
+        /** Bit-wise representations of master Table D FXY numbers; copied from Fortran idfxyn array. */
 	extern f77int *idfxyn_c;
+        /** Master Table D sequence names; copied from Fortran cdseq array. */
 	extern char   (*cdseq_c)[120];
+        /** Master Table D mnemonics; copied from Fortran cdmnem array. */
 	extern char   (*cdmnem_c)[8];
+        /** Number of child descriptors for master Table D sequence; copied from Fortran ndelem array. */
 	extern f77int *ndelem_c;
+        /** Bit-wise representations of child descriptors for master Table D sequence; copied from Fortran idefxy array. */
 	extern f77int *idefxy_c;
 #endif

--- a/src/mstabs.h
+++ b/src/mstabs.h
@@ -18,41 +18,52 @@
 #endif
 
 /** Function prototype. */
-void cpmstabs( f77int *, f77int *, char (*)[4], char (*)[12], char (*)[4],
-        char (*)[24], char (*)[8], char (*)[120], f77int *, f77int *,
-        char (*)[120], char (*)[8], f77int *, f77int *, f77int * );
-
-/** Macro for text substitution within this file. */
-#define MSTABS_BASE(var) mstabs_newCarr_ ## var 
+void cpmstabs( f77int *pnmtb, f77int *pibfxyn, char (*pcbscl)[4], char (*pcbsref)[12], char (*pcbbw)[4],
+        char (*pcbunit)[24], char (*pcbmnem)[8], char (*pcbelem)[120], f77int *pnmtd, f77int *pidfxyn,
+        char (*pcdseq)[120], char (*pcdmnem)[8], f77int *pndelem, f77int *pidefxy, f77int *maxcd );
 
 #ifdef IN_ARALLOCC
-	f77int MSTABS_BASE(nmtb); 
-	f77int *MSTABS_BASE(ibfxyn); /**< ??? */
-	char   (*MSTABS_BASE(cbscl))[4]; /**< ??? */
-	char   (*MSTABS_BASE(cbsref))[12]; /**< ??? */
-	char   (*MSTABS_BASE(cbbw))[4]; /**< ??? */
-	char   (*MSTABS_BASE(cbunit))[24]; /**< ??? */
-	char   (*MSTABS_BASE(cbmnem))[8]; /**< ??? */
-	char   (*MSTABS_BASE(cbelem))[120]; /**< ??? */
-	f77int MSTABS_BASE(nmtd); /**< ??? */
-	f77int *MSTABS_BASE(idfxyn); /**< ??? */
-	char   (*MSTABS_BASE(cdseq))[120]; /**< ??? */
-	char   (*MSTABS_BASE(cdmnem))[8]; /**< ??? */
-	f77int *MSTABS_BASE(ndelem); /**< ??? */
-	f77int *MSTABS_BASE(idefxy); /**< ??? */
+        /** Number of master Table B entries; copied from Fortran nmtb variable. */
+	f77int nmtb_c; 
+        /** Bit-wise representations of master Table B FXY numbers; copied from Fortran ibfxyn array. */
+	f77int *ibfxyn_c;
+        /** Master Table B scale factors; copied from Fortran cbscl array. */
+	char   (*cbscl_c)[4];
+        /** Master Table B reference value; copied from Fortran cbsref array. */
+	char   (*cbsref_c)[12];
+        /** Master Table B bit widths; copied from Fortran cbbw array. */
+	char   (*cbbw_c)[4];
+        /** Master Table B units; copied from Fortran cbunit array. */
+	char   (*cbunit_c)[24];
+        /** Master Table B mnemonics; copied from Fortran cbmnem array. */
+	char   (*cbmnem_c)[8];
+        /** Master Table B element names; copied from Fortran cbelem array. */
+	char   (*cbelem_c)[120];
+        /** Number of master Table D entries; copied from Fortran nmtd variable. */
+	f77int nmtd_c;
+        /** Bit-wise representations of master Table D FXY numbers; copied from Fortran idfxyn array. */
+	f77int *idfxyn_c;
+        /** Master Table D sequence names; copied from Fortran cdseq array. */
+	char   (*cdseq_c)[120];
+        /** Master Table D mnemonics; copied from Fortran cdmnem array. */
+	char   (*cdmnem_c)[8];
+        /** Number of child descriptors for master Table D sequence; copied from Fortran ndelem array. */
+	f77int *ndelem_c;
+        /** Bit-wise representations of child descriptors for master Table D sequence; copied from Fortran idefxy array. */
+	f77int *idefxy_c;
 #else
-	extern f77int MSTABS_BASE(nmtb); /**< ??? */
-	extern f77int *MSTABS_BASE(ibfxyn); /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cbscl))[4]; /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cbsref))[12]; /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cbbw))[4]; /**< ??? @return ??? */
-	extern char   (*MSTABS_BASE(cbunit))[24]; /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cbmnem))[8]; /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cbelem))[120]; /**< ???  @return ???*/
-	extern f77int MSTABS_BASE(nmtd); /**< ???  @return ???*/
-	extern f77int *MSTABS_BASE(idfxyn); /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cdseq))[120]; /**< ???  @return ???*/
-	extern char   (*MSTABS_BASE(cdmnem))[8]; /**< ???  @return ???*/
-	extern f77int *MSTABS_BASE(ndelem); /**< ???  @return ???*/
-	extern f77int *MSTABS_BASE(idefxy); /**< ???  @return ???*/
+	extern f77int nmtb_c;
+	extern f77int *ibfxyn_c;
+	extern char   (*cbscl_c)[4];
+	extern char   (*cbsref_c)[12];
+	extern char   (*cbbw_c)[4];
+	extern char   (*cbunit_c)[24];
+	extern char   (*cbmnem_c)[8];
+	extern char   (*cbelem_c)[120];
+	extern f77int nmtd_c;
+	extern f77int *idfxyn_c;
+	extern char   (*cdseq_c)[120];
+	extern char   (*cdmnem_c)[8];
+	extern f77int *ndelem_c;
+	extern f77int *idefxy_c;
 #endif

--- a/src/nummtb.c
+++ b/src/nummtb.c
@@ -2,6 +2,13 @@
  * @brief Search for an entry corresponding to IDN in the bufr
  * master table.
  * @author J Ator @date 2009-03-23
+ *
+ * ### Program history log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2009-03-23 | J. Ator | Original author.
+ * 2023-01-18 | J. Ator | Remove MSTABS_BASE macro.
+
 */
 
 #include "bufrlib.h"
@@ -15,7 +22,7 @@
  * table must be sorted in ascending order (by fxy number) in order
  * for this routine to work properly.
  *
- * @param idn- bit-wise representation of fxy value to be searched for.
+ * @param idn - bit-wise representation of fxy value to be searched for.
  * @param tab - table in which idn was found ('B' or 'D').
  * @param ipt - index of entry for idn in master table tab.
  *
@@ -29,13 +36,13 @@ void nummtb( f77int *idn, char *tab, f77int *ipt )
 
 	if ( *idn >= ifxy( "300000", 6 ) ) {
 	    *tab = 'D';
-	    pifxyn = &MSTABS_BASE(idfxyn)[0];
-	    nmt = MSTABS_BASE(nmtd);
+	    pifxyn = &idfxyn_c[0];
+	    nmt = nmtd_c;
 	}
 	else {
 	    *tab = 'B';
-	    pifxyn = &MSTABS_BASE(ibfxyn)[0];
-	    nmt = MSTABS_BASE(nmtb);
+	    pifxyn = &ibfxyn_c[0];
+	    nmt = nmtb_c;
 	}
 
         pbs = ( f77int * ) bsearch( idn, pifxyn, ( size_t ) nmt, sizeof( f77int ),

--- a/src/stseq.c
+++ b/src/stseq.c
@@ -34,15 +34,16 @@
  * @param[in] ncdesc -- f77int*: Number of WMO-standard child descriptors
  *                      in cdesc
  *
- * <b>Program history log:</b>
- * | Date | Programmer | Comments |
- * | -----|------------|----------|
- * | 2009-03-23 | J. Ator | Original author |
- * | 2010-03-19 | J. Ator | Added processing for 2-04 associated fields |
- * | 2010-04-05 | J. Ator | Added processing for 2-2X, 2-3X and 2-4X non-marker operators |
- * | 2015-03-04 | J. Ator | Handle special case when associated fields are in effect for a Table D descriptor |
- * | 2021-05-17 | J. Ator | Allow up to 24 characters in cbunit |
- * | 2021-08-18 | J. Ator | Use strcpy instead of strncpy and then overwrite trailing null, in order to silence superfluous GNU compiler warnings |
+ * ### Program history log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2009-03-23 | J. Ator | Original author.
+ * 2010-03-19 | J. Ator | Added processing for 2-04 associated fields.
+ * 2010-04-05 | J. Ator | Added processing for 2-2X, 2-3X and 2-4X non-marker operators.
+ * 2015-03-04 | J. Ator | Handle special case when associated fields are in effect for a Table D descriptor.
+ * 2021-05-17 | J. Ator | Allow up to 24 characters in cbunit.
+ * 2021-08-18 | J. Ator | Use strcpy instead of strncpy and then overwrite trailing null, in order to silence superfluous GNU compiler warnings.
+ * 2023-01-18 | J. Ator | Remove MSTABS_BASE macro.
 */
 
 void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
@@ -112,8 +113,8 @@ void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
 		sprintf( nemo2, "RPSEQ%.3lu", ( unsigned long ) *irepct );
 
 		stseq( lun, irepct, &rpidn, nemo2, rpseq,
-		    &MSTABS_BASE(idefxy)[icvidx(&ipt,&i0,&imxcd)],
-		    &MSTABS_BASE(ndelem)[ipt] );
+		    &idefxy_c[icvidx(&ipt,&i0,&imxcd)],
+		    &ndelem_c[ipt] );
 		pkint = rpidn;
 
 	    }
@@ -121,10 +122,10 @@ void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
 /*
 **		Store cdesc[i] as is directly within the internal Table D.
 */
-		stseq( lun, irepct, &cdesc[i], &MSTABS_BASE(cdmnem)[ipt][0],
-		    &MSTABS_BASE(cdseq)[ipt][0],
-		    &MSTABS_BASE(idefxy)[icvidx(&ipt,&i0,&imxcd)],
-		    &MSTABS_BASE(ndelem)[ipt] );
+		stseq( lun, irepct, &cdesc[i], &cdmnem_c[ipt][0],
+		    &cdseq_c[ipt][0],
+		    &idefxy_c[icvidx(&ipt,&i0,&imxcd)],
+		    &ndelem_c[ipt] );
 		pkint = cdesc[i];
 	    }
         }
@@ -330,10 +331,10 @@ void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
 **		(this is a special case!)
 */
 		nummtb( &cdesc[i], &tab, &ipt );
-	    	stseq( lun, irepct, &cdesc[i], &MSTABS_BASE(cdmnem)[ipt][0],
-		       &MSTABS_BASE(cdseq)[ipt][0],
-		       &MSTABS_BASE(idefxy)[icvidx(&ipt,&i0,&imxcd)],
-		       &MSTABS_BASE(ndelem)[ipt] );
+	    	stseq( lun, irepct, &cdesc[i], &cdmnem_c[ipt][0],
+		       &cdseq_c[ipt][0],
+		       &idefxy_c[icvidx(&ipt,&i0,&imxcd)],
+		       &ndelem_c[ipt] );
 		pkint = cdesc[i];
 	    }
 	    else {
@@ -386,17 +387,17 @@ void stseq( f77int *lun, f77int *irepct, f77int *idn, char nemo[8],
 */
 		nb = igetntbi( lun, &tab, sizeof( tab ) );
 		cadn30( &cdesc[i], adn2, sizeof( adn2 ) ); 
-		stntbi( &nb, lun, adn2, &MSTABS_BASE(cbmnem)[ipt][0],
-			&MSTABS_BASE(cbelem)[ipt][0], sizeof( adn2 ), 8, 55 );
+		stntbi( &nb, lun, adn2, &cbmnem_c[ipt][0],
+			&cbelem_c[ipt][0], sizeof( adn2 ), 8, 55 );
 
 		/* Initialize card to all blanks. */
 		memset( card, (int) cblk, sizeof( card ) );
 
-		strncpy( &card[2], &MSTABS_BASE(cbmnem)[ipt][0], 8 );
-		strncpy( &card[13], &MSTABS_BASE(cbscl)[ipt][0], 4 );
-		strncpy( &card[19], &MSTABS_BASE(cbsref)[ipt][0], 12 );
-		strncpy( &card[33], &MSTABS_BASE(cbbw)[ipt][0], 4 );
-		strncpy( &card[40], &MSTABS_BASE(cbunit)[ipt][0], 24 );
+		strncpy( &card[2], &cbmnem_c[ipt][0], 8 );
+		strncpy( &card[13], &cbscl_c[ipt][0], 4 );
+		strncpy( &card[19], &cbsref_c[ipt][0], 12 );
+		strncpy( &card[33], &cbbw_c[ipt][0], 4 );
+		strncpy( &card[40], &cbunit_c[ipt][0], 24 );
 		elemdx( card, lun, sizeof( card ) );
 	    }
 	    pkint = cdesc[i];

--- a/utils/debufr.c.in
+++ b/utils/debufr.c.in
@@ -34,42 +34,23 @@
 #define prtusage prtusage_
 #endif
 
-/**
- * ???
- *
- * @param c1 - ???
- * @param c2 - ???
- * @param f1 - ???
- * @param c3 - ???
- * @param c4 - ???
- * @param c5 - ???
- * @param c6 - ???
- * @param c7 - ???
- * @param s1 - ???
- * @param s2 - ???
- * @param s3 - ???
- * @param s4 - ???
- * @param s5 - ???
- * @param s6 - ???
- * @param s7 - ???
- *
- * @author J. Ator @date 2018-03-01 
- */ 
-void fdebufr( char *c1, char *c2, f77int *f1, char *c3, char *c4, char *c5, char *c6, char *c7,
+/** Funtion prototypes. */ 
+void fdebufr( char *ofile, char *tbldir, f77int *lentd, char *tblfil, char *prmstg, char *basic, char *forcemt, char *cfms,
               size_t s1, size_t s2, size_t s3, size_t s4, size_t s5, size_t s6, size_t s7);
-void prtusage( char * );
+void prtusage( char *prgnam );
 
-#define MXFLEN 500 /**< ??? */
-#define MXFLEN_TBLFIL (MXFLEN+50) /**< ??? */
+/** Maximum length of the [path/]name passed in for bufrfile. */
+#define MXFLEN 500
+/** Maximum length of the [path/]name for a BUFR tables file, based on the value of MXFLEN. */
+#define MXFLEN_TBLFIL (MXFLEN+50)
 
 /**
  * This function prints program usage information to standard output.
  *   
- * @param prgnam - path/name of program executable
+ * @param prgnam - [path/]name of program executable.
  *
  * @author J. Ator @date 2018-03-01 
  */
-
 void prtusage( char *prgnam ) {
 	printf( "\nUSAGE:\n" );
 	printf( "  %s [-v] [-h] [-b] [-c] [-m] [-o outfile] [-t tabledir] [-f tablefil] [-p prmstg] bufrfile\n\n", prgnam );
@@ -114,8 +95,7 @@ void prtusage( char *prgnam ) {
 }
 
 /**
- * This program decodes a BUFR file and generates a verbose
- * listing of the contents.
+ * This program decodes a BUFR file and generates a verbose listing of the contents.
  *
  * If a [DX BUFR Tables](@ref dfbftab) file is
  * specified (using the -f option) or if the specified BUFR file
@@ -181,8 +161,7 @@ void prtusage( char *prgnam ) {
  * </pre>
  *
  * @remarks
- * - Fortran logical unit numbers 51, 90, 91, 92 and 93 are reserved
- * for use within this program.
+ * - Fortran logical unit numbers 51, 90, 91, 92 and 93 are reserved for use within this program.
  *
  * @param argc - argument count.
  * @param argv - argument array.
@@ -191,7 +170,6 @@ void prtusage( char *prgnam ) {
  *
  * @author J. Ator @date 2018-03-01 
  */
-
 int main( int argc, char *argv[ ] ) {
 
 	int ch;

--- a/utils/debufr.c.in
+++ b/utils/debufr.c.in
@@ -31,12 +31,11 @@
 
 #ifdef UNDERSCORE
 #define fdebufr fdebufr_
-#define prtusage prtusage_
 #endif
 
-/** Funtion prototypes. */ 
 void fdebufr( char *ofile, char *tbldir, f77int *lentd, char *tblfil, char *prmstg, char *basic, char *forcemt, char *cfms,
               size_t s1, size_t s2, size_t s3, size_t s4, size_t s5, size_t s6, size_t s7);
+
 void prtusage( char *prgnam );
 
 /** Maximum length of the [path/]name passed in for bufrfile. */

--- a/utils/xbfmg.c
+++ b/utils/xbfmg.c
@@ -24,13 +24,17 @@
 #define prtusage prtusage_
 #endif
 
-void prtusage( char * );
+/** Function prototype. */ 
+void prtusage( char *prgnam );
 
-#define MXFLEN 125 /**< Maximum length of bufrfile [path/]name. */
+/** Maximum length of bufrfile [path/]name. */
+#define MXFLEN 125
 
 /**
  * This function prints program usage information to standard output.
  *   
+ * @param prgnam - [path/]name of program executable.
+ *
  * @author J. Ator @date 2018-03-01
  */
 void prtusage( char *prgnam ) {

--- a/utils/xbfmg.c
+++ b/utils/xbfmg.c
@@ -20,11 +20,6 @@
 
 #include "bufrlib.h"
 
-#ifdef UNDERSCORE
-#define prtusage prtusage_
-#endif
-
-/** Function prototype. */ 
 void prtusage( char *prgnam );
 
 /** Maximum length of bufrfile [path/]name. */


### PR DESCRIPTION
This fills in some missing items from #263

This also completely removes the MSTABS_BASE macro from the library.  This macro abstraction is no longer needed, since dynamic memory allocation is now used for the only remaining library build.

@jack-woollen at some point could you please fill in the documentation for arrays knt, iseq, and jseq in moda_tables.F?  I'm not sure what those are (thanks! ;-)