### PR TITLE
doxygen and removed tabs

### DIFF
--- a/src/iupbs3.f
+++ b/src/iupbs3.f
@@ -1,85 +1,85 @@
 C> @file
 C> @brief Read a data value from Section 3 of a BUFR message.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2009-03-23 | J. Ator | Original author.
+C> 2022-10-04 | J. Ator | Added 8-byte wrapper.
+C>
+C> @author J. Ator @date 2009-03-23
 
 C> This function returns a specified value from within Section 3
 C> of a BUFR message.
 C>
-C> @author J. Ator
-C> @date 2009-03-23
-C>
-C> @param[in]  MBAY   -- integer(*): BUFR message
-C> @param[in]  S3MNEM  -- character*(*): Value to be read from
-C>                        Section 3 of MBAY
-C>                         - 'NSUB'  = Number of data subsets
-C>                         - 'IOBS'  = Flag indicating whether the
-C>                                     message contains observed data:
-C>                                     - 0 = No
-C>                                     - 1 = Yes
-C>                         - 'ICMP'  = Flag indicating whether the
-C>                                     message contains compressed data:
-C>                                     - 0 = No
-C>                                     - 1 = Yes
-C> @returns iupbs3 -- integer: Value corresponding to S3MNEM
-C>                      - -1 = S3MNEM was invalid 
-C>
 C> @remarks
-C> - The start of the BUFR message (i.e. the string 'BUFR') must be
-C>   aligned on the first 4 bytes of MBAY.
+C> The start of the BUFR message (i.e. the string 'BUFR') must be
+C> aligned on the first 4 bytes of MBAY.
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 2009-03-23 | J. Ator | Original author |
-C> | 2022-10-04 | J. Ator | Added 8-byte wrapper |
+C> @param[in] MBAY - integer(*): BUFR message
+C> @param[in] S3MNEM - character*(*): Value to be read from
+C> Section 3 of MBAY
+C> - 'NSUB'  = Number of data subsets
+C> - 'IOBS'  = Flag indicating whether the message contains observed data:
+C>   - 0 = No
+C>   - 1 = Yes
+C> - 'ICMP'  = Flag indicating whether the message contains compressed data:
+C>   - 0 = No
+C>   - 1 = Yes
+C>
+C> @returns iupbs3 - integer: Value corresponding to S3MNEM
+C> - -1 = S3MNEM was invalid
+C>
+C> @author J. Ator @date 2009-03-23
 
-	RECURSIVE FUNCTION IUPBS3(MBAY,S3MNEM) RESULT(IRET)
+        RECURSIVE FUNCTION IUPBS3(MBAY,S3MNEM) RESULT(IRET)
 
-	USE MODV_IM8B
+        USE MODV_IM8B
 
-	DIMENSION	MBAY(*)
+        DIMENSION       MBAY(*)
 
-	CHARACTER*(*)	S3MNEM
+        CHARACTER*(*)   S3MNEM
 
 C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
 
 C       Check for I8 integers.
 
-	IF(IM8B) THEN
-	    IM8B=.FALSE.
+        IF(IM8B) THEN
+           IM8B=.FALSE.
 
-	    IRET = IUPBS3(MBAY,S3MNEM)
+           IRET = IUPBS3(MBAY,S3MNEM)
 
-	    IM8B=.TRUE.
-	    RETURN
-	ENDIF
+           IM8B=.TRUE.
+           RETURN
+        ENDIF
 
-C	Call subroutine WRDLEN to initialize some important information
-C	about the local machine, just in case subroutine OPENBF hasn't
-C	been called yet.
+C       Call subroutine WRDLEN to initialize some important information
+C       about the local machine, just in case subroutine OPENBF hasn't
+C       been called yet.
 
-	CALL WRDLEN
+        CALL WRDLEN
 
-C	Skip to the beginning of Section 3.
+C       Skip to the beginning of Section 3.
 
-	CALL GETLENS(MBAY,3,LEN0,LEN1,LEN2,LEN3,L4,L5)
-	IPT = LEN0 + LEN1 + LEN2
+        CALL GETLENS(MBAY,3,LEN0,LEN1,LEN2,LEN3,L4,L5)
+        IPT = LEN0 + LEN1 + LEN2
 
-C	Unpack the requested value.
+C       Unpack the requested value.
 
-	IF(S3MNEM.EQ.'NSUB') THEN
-	    IRET = IUPB(MBAY,IPT+5,16)
-	ELSE IF( (S3MNEM.EQ.'IOBS') .OR. (S3MNEM.EQ.'ICMP') ) THEN
-	    IVAL = IUPB(MBAY,IPT+7,8)
-	    IF(S3MNEM.EQ.'IOBS') THEN
-		IMASK = 128
-	    ELSE
-		IMASK = 64
-	    ENDIF
-	    IRET = MIN(1,IAND(IVAL,IMASK))
-	ELSE
-	    IRET = -1
-	ENDIF
+        IF(S3MNEM.EQ.'NSUB') THEN
+           IRET = IUPB(MBAY,IPT+5,16)
+        ELSE IF( (S3MNEM.EQ.'IOBS') .OR. (S3MNEM.EQ.'ICMP') ) THEN
+           IVAL = IUPB(MBAY,IPT+7,8)
+           IF(S3MNEM.EQ.'IOBS') THEN
+              IMASK = 128
+           ELSE
+              IMASK = 64
+           ENDIF
+           IRET = MIN(1,IAND(IVAL,IMASK))
+        ELSE
+           IRET = -1
+        ENDIF
 
-	RETURN
-	END
+        RETURN
+        END


### PR DESCRIPTION
Part of #272 
Part of #246 

Trying to remove the warnings, I untabified the file and caused a re-indent. This fixed the tab character warning.

I also cleaned up the doxygen.

