### PR TITLE
remove brew update

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -22,8 +22,6 @@ jobs:
     
     - name: install-deps
       run: |
-        brew update
-        brew install doxygen
         pip3 install setuptools
         pip3 install numpy
         pip3 install netCDF4


### PR DESCRIPTION
Fixes #274 

Remove brew update from the MacOS CI.