### PR TITLE
more documentation updates

### DIFF
--- a/src/cktaba.f
+++ b/src/cktaba.f
@@ -22,8 +22,9 @@ C> using one of the [message-reading subroutines](@ref hierarchy).
 C>
 C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C> @param[out] SUBSET - character*8: Table A mnemonic
-C>                      - "        " = IRET equal to 11 (see below) and not
-C>                                     using Section 3 decoding.
+C>                      - returned as a string of all blank characters
+C>                        if IRET is equal to 11 (see below) and if Section 3
+C>                        isn't being used for decoding  
 C> @param[out] JDATE    - integer: date-time stored within Section 1 of BUFR
 C>                        in format of either YYMMDDHH or
 C>                        YYYYMMDDHH, depending on datelen() value.

--- a/src/drstpl.f
+++ b/src/drstpl.f
@@ -1,6 +1,6 @@
 C> @file
-C> @brief Called by subroutine ufbrw() whenever it can't find a mnemonic it wants to write within the
-C> current subset buffer.
+C> @brief Search for a specified mnemonic within unexpanded sequences
+C> of the internal jump/link table.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -26,18 +26,18 @@ C> appears in the subset buffer, and in doing so it will also return
 C> a new value for inv2.
 C>
 C> @param[in] INOD - integer: jump/link table index of mnemonic to look for.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C> @param[in] INV1 - integer: starting index of the portion of the subset
-C> buffer currently being processed by ufbrw.
-C> @param[inout] INV2 - integer: on input, ending index of the portion
-C> of the subset buffer currently being processed by ufbrw. Onn output:
-C> if invn = 0, then inv2 is unchanged from its.  input value. Otherwise,
-C> it contains the redefined ending index of the portion of the subset
-C> buffer currently being processed by ufbrw, since expanding a delayed
-C> replication sequence will have necessarily increased the size of this
-C> buffer.
-C> @param[out] INVN - integer: location index of inod within subset buffer:.
-C> 0 not found.
+C> buffer currently being processed by ufbrw().
+C> @param[inout] INV2 - integer:
+C>  - on input, ending index of the portion of the subset buffer currently
+C>    being processed by ufbrw().
+C>  - on output, if invn = 0 then inv2 is unchanged from its input value.
+C>    Otherwise, it contains the redefined ending index of the portion of the subset
+C>    buffer currently being processed by ufbrw(), since expanding a delayed
+C>    replication sequence will have necessarily increased the size of this buffer.
+C> @param[out] INVN - integer: location index of inod within subset buffer.
+C>  - 0 not found.
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE DRSTPL(INOD,LUN,INV1,INV2,INVN)

--- a/src/dxinit.f
+++ b/src/dxinit.f
@@ -1,5 +1,5 @@
 C> @file
-C> @brief Initialize the internal arrays (in module tababd) holding the dictionary table.
+C> @brief Initialize the internal arrays which contain the dictionary table.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -15,12 +15,12 @@ C>
 C> @author Woollen @date 1994-01-06
       
 C> This subroutine initializes the internal arrays
-c> (in module tababd) holding the dictionary table. It then
-c> initializes the table with apriori table b and d entries
-c> (optional).
+C> (in module tababd) holding the dictionary table. It then
+C> initializes the table with apriori Table B and D entries
+C> (optional).
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[in] IOI - integer: switch:.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
+C> @param[in] IOI - integer: switch:
 C> - 0 do not initialize the table with apriori Table B and D entries.
 C> - else initialize the table with apriori Table B and D entries.
 C>

--- a/src/dxmini.f
+++ b/src/dxmini.f
@@ -1,4 +1,5 @@
 C> @file
+C> @brief Initialize a BUFR DX tables message.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -17,21 +18,21 @@ C> 2021-05-14 | J. Ator    | Changed default master table version to 36.
 C>
 C> @author Woollen @date 1994-01-06
       
-C> This subroutine initializes a bufr table (dictionary)
-C> message, writing all the preliminary information into sections 0,
+C> This subroutine initializes a BUFR DX tables (dictionary)
+C> message, writing all the preliminary information into Sections 0,
 C> 1, 3, 4.  Subroutine wrdxtb() will write the
 C> actual table information into the message.
 C>
 C> @note: Argument LUN is not referenced in this subroutine. It is left
 C> here in case an application program calls this subroutine.
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[out] MBAY - integer: (mxmsgld4)-word packed binary array containing bufr message.
-C> @param[out] MBYT - integer: length of bufr message (bytes).
-C> @param[out] MB4 - integer: byte number in message of first byte in section 4.
-C> @param[out] MBA - integer: byte number in message of fourth byte in section 4.
-C> @param[out] MBB - integer: byte number in message of fifth byte in section 4.
-C> @param[out] MBD - integer: byte number in message of sixth byte in section 4.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
+C> @param[out] MBAY - integer: BUFR message.
+C> @param[out] MBYT - integer: length (in bytes) of BUFR message.
+C> @param[out] MB4 - integer: byte number in message of first byte in Section 4.
+C> @param[out] MBA - integer: byte number in message of fourth byte in Section 4.
+C> @param[out] MBB - integer: byte number in message of fifth byte in Section 4.
+C> @param[out] MBD - integer: byte number in message of sixth byte in Section 4.
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE DXMINI(LUN,MBAY,MBYT,MB4,MBA,MBB,MBD)

--- a/src/elemdx.f
+++ b/src/elemdx.f
@@ -1,8 +1,6 @@
 C> @file
 C> @brief Decode the scale factor, reference value,
-c> bit width and units (i.e., the "elements") from a table b mnemonic
-c> definition card that was previously read from a user-supplied bufr
-c> dictionary table file in character format by subroutine rdusdx().
+C> bit width, and units from a Table B mnemonic definition.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -18,10 +16,10 @@ C> 2007-01-19 | J. Ator    | Added extra argument for call to jstchr().
 C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C> 2021-09-30 | J. Ator    | Replace jstchr with Fortran intrinsic adjustl.
 C>
-C> @author WOOLLEN @date 1994-01-06
+C> @author Woollen @date 1994-01-06
       
 C> This subroutine decodes the scale factor, reference value,
-c> bit width and units (i.e., the "elements") from a table b mnemonic
+c> bit width and units (i.e., the "elements") from a table B mnemonic
 c> definition card that was previously read from a user-supplied bufr
 c> dictionary table file in character format by subroutine rdusdx().
 C> These decoded values are then added to the
@@ -30,9 +28,9 @@ c> table B array TABB(*,LUN) in module tababd.
 C>
 C> @param[in] CARD - character*80: mnemonic definition card that was read
 C> from a user-supplied bufr dictionary table.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays .
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C>
-C> @author WOOLLEN @date 1994-01-06
+C> @author Woollen @date 1994-01-06
       SUBROUTINE ELEMDX(CARD,LUN)
 
       USE MODA_TABABD

--- a/src/fstag.f
+++ b/src/fstag.f
@@ -1,4 +1,6 @@
 C> @file
+C> @brief Search for a specified occurrence of a specified mnemonic within
+C> a data subset definition, starting from a specified location.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -8,19 +10,19 @@ C> 2014-12-10 | J. Ator | Use modules instead of common blocks.
 C>
 C> @author J Ator @date 2014-10-02
 	
-C> This subroutine finds the (nutag)th occurrence of mnemonic
-C> utag within the current overall subset definition, starting from
-C> parameter #(nin) within the subset. The subroutine searches forward
-C> from nin if nutag is positive or else backward if nutag is negative.
+C> This subroutine finds the (NUTAG)th occurrence of mnemonic
+C> UTAG within the current overall subset definition, starting from
+C> parameter #(NIN) within the subset. The subroutine searches forward
+C> from NIN if NUTAG is positive or else backward if NUTAG is negative.
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C> @param[in] UTAG - character*(*): mnemonic.
-C> @param[in] NUTAG - integer: ordinal occurrence of utag to search for within
-C> the overall subset definition, counting from parameter #(nin) within the subset.
-C> The subroutine will search in a forward direction from parameter #(nin) if
-C> nutag is positive or else in a backward direction if nutag is negative..
-C> @param[in] NIN - integer: location within the overall subset definition from which to begin searching for utag..
-C> @param[out] NOUT - integer: location of (nutag)th occurrence of utag.
+C> @param[in] NUTAG - integer: ordinal occurrence of UTAG to search for within
+C>     the overall subset definition, counting from parameter #(NIN) within the subset.
+C>     The subroutine will search in a forward direction from parameter #(NIN) if
+C>     NUTAG is positive or else in a backward direction if NUTAG is negative.
+C> @param[in] NIN - integer: location within the overall subset definition from which to begin searching for UTAG.
+C> @param[out] NOUT - integer: location of (NUTAG)th occurrence of UTAG.
 C> @param[out] IRET - integer: return code.
 C> - 0 Normal return.
 C> - -1 Requested mnemonic could not be found, or some other error occurred.

--- a/src/getwin.f
+++ b/src/getwin.f
@@ -1,4 +1,6 @@
 C> @file
+C> @brief Look for a window containing a specified node within
+C> the internal jump/link table.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -37,7 +39,7 @@ C> entire subset buffer itself. For the purposes of these "window
 C> operator" subroutines, a window essentially consists of all of the
 C> elements within a particular delayed replication group, since such
 C> groups effectively define the dimensions within a bufr subset for
-C> the bufr archive library subroutines such as ufbint, ufbin3, etc.
+C> the BUFR archive library subroutines such as ufbint(), ufbin3(), etc.
 C> which read/write individual data values. A bufr subset with no
 C> delayed replication groups is considered to have only one
 C> dimension, and therefore only one "window" which spans the entire
@@ -51,9 +53,9 @@ C> within the subset.
 C>
 C> @param[in] NODE - integer: jump/link table index of mnemonic to look for.
 C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[out] IWIN - integer: starting index of the current window iteration which
-C> ontains node 0 = not found or no more iterations available.
-C> @param[out] JWIN - integer: ending index of the current window iteration which contains node .
+C> @param[out] IWIN - integer: starting index of the current window iteration which contains node
+C>                    - 0 = not found or no more iterations available.
+C> @param[out] JWIN - integer: ending index of the current window iteration which contains node.
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE GETWIN(NODE,LUN,IWIN,JWIN)

--- a/src/ichkstr.f
+++ b/src/ichkstr.f
@@ -1,20 +1,18 @@
 C> @file
-C> @brief Compare a specified number of characters
-c> from an input character array against the same number of characters
-c> from an input character string and determines whether the two are
-c> equivalent. 	
+C> @brief Check for equivalence between a character array and a
+C> character string.
 C> @author Ator @date 2005-11-29
 	
 C> This function compares a specified number of characters
-c> from an input character array against the same number of characters
-c> from an input character string and determines whether the two are
-c> equivalent. The character array is assumed to be in ASCII, whereas
-c> the character string is assumed to be in the native character set
-c> (i.e. ASCII or EBCDIC) of the local machine.
+C> from an input character array against the same number of characters
+C> from an input character string and determines whether the two are
+C> equivalent. The character array is assumed to be in ASCII, whereas
+C> the character string is assumed to be in the native character set
+C> (i.e. ASCII or EBCDIC) of the local machine.
 C>
-C> @param[in] STR - character*(*): n-character string in ASCII or
+C> @param[in] STR - character*(*): N-character string in ASCII or
 C> EBCDIC, depending on the native machine.
-C> @param[in] CHR - character*1: array of n characters in ASCII.
+C> @param[in] CHR - character*1: array of N characters in ASCII.
 C> @param[in] N - integer: number of characters to be compared.
 C>
 C> @return
@@ -23,8 +21,6 @@ C> - 1 STR(1:N) and (CHR(I),I=1,N) are not equivalent.
 C>
 C> @author Ator @date 2005-11-29
 	FUNCTION ICHKSTR(STR,CHR,N)
-
-
 
 	CHARACTER*(*) STR
 

--- a/src/igetfxy.f
+++ b/src/igetfxy.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief looks for and returns a valid fxy number
-C> from within the given input string.	
+C> @brief Search for a valid FXY number within a character string.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -10,7 +9,7 @@ C> 2021-09-30 | J. Ator | Replace jstchr with Fortran intrinsic adjustl.
 C>
 C> @author Ator @date 2007-01-19
 	
-C> This function looks for and returns a valid fxy number
+C> This function looks for and returns a valid FXY number
 C> from within the given input string. The FXY number may be in
 C> format of either FXXYYY or F-XX-YYY within the input string, but
 C> it is always returned in format FXXYYY upon output.
@@ -24,8 +23,6 @@ C> - -1 could not find a valid FXY number in STR.
 C>
 C> @author Ator @date 2007-01-19
 	FUNCTION IGETFXY ( STR, CFXY )
-
-
 
 	CHARACTER*(*)	STR
 	CHARACTER*6	CFXY

--- a/src/igetrfel.f
+++ b/src/igetrfel.f
@@ -1,6 +1,6 @@
 C> @file
-C> @brief Check whether the input element refers to
-c> a previous element within the same subset via an internal bitmap.
+C> @brief Check whether a specified element refers to
+C> a previous element within the same subset via an internal bitmap.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -11,18 +11,18 @@ C>
 C> @author J Ator @date 2016-05-27
 	
 C> This function checks whether the input element refers to
-c> a previous element within the same subset via an internal bitmap.
+C> a previous element within the same subset via an internal bitmap.
 C> If so, then the referenced element is returned. In addition, if
-c> the input element is a 2-xx-255 marker operator, its scale factor,
-c> bit width and reference value are set internally to match those
-c> of the referenced element.
+C> the input element is a 2-XX-255 marker operator, its scale factor,
+C> bit width and reference value are set internally to match those
+C> of the referenced element.
 C>
 C> @param[in] N - integer: subset element.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C>
-C> @return Subset element referenced by element n
-c> within the same subset. 0 = input element does not refer to a previous
-c> element, or referenced element not found.
+C> @return Subset element referenced by element N within the same subset.
+C> - 0 input element does not refer to a previous element, or referenced
+C> element not found.
 C>
 C> @author J Ator @date 2016-05-27
 	INTEGER FUNCTION IGETRFEL ( N, LUN )

--- a/src/igettdi.f
+++ b/src/igettdi.f
@@ -1,6 +1,12 @@
 C> @file
-C> @brief Return the next usable Table D index for the
+C> @brief Get the next usable Table D index for the
 C> current master table, or reset the index.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 2009-03-23 | J. Ator | Original author.
+C>
 C> @author Ator @date 2009-03-23
 	
 C> Depending on the value of the input flag, this function
@@ -8,13 +14,16 @@ C> either returns the next usable scratch Table D index for the
 C> current master table or else resets the index back to its
 C> minimum value.
 C>
-C> @param[in] IFLAG - integer: flag: if set to 0, then the function will
-C>                reset the scratch Table D index back to its minimum
-C>                value; otherwise, it will return the next usable
-C>                scratch Table D index for the current master table.
+C> @param[in] IFLAG - integer:
+C>   - if set to 0, then the function will reset the scratch Table D index
+C>     back to its minimum value
+C>   - otherwise, the function will return the next usable scratch Table D
+C>     index for the current master table
 C>
-C> @return - integer: next usable scratch Table D index for the
-C> current master table, or -1 if function was called with iflag=0.
+C> @return - integer:
+C>   - -1 if function was called with IFLAG=0
+C>   - otherwise, the next usable scratch Table D index for the
+C>     current master table
 C>
 C> @author Ator @date 2009-03-23
 	FUNCTION IGETTDI ( IFLAG )

--- a/src/inctab.f
+++ b/src/inctab.f
@@ -1,5 +1,5 @@
 C> @file
-C> @brief Return the next available positional index
+C> @brief Get the next available positional index
 C> for writing into the internal jump/link table.
 C>
 C> ### Program History Log

--- a/src/invcon.f
+++ b/src/invcon.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Search a "window" for an
-c> element identified in the user string as a conditional node.
+C> @brief Search a specified window for a conditional node.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -17,11 +16,12 @@ C>
 C> @author Woollen @date 1994-01-06
       
 C> This function searches a "window" (see below remarks) for an
-c> element identified in the user string as a conditional node (i.e. an
-c> element which must meet a condition in order to be read from or written to
-c> a data subset). If a conditional element is found and it conforms to the
-c> condition, then the index of the element within the window is returned.
-c> otherwise a value of zero is returned.
+C> element identified in the user string as a conditional node.
+C> A conditional node is an element which must meet a condition in order to be
+C> read from or written to a data subset.
+C> If a conditional element is found and it conforms to the
+C> condition, then the index of the element within the window is returned;
+C> otherwise a value of zero is returned.
 C>
 C> @note: See getwin() for an explanation of "windows" within the context
 C> of a bufr data subset.
@@ -36,7 +36,8 @@ C> @param[in] INV1 - integer: first index of window to search
 C> @param[in] INV2 - integer: last index of window to search
 C>
 C> @return integer: index within window of conditional node
-C> conforming to specified condition. 0 = none found.
+C> conforming to specified condition.
+C> - 0 none found.
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION INVCON(NC,LUN,INV1,INV2)

--- a/src/invtag.f
+++ b/src/invtag.f
@@ -1,5 +1,5 @@
 C> @file
-C> @brief Look for a specified mnemonic within a specified portion
+C> @brief Search for a specified mnemonic within a specified portion
 C> of the current data subset.
 C>
 C> ### Program History Log
@@ -17,7 +17,7 @@ C> @author Woollen @date 1994-01-06
       
 C> This function looks for a specified mnemonic within the
 C> portion of the current subset buffer bounded by the indices inv1
-C> and inv2. It is similar to bufr archive library function invwin(),
+C> and inv2. It is similar to BUFR archive library function invwin(),
 C> except that invwin() searches based on the actual node within the
 C> internal jump/link table, rather than on the mnemonic corresponding
 C> to that node.
@@ -27,8 +27,8 @@ C> @param[in] LUN - integer: i/o stream index into internal memory arrays
 C> @param[in] INV1 - integer: starting index of the portion of the subset buffer in which to look
 C> @param[in] INV2 - integer: ending index of the portion of the subset buffer in which to look
 C>
-C> @return - integer: location index of node within specified
-C> portion of subset buffer, 0 = not found.
+C> @return - integer: location index of node within specified portion of subset buffer
+C> - 0 not found
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION INVTAG(NODE,LUN,INV1,INV2)

--- a/src/invwin.f
+++ b/src/invwin.f
@@ -1,5 +1,5 @@
 C> @file
-C> @brief Look for a specified node within a specified portion
+C> @brief Search for a specified node within a specified portion
 C> of the current data subset.
 C>
 C> ### Program History Log
@@ -25,8 +25,8 @@ C> @param[in] LUN - integer: i/o stream index into internal memory arrays
 C> @param[in] INV1 - integer: starting index of the portion of the subset buffer in which to look
 C> @param[in] INV2 - integer: ending index of the portion of the subset buffer in which to look
 C>
-C> @return - integer: location index of node within specified
-C> portion of subset buffer, 0 = not found.
+C> @return - integer: location index of node within specified portion of subset buffer
+C> - 0 not found
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION INVWIN(NODE,LUN,INV1,INV2)

--- a/src/ipks.f
+++ b/src/ipks.f
@@ -9,7 +9,7 @@ C> 2012-03-02 | J. Ator    | Original author; adapted from internal statement fu
 C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
 C> 2022-05-06 | J. Woollen | Make imask and ipks 8byte integers.
 C>
-C> @author J @date 2012-03-02
+C> @author J. Ator @date 2012-03-02
 
 C> This function packs a real*8 user value into an
 C> integer by applying the proper scale and reference values.
@@ -23,7 +23,7 @@ C> @param[in] NODE - integer: index into internal jump/link tables
 C>
 C> @return - integer*8: packed value
 C>
-C> @author J @date 2012-03-02
+C> @author J. Ator @date 2012-03-02
 	FUNCTION IPKS(VAL,NODE)
 
 	USE MODA_TABLES

--- a/src/irev.F
+++ b/src/irev.F
@@ -13,34 +13,32 @@ C> 2007-01-19 | J. Ator    | Big-endian vs. little-endian determined at compile 
 C>
 C> @author Woollen @date 1994-01-06
       
-C> This function will, when the local machine is "little-
-C> endian" (i.e., uses a right to left scheme for numbering the bytes
+C> This function will, when the local machine is "little-endian" (i.e.,
+C> when it uses a right to left scheme for numbering the bytes
 C> within a machine word), return a copy of an input integer word with
-C> the bytes reversed. Although, by definition (within wmo manual
-C> 306), a bufr message is a stream of individual octets (i.e., bytes)
+C> the bytes reversed. Although, by definition (within WMO Manual
+C> 306), a BUFR message is a stream of individual octets (i.e., bytes)
 C> that is independent of any particular machine representation, the
-C> bufr archive library software often needs to interpret all or parts
+C> BUFR archive library software often needs to interpret all or parts
 C> of two or more adjacent bytes in order to construct an integer
 C> word. By default, the software uses the "big-endian" (left to
-C> right) scheme for numbering bytes. By reversing the bytes, irev
+C> right) scheme for numbering bytes. By reversing the bytes, irev()
 C> allows the integer word to be properly read or written (depending
 C> on whether input or output operations, respectively, are being
-C> performed) on little-endian machines. If the local machine is
-C> big-endian, irev() simply returns a copy of the same integer that was
+C> performed) on "little-endian" machines. If the local machine is
+C> "big-endian", irev() simply returns a copy of the same integer that was
 C> input.
 C>
 C> @param[in] N - integer: integer word with bytes ordered according
-C> to the big-endian numbering scheme
+C> to the "big-endian" numbering scheme
 C>
 C> @return - integer: integer word with bytes ordered according to
 C> the numbering scheme of the local machine (either
-C> "big-endian" or "little-endian", if "big-endian then
+C> "big-endian" or "little-endian"; if "big-endian" then
 C> this is just a direct copy of N).
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION IREV(N)
-
-
 
       COMMON /HRDWRD/ NBYTW,NBITW,IORD(8)
 

--- a/src/lstjpb.f
+++ b/src/lstjpb.f
@@ -29,11 +29,12 @@ C> jump/link table.
 C>
 C> @param[in] NODE - integer: jump/link table index of entry to begin
 C> searching backwards from
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays
 C> @param[in] JBTYP - character*(*): type of node for which to search
 C>
 C> @return - integer: index of first node of type jbtyp found by
-C> jumping backwards from input node, 0 = no such node found.
+C> jumping backwards from input node
+C> - 0 no such node found
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION LSTJPB(NODE,LUN,JBTYP)

--- a/src/mrginv.f
+++ b/src/mrginv.f
@@ -1,29 +1,21 @@
 C> @file
-C> @author WOOLLEN @date 1996-10-09
-      
-C> THIS SUBROUTINE PRINTS A SUMMARY OF MERGE ACTIVITY.
+C> @brief Print a summary of merge activity.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1996-10-09  J. WOOLLEN -- ORIGINAL AUTHOR (ENTRY POINT IN INVMRG)
-C> 2002-05-14  J. WOOLLEN -- CHANGED FROM AN ENTRY POINT TO INCREASE
-C>                           PORTABILITY TO OTHER PLATFORMS
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY)
-C> 2009-04-21  J. ATOR    -- USE ERRWRT
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1996-10-09 | J. Woollen | Original author.
+C> 2002-05-14 | J. Woollen | Changed from an entry point to increase portability to other platforms.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Added documentation.
+C> 2009-04-21 | J. Ator    | Use errwrt()
 C>
-C> USAGE:    CALL MRGINV
+C> @author J. Woollen @date 1996-10-09
+
+C> This subroutine prints a summary of merge activity.
 C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        ERRWRT
-C>    THIS ROUTINE IS CALLED BY: None
-C>                               Normally called only by application
-C>                               programs.
-C>
+C> @author J. Woollen @date 1996-10-09
       SUBROUTINE MRGINV
-
-
 
       COMMON /MRGCOM/ NRPL,NMRG,NAMB,NTOT
       COMMON /QUIET / IPRT

--- a/src/msgini.f
+++ b/src/msgini.f
@@ -13,7 +13,7 @@ C> 2000-09-19 | J. Woollen | Maximum message length increased from 10,000 to 20,
 C> 2002-05-14 | J. Woollen | Removed entry point minimg.
 C> 2003-11-04 | J. Ator    | Added documentation.
 C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
-C> 2003-11-04 | D. Keyser  | maxjl increased from 16000; unified/portable for wrf; documentation; more dia|gnostic info.
+C> 2003-11-04 | D. Keyser  | maxjl increased from 16000; unified/portable for wrf; documentation; more diagnostic info.
 C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
 C> 2005-11-29 | J. Ator    | Changed default master table version to 12.
 C> 2009-05-07 | J. Ator    | Changed default master table version to 13.

--- a/src/msgupd.f
+++ b/src/msgupd.f
@@ -5,38 +5,38 @@ C>
 C> ### Program History Log
 C> Date | Programmer | Comments
 C> -----|------------|----------
-C> 1994-01-06  J. Woollen | Original author.
-C> 1998-07-08  J. Woollen | Replaced call to cray library routine "abort" with call to new internal bufrlib routine "bort".
-C> 1998-12-14  J. Woollen | No longer calls bort if a subset is larger than a message, just discards the subset.
-C> 1999-11-18  J. Woollen | Increased number of open bufr files to 32.
-C> 2000-09-19  J. Woollen | Maximum message length increased from 10,000 to 20,000 bytes.
-C> 2003-11-04  J. Ator    | Added documentation.
-C> 2003-11-04  S. Bender  | Added remarks/bufrlib routine interdependencies.
-C> 2003-11-04  D. Keyser  | Unified/portable for wrf; added history documentation.
-C> 2004-08-09  J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
-C> 2009-03-23  J. Ator    | Use msgfull and errwrt.
-C> 2014-10-20  J. Woollen | Account for subsets with byte count > 65530.
-C> 2014-10-20  D. Keyser  | For case above, do not write "current" message if it contains zero subsets.
-C> 2014-12-10  J. Ator    | Use modules instead of common blocks.
-C> 2016-03-21  D. Stokes  | Call usrtpl for overlarge subsets.
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced call to cray library routine "abort" with call to new internal bufrlib routine "bort".
+C> 1998-12-14 | J. Woollen | No longer calls bort if a subset is larger than a message, just discards the subset.
+C> 1999-11-18 | J. Woollen | Increased number of open bufr files to 32.
+C> 2000-09-19 | J. Woollen | Maximum message length increased from 10,000 to 20,000 bytes.
+C> 2003-11-04 | J. Ator    | Added documentation.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; added history documentation.
+C> 2004-08-09 | J. Ator    | Maximum message length increased from 20,000 to 50,000 bytes.
+C> 2009-03-23 | J. Ator    | Use msgfull and errwrt.
+C> 2014-10-20 | J. Woollen | Account for subsets with byte count > 65530.
+C> 2014-10-20 | D. Keyser  | For case above, do not write "current" message if it contains zero subsets.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C> 2016-03-21 | D. Stokes  | Call usrtpl for overlarge subsets.
 C>
 C> @author Woollen @date 1994-01-06
       
 C> This subroutine packs up the current subset within memory
 C> (array ibay in module bitbuf) and then tries to add it to
-C> the BUFR message that is currently open within memory for lunit
+C> the BUFR message that is currently open within memory for LUNIT
 C> (array mbay in module bitbuf). If the subset will not fit
 C> into the currently open message, or if the subset byte count exceeds
 C> 65530 (sufficiently close to the 16-bit byte counter upper limit of
-C> 65535), then that message is flushed to lunit and a new one is
+C> 65535), then that message is flushed to LUNIT and a new one is
 C> created in order to hold the current subset. Any subset with byte
 C> count > 65530 will be written into its own one-subset message.
 C> if the current subset is larger than the maximum message length,
 C> then the subset is discarded and a diagnostic is printed.
 C>
 C> @param[in] LUNIT - integer: fortran logical unit number for BUFR file.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays
-C> (associated with file connected to logical unit lunit).
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays
+C> (associated with file connected to logical unit LUNIT).
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE MSGUPD(LUNIT,LUN)

--- a/src/mvb.f
+++ b/src/mvb.f
@@ -19,11 +19,11 @@ C> @author Woollen @date 1994-01-06
 C> This subroutine copies a specified number of bytes from
 C> one packed binary array to another.
 C>
-C> @param[in] IB1 - integer: *-word packed input binary array.
-C> @param[in] NB1 - integer: pointer to first byte in ib1 to copy from.
-C> @param[out] IB2 - integer: *-word packed output binary array.
-C> @param[in] NB2 - integer: pointer to first byte in ib2 to copy to.
-C> @param[in] NBM - integer: number of bytes to copy .
+C> @param[in] IB1 - integer: packed input binary array.
+C> @param[in] NB1 - integer: pointer to first byte in IB1 to copy from.
+C> @param[out] IB2 - integer: packed output binary array.
+C> @param[in] NB2 - integer: pointer to first byte in IB2 to copy to.
+C> @param[in] NBM - integer: number of bytes to copy.
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE MVB(IB1,NB1,IB2,NB2,NBM)

--- a/src/nemdefs.f
+++ b/src/nemdefs.f
@@ -1,6 +1,15 @@
 C> @file
 C> @brief Get the element name and units associated with a
 C> Table B mnemonic.
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 2014-10-02 | J. Ator | Original version
+C> 2014-12-10 | J. Ator | Use modules instead of COMMON blocks
+C> 2022-08-04 | J. Woollen | Added 8-byte wrapper
+C>
+C> @author J. Ator @date 2014-10-02
 
 C> Given a Table B mnemonic defined in the
 C> [DX BUFR Tables](@ref dfbftab) associated with a BUFR file
@@ -9,30 +18,22 @@ C> was opened in subroutine openbf() with IO = 'SEC3'), this
 C> subroutine returns the element name and units associated
 C> with that mnemonic.
 C>
-C> @author J. Ator
-C> @date 2014-10-02
-C>
-C> @param[in] LUNIT  -- integer: Fortran logical unit number for
-C>                      BUFR file
-C> @param[in] NEMO   -- character*(*): Table B mnemonic
-C> @param[out] CELEM -- character*55: Element name associated
+C> @param[in] LUNIT  - integer: Fortran logical unit number for
+C>                     BUFR file
+C> @param[in] NEMO   - character*(*): Table B mnemonic
+C> @param[out] CELEM - character*55: Element name associated
 C>                      with NEMO
-C> @param[out] CUNIT -- character*24: Units associated with NEMO
-C> @param[out] IRET  -- integer: return code
-C>                      - 0 = normal return
-C>                      - -1 = NEMO could not be found, or some
-C>                             other error occurred
+C> @param[out] CUNIT - character*24: Units associated with NEMO
+C> @param[out] IRET  - integer: return code
+C>                      - 0 normal return
+C>                      - -1 NEMO could not be found, or some
+C>                           other error occurred
 C>
-C> <p>Logical unit LUNIT should have already been opened for
+C> Logical unit LUNIT should have already been opened for
 C> input or output operations via a previous call to subroutine
 C> openbf().
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 2014-10-02 | J. Ator | Original version |
-C> | 2014-12-10 | J. Ator | Use modules instead of COMMON blocks |
-C> | 2022-08-04 | J. Woollen | Added 8-byte wrapper |
+C> @author J. Ator @date 2014-10-02
 
 	RECURSIVE SUBROUTINE NEMDEFS ( LUNIT, NEMO, CELEM, CUNIT, IRET )
 

--- a/src/nemock.f
+++ b/src/nemock.f
@@ -1,41 +1,28 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
-      
-C> THIS FUNCTION CHECKS A MNEMONIC TO VERIFY THAT IT HAS A
-C>   LENGTH OF BETWEEN ONE AND EIGHT CHARACTERS AND THAT IT ONLY
-C>   CONTAINS CHARACTERS FROM THE ALLOWABLE CHARACTER SET.
+C> @brief Check the validity of a mnemonic.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 2003-11-04  J. ATOR    -- ADDED DOCUMENTATION
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- SPLIT NON-ZERO RETURN INTO -1 FOR LENGTH
-C>                           NOT 1-8 CHARACTERS AND -2 FOR INVALID
-C>                           CHARACTERS (RETURN ONLY -1 BEFORE FOR ALL
-C>                           PROBLEMATIC CASES); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED HISTORY DOCUMENTATION
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 2003-11-04 | J. Ator    | Added documentation.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Split non-zero return into multiple options.
 C>
-C> USAGE:    NEMOCK (NEMO)
-C>   INPUT ARGUMENT LIST:
-C>     NEMO     - CHARACTER*(*): MNEMONIC TO BE CHECKED
+C> @author J. Woollen @date 1994-01-06
+
+C> This function checks a mnemonic to verify that it has a
+C> length of between 1 and 8 characters and that it only
+C> contains characters from the allowable character set.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     NEMOCK   - INTEGER: INDICATOR AS TO WHETHER NEMO IS VALID:
-C>                       0 = yes
-C>                      -1 = no, length not between 1 and 8 characters
-C>                      -2 = no, it does not contain characters from the
-C>                           allowable character set
+C> @param[in] NEMO - character*(*): mnemonic to be checked
+C> @returns - integer: indicator as to whether NEMO is valid:
+C>  - 0 yes
+C>  - -1 no, the length is not between 1 and 8 characters
+C>  - -2 no, it contains characters from outside of the allowable character set
 C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        None
-C>    THIS ROUTINE IS CALLED BY: RDUSDX   SEQSDX   SNTBBE   SNTBDE
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author J. Woollen @date 1994-01-06
       FUNCTION NEMOCK(NEMO)
-
-
 
       CHARACTER*(*) NEMO
       CHARACTER*38  CHRSET

--- a/src/nemspecs.f
+++ b/src/nemspecs.f
@@ -1,6 +1,15 @@
 C> @file
 C> @brief Get the scale factor, reference value and bit width
 C> associated with a specified occurrence of a Table B mnemonic.
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 2014-10-02 | J. Ator | Original version
+C> 2014-12-10 | J. Ator | Use modules instead of COMMON blocks
+C> 2022-08-04 | J. Woollen | Added 8-byte wrapper
+C>
+C> @author J. Ator @date 2014-10-02
 
 C> Given a Table B mnemonic defined within a data subset, this
 C> subroutine returns the scale factor, reference value and bit
@@ -8,45 +17,37 @@ C> width of a specified occurrence of that mnemonic within the
 C> overall data subset definition, counting from the beginning
 C> of the subset.
 C>
-C> <p>The values returned include the application of any Table C
+C> The values returned include the application of any Table C
 C> operators (e.g. 2-01-YYY, 2-02-YYY, 2-03-YYY, 2-07-YYY,
 C> 2-08-YYY) which may be in effect for the specified occurrence
 C> of the mnemonic.
 C>
-C> @author J. Ator
-C> @date 2014-10-02
+C> @param[in] LUNIT  - integer: Fortran logical unit number for
+C>                     BUFR file
+C> @param[in] NEMO   - character*(*): Table B mnemonic
+C> @param[in] NNEMO  - integer: Ordinal occurrence of NEMO for
+C>                     which information is to be returned,
+C>                     counting from the beginning of the overall
+C>                     subset definition
+C> @param[out] NSCL  - integer: Scale factor in effect for
+C>                     (NNEMO)th occurrence of NEMO
+C> @param[out] NREF  - integer: Reference value in effect for
+C>                     (NNEMO)th occurrence of NEMO
+C> @param[out] NBTS  - integer: Bit width in effect for
+C>                     (NNEMO)th occurrence of NEMO
+C> @param[out] IRET  - integer: return code
+C>                      - 0 normal return
+C>                      - -1 NEMO could not be found, or some
+C>                           other error occurred
 C>
-C> @param[in] LUNIT  -- integer: Fortran logical unit number for
-C>                      BUFR file
-C> @param[in] NEMO   -- character*(*): Table B mnemonic
-C> @param[in] NNEMO  -- integer: Ordinal occurrence of NEMO for
-C>                      which information is to be returned,
-C>                      counting from the beginning of the overall
-C>                      subset definition
-C> @param[out] NSCL  -- integer: Scale factor in effect for
-C>                      (NNEMO)th occurrence of NEMO
-C> @param[out] NREF  -- integer: Reference value in effect for
-C>                      (NNEMO)th occurrence of NEMO
-C> @param[out] NBTS  -- integer: Bit width in effect for
-C>                      (NNEMO)th occurrence of NEMO
-C> @param[out] IRET  -- integer: return code
-C>                      - 0 = normal return
-C>                      - -1 = NEMO could not be found, or some
-C>                            other error occurred
-C>
-C> <p>A data subset must already be in scope within the BUFRLIB
+C> A data subset must already be in scope within the BUFRLIB
 C> internal arrays for LUNIT, either via a previous call to one
 C> of the [subset-reading subroutines](@ref hierarchy)
 C> (when reading BUFR data subsets) or via a previous call to one
 C> of the [message-writing subroutines](@ref hierarchy)
 C> (when writing BUFR data subsets).
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 2014-10-02 | J. Ator | Original version |
-C> | 2014-12-10 | J. Ator | Use modules instead of COMMON blocks |
-C> | 2022-08-04 | J. Woollen | Added 8-byte wrapper |
+C> @author J. Ator @date 2014-10-02
 
 	RECURSIVE SUBROUTINE NEMSPECS
      .		( LUNIT, NEMO, NNEMO, NSCL, NREF, NBTS, IRET )

--- a/src/nemtab.f
+++ b/src/nemtab.f
@@ -1,46 +1,47 @@
 C> @file
 C> @brief Get information about a descriptor, based on the mnemonic
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1994-01-06 | J. Woollen | Original author
+C> 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files
+C> 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32
+C> 2000-09-19 | J. Woollen | Added capability to encode and decode data using the operator descriptors (BUFR table C) for changing width and changing scale
+C> 2003-11-04 | J. Ator    | Added documentation
+C> 2003-11-04 | S. Bender  | Added remarks and routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation
+C> 2005-11-29 | J. Ator    | Added support for 207 and 208 operators
+C> 2010-03-19 | J. Ator    | Added support for 204 and 205 operators
+C> 2012-03-02 | J. Ator    | Added support for 203 operator
+C> 2015-02-25 | J. Ator    | Allow processing of 2-2x, 2-3x and 2-4X non-marker operators in DX tables
+C>
+C> @author J. Woollen @date 1994-01-06
 
 C> This subroutine returns information about a descriptor from the
 C> internal DX BUFR tables, based on the mnemonic associated with
 C> that descriptor.
 C>
-C> @author J. Woollen
-C> @date 1994-01-06
+C> @param[in] LUN - integer: Internal I/O stream index associated
+C>                  with DX BUFR tables
+C> @param[in] NEMO - character*(*): Mnemonic
+C> @param[out] IDN - integer: Bit-wise representation of FXY value
+C>                   for descriptor associated with NEMO
+C> @param[out] TAB - character: Type associated with IDN
+C>                    - 'B' Table B descriptor
+C>                    - 'D' Table D descriptor
+C>                    - 'C' Table C operator
+C> @param[out] IRET - integer:
+C>                    - Positional index of IDN within internal
+C>                      Table B, if TAB = 'B'
+C>                    - Positional index of IDN within internal
+C>                      Table D, if TAB = 'D'
+C>                    - The X portion of the FXY value in IDN, if
+C>                      TAB = 'C'
+C>                    - 0, otherwise
 C>
-C> @param[in] LUN -- integer: Internal I/O stream index associated
-C>                   with DX BUFR tables
-C> @param[in] NEMO -- character*(*): Mnemonic
-C> @param[out] IDN -- integer: Bit-wise representation of FXY value
-C>                    for descriptor associated with NEMO
-C> @param[out] TAB -- character: Type associated with IDN
-C>                     - 'B' = Table B descriptor
-C>                     - 'D' = Table D descriptor
-C>                     - 'C' = Table C operator
-C> @param[out] IRET -- integer:
-C>                     - Positional index of IDN within internal
-C>                       Table B, if TAB = 'B'
-C>                     - Positional index of IDN within internal
-C>                       Table D, if TAB = 'D'
-C>                     - The X portion of the FXY value in IDN, if
-C>                       TAB = 'C'
-C>                     - 0, otherwise
-C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files |
-C> | 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32 |
-C> | 2000-09-19 | J. Woollen | Added capability to encode and decode data using the operator descriptors (BUFR table C) for changing width and changing scale |
-C> | 2003-11-04 | J. Ator    | Added documentation |
-C> | 2003-11-04 | S. Bender  | Added remarks and routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation |
-C> | 2005-11-29 | J. Ator    | Added support for 207 and 208 operators |
-C> | 2010-03-19 | J. Ator    | Added support for 204 and 205 operators |
-C> | 2012-03-02 | J. Ator    | Added support for 203 operator |
-C> | 2015-02-25 | J. Ator    | Allow processing of 2-2x, 2-3x and 2-4X non-marker operators in DX tables |
-C>
+C> @author J. Woollen @date 1994-01-06
+
       SUBROUTINE NEMTAB(LUN,NEMO,IDN,TAB,IRET)
 
       USE MODA_TABABD

--- a/src/nemtba.f
+++ b/src/nemtba.f
@@ -1,37 +1,38 @@
 C> @file
 C> @brief Search for a Table A descriptor within the internal DX
 C> BUFR tables
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1994-01-06 | J. Woollen | Original author
+C> 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files
+C> 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort()
+C> 1999-11-18 | J. Woollen | The number of bufr files which can be opened at one time increased from 10 to 32
+C> 2003-11-04 | J. Ator    | Added documentation
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2009-05-07 | J. Ator    | Use nemtbax()
+C>
+C> @author J. Woollen @date 1994-01-06
 
 C> This subroutine searches for a descriptor within Table A of the
 C> internal DX BUFR tables.
 C>
-C> <p>It is similar to subroutine nemtbax(), except that it calls
+C> It is similar to subroutine nemtbax(), except that it calls
 C> subroutine bort() if the descriptor is not found in Table A,
 C> whereas nemtbax() will return an INOD value of 0 in such cases.
 C>
-C> @author J. Woollen
-C> @date 1994-01-06
+C> @param[in] LUN - integer: Internal I/O stream index associated
+C>                  with DX BUFR tables
+C> @param[in] NEMO - character*(*): Mnemonic for Table A descriptor
+C> @param[out] MTYP - integer: Message type corresponding to NEMO
+C> @param[out] MSBT - integer: Message subtype corresponding to NEMO
+C> @param[out] INOD - integer: Positional index of NEMO within
+C>                    internal Table A
 C>
-C> @param[in] LUN -- integer: Internal I/O stream index associated
-C>                   with DX BUFR tables
-C> @param[in] NEMO -- character*(*): Mnemonic for Table A descriptor
-C> @param[out] MTYP -- integer: Message type corresponding to NEMO
-C> @param[out] MSBT -- integer: Message subtype corresponding to NEMO
-C> @param[out] INOD -- integer: Positional index of NEMO within
-C>                     internal Table A
-C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files |
-C> | 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort() |
-C> | 1999-11-18 | J. Woollen | The number of bufr files which can be opened at one time increased from 10 to 32 |
-C> | 2003-11-04 | J. Ator    | Added documentation |
-C> | 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally |
-C> | 2009-05-07 | J. Ator    | Use nemtbax |()
-C>
+C> @author J. Woollen @date 1994-01-06
+
       SUBROUTINE NEMTBA(LUN,NEMO,MTYP,MSBT,INOD)
 
       CHARACTER*(*) NEMO

--- a/src/nemtbax.f
+++ b/src/nemtbax.f
@@ -1,35 +1,35 @@
 C> @file
 C> @brief Search for a Table A descriptor within the internal DX
 C> BUFR tables
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1999-11-18 | J. Woollen | Original author
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks
+C>
+C> @author J. Woollen @date 1999-11-18
 
 C> This subroutine searches for a descriptor within Table A of the
 C> internal DX BUFR tables.
 C>
-C> <p>It is similar to subroutine nemtba(), except it returns an INOD
+C> It is similar to subroutine nemtba(), except it returns an INOD
 C> value of 0 if the descriptor is not found in Table A, whereas
 C> nemtba() will call subroutine bort() in such cases.
 C>
-C> @author J. Woollen
-C> @date 1999-11-18
-C>
-C> @param[in] LUN -- integer: Internal I/O stream index associated
+C> @param[in] LUN - integer: Internal I/O stream index associated
 C>                   with DX BUFR tables
-C> @param[in] NEMO -- character*(*): Mnemonic for Table A descriptor
-C> @param[out] MTYP -- integer: Message type corresponding to NEMO
-C> @param[out] MSBT -- integer: Message subtype corresponding to NEMO
-C> @param[out] INOD -- integer:
+C> @param[in] NEMO - character*(*): Mnemonic for Table A descriptor
+C> @param[out] MTYP - integer: Message type corresponding to NEMO
+C> @param[out] MSBT - integer: Message subtype corresponding to NEMO
+C> @param[out] INOD - integer:
 C>                     - Positional index of NEMO within internal
 C>                       Table A, if found
 C>                     - 0, otherwise
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1999-11-18 | J. Woollen | Original author |
-C> | 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally |
-C> | 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks |
-C>
+C> @author J. Woollen @date 1999-11-18
       SUBROUTINE NEMTBAX(LUN,NEMO,MTYP,MSBT,INOD)
 
       USE MODA_TABABD

--- a/src/nemtbb.f
+++ b/src/nemtbb.f
@@ -1,33 +1,34 @@
 C> @file
 C> @brief Get information about a Table B descriptor
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1994-01-06 | J. Woollen | Original author
+C> 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files
+C> 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort()
+C> 1999-11-18 | J. Woollen | Changed call to function "val$" to valx()
+C> 2003-11-04 | J. Ator    | Added documentation
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks
+C>
+C> @author J. Woollen @date 1994-01-06
 
 C> This subroutine returns information about a Table B descriptor
 C> from the internal DX BUFR tables.
 C>
-C> @author J. Woollen
-C> @date 1994-01-06
-C>
-C> @param[in] LUN -- integer: Internal I/O stream index associated
+C> @param[in] LUN - integer: Internal I/O stream index associated
 C>                   with DX BUFR tables
-C> @param[in] ITAB -- integer: Positional index of descriptor within
+C> @param[in] ITAB - integer: Positional index of descriptor within
 C>                    internal Table B
-C> @param[out] UNIT -- character*24: Units of descriptor
-C> @param[out] ISCL -- integer: Scale factor of descriptor
-C> @param[out] IREF -- integer: Reference value of descriptor
-C> @param[out] IBIT -- integer: Bit width of descriptor
+C> @param[out] UNIT - character*24: Units of descriptor
+C> @param[out] ISCL - integer: Scale factor of descriptor
+C> @param[out] IREF - integer: Reference value of descriptor
+C> @param[out] IBIT - integer: Bit width of descriptor
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files |
-C> | 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort() |
-C> | 1999-11-18 | J. Woollen | Changed call to function "val$" to valx() |
-C> | 2003-11-04 | J. Ator    | Added documentation |
-C> | 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally |
-C> | 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks |
-C>
+C> @author J. Woollen @date 1994-01-06
+
       SUBROUTINE NEMTBB(LUN,ITAB,UNIT,ISCL,IREF,IBIT)
 
       USE MODA_TABABD

--- a/src/nemtbd.f
+++ b/src/nemtbd.f
@@ -1,19 +1,30 @@
 C> @file
 C> @brief Get information about a Table D descriptor
+C>
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1994-01-06 | J. Woollen | Original author
+C> 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files
+C> 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort()
+C> 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32
+C> 2000-09-19 | J. Woollen | Handle child mnemonics which are Table C operators
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks
+C>
+C> @author J. Woollen @date 1994-01-06
 
 C> This subroutine returns information about a Table D descriptor
 C> from the internal DX BUFR tables.
 C>
-C> @author J. Woollen
-C> @date 1994-01-06
-C>
-C> @param[in] LUN -- integer: Internal I/O stream index associated
+C> @param[in] LUN - integer: Internal I/O stream index associated
 C>                   with DX BUFR tables
-C> @param[in] ITAB -- integer: Positional index of descriptor within
+C> @param[in] ITAB - integer: Positional index of descriptor within
 C>                    internal Table D
-C> @param[out] NSEQ -- integer: Number of child mnemonics for descriptor
-C> @param[out] NEMS -- character*8(*): Child mnemonics
-C> @param[out] IRPS -- integer(*): Array of values corresponding to NEMS
+C> @param[out] NSEQ - integer: Number of child mnemonics for descriptor
+C> @param[out] NEMS - character*8(*): Child mnemonics
+C> @param[out] IRPS - integer(*): Array of values corresponding to NEMS
 C>                     - 5, if corresponding NEMS value is a Table D
 C>                       mnemonic using 1-bit delayed replication
 C>                     - 4, if corresponding NEMS value is a Table D
@@ -39,18 +50,8 @@ C> descriptor referenced by ITAB.  This information should have already
 C> been stored into internal arrays via previous calls to subroutine
 C> pktdd().
 C>
-C> <b>Program history log:</b>
-C> | Date | Programmer | Comments |
-C> | -----|------------|----------|
-C> | 1994-01-06 | J. Woollen | Original author |
-C> | 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files |
-C> | 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort() |
-C> | 1999-11-18 | J. Woollen | The number of BUFR files which can be opened at one time increased from 10 to 32 |
-C> | 2000-09-19 | J. Woollen | Handle child mnemonics which are Table C operators |
-C> | 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies |
-C> | 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally |
-C> | 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks |
-C>
+C> @author J. Woollen @date 1994-01-06
+
       SUBROUTINE NEMTBD(LUN,ITAB,NSEQ,NEMS,IRPS,KNTS)
 
       USE MODV_MAXCD

--- a/src/nenubd.f
+++ b/src/nenubd.f
@@ -1,50 +1,34 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
-      
-C> THIS SUBROUTINE CHECKS A MNEMONIC AND FXY VALUE PAIR THAT
-C>   WERE READ FROM A USER-SUPPLIED BUFR DICTIONARY TABLE IN CHARACTER
-C>   FORMAT, IN ORDER TO MAKE SURE THAT NEITHER VALUE HAS ALREADY BEEN
-C>   DEFINED WITHIN INTERNAL BUFR TABLE B OR D (IN MODULE TABABD) FOR
-C>   THE GIVEN LUN.  IF EITHER VALUE HAS ALREADY BEEN DEFINED FOR THIS
-C>   LUN, THEN AN APPROPRIATE CALL IS MADE TO BUFR ARCHIVE LIBRARY
-C>   SUBROUTINE BORT.
+C> @brief Confirm that a mnemonic and FXY value haven't already been defined
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR (ENTRY POINT IN NENUCK)
-C> 1995-06-28  J. WOOLLEN -- INCREASED THE SIZE OF INTERNAL BUFR TABLE
-C>                           ARRAYS IN ORDER TO HANDLE BIGGER FILES
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT" (IN PARENT ROUTINE NENUCK)
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI) (IN PARENT
-C>                           ROUTINE NENUCK)
-C> 2002-05-14  J. WOOLLEN -- CHANGED FROM AN ENTRY POINT TO INCREASE
-C>                           PORTABILITY TO OTHER PLATFORMS (NENUCK WAS
-C>                           THEN REMOVED BECAUSE IT WAS JUST A DUMMY
-C>                           ROUTINE WITH ENTRIES)
-C> 2003-11-04  J. ATOR    -- ADDED DOCUMENTATION
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED HISTORY
-C>                           DOCUMENTATION; OUTPUTS MORE COMPLETE
-C>                           DIAGNOSTIC INFO WHEN ROUTINE TERMINATES
-C>                           ABNORMALLY
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 1994-01-06 | J. Woollen | Original author
+C> 1995-06-28 | J. Woollen | Increased the size of internal BUFR table arrays in order to handle bigger files
+C> 1998-07-08 | J. Woollen | Replaced call to Cray library routine "ABORT" with call to new internal routine bort()
+C> 1999-11-18 | J. Woollen | The number of bufr files which can be opened at one time increased from 10 to 32
+C> 2002-05-14 | J. Woollen | Changed from an entry point to increase portability to other platforms
+C> 2003-11-04 | J. Ator    | Added documentation
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks
 C>
-C> USAGE:    CALL NENUBD (NEMO, NUMB, LUN)
-C>   INPUT ARGUMENT LIST:
-C>     NEMO     - CHARACTER*8: MNEMONIC
-C>     NUMB     - CHARACTER*6: FXY VALUE ASSOCIATED WITH NEMO
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
+C> @author J. Woollen @date 1994-01-06
+
+C> This subroutine checks a mnemonic and FXY value pair that were read
+C> from a user-supplied BUFR DX dictionary table in character format,
+C> in order to make sure that neither value has already been
+C> defined within internal BUFR table B or D (in module tababd) for
+C> the given LUN.  If either value has already been defined for this
+C> LUN, then an appropriate call is made to BUFR archive library
+C> subroutine bort().
 C>
-C>    THIS ROUTINE CALLS:        BORT
-C>    THIS ROUTINE IS CALLED BY: STBFDX   STNTBI
-C>                               Normally not called by any application
-C>                               programs.
+C> @param[in] NEMO - character*8: Mnemonic
+C> @param[in] NUMB - character*6: FXY value associated with NEMO
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays
 C>
+C> @author J. Woollen @date 1994-01-06
       SUBROUTINE NENUBD(NEMO,NUMB,LUN)
 
       USE MODA_TABABD

--- a/src/nevn.f
+++ b/src/nevn.f
@@ -1,56 +1,48 @@
 C> @file
-C> @author WOOLLEN @date 2003-11-04
-      
-C> THIS FUNCTION LOOKS FOR ALL STACKED DATA EVENTS FOR A
-C>   SPECIFIED DATA VALUE AND LEVEL WITHIN THE PORTION OF THE CURRENT
-C>   SUBSET BUFFER BOUNDED BY THE INDICES INV1 AND INV2.  ALL SUCH
-C>   EVENTS ARE ACCUMULATED AND RETURNED TO THE CALLING PROGRAM WITHIN
-C>   ARRAY USR.  THE VALUE OF THE FUNCTION ITSELF IS THE TOTAL NUMBER
-C>   OF EVENTS FOUND.
+C> @brief Search for stacked data events within a specified portion
+C> of the current data subset.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2003-11-04  J. WOOLLEN -- ORIGINAL AUTHOR (WAS IN VERIFICATION
-C>                           VERSION)
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY
-C> 2009-03-31  J. WOOLLEN -- ADDED ADDITIONAL DOCUMENTATION
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> ### Program history log
+C> Date | Programmer | Comments
+C> -----|------------|---------
+C> 2003-11-04 | J. Woollen | Original author.
+C> 2003-11-04 | D. Keyser  | Unified/portable for WRF; added documentation; outputs more complete diagnostic info when routine terminates abnormally
+C> 2009-03-31 | J. Woollen | Added documentation.
+C> 2014-12-10 | J. Ator    | Use modules instead of COMMON blocks.
 C>
-C> USAGE:    NEVN (NODE, LUN, INV1, INV2, I1, I2, I3, USR)
-C>   INPUT ARGUMENT LIST:
-C>     NODE     - INTEGER: JUMP/LINK TABLE INDEX OF NODE TO RETURN
-C>                STACKED VALUES FOR
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     INV1     - INTEGER: STARTING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER IN WHICH TO LOOK FOR STACK VALUES
-C>     INV2     - INTEGER: ENDING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER IN WHICH TO LOOK FOR STACK VALUES
-C>     I1       - INTEGER: LENGTH OF FIRST DIMENSION OF USR
-C>     I2       - INTEGER: LENGTH OF SECOND DIMENSION OF USR
-C>     I3       - INTEGER: LENGTH OF THIRD DIMENSION OF USR
+C> @author J. Woollen @date 2003-11-04
+
+C> This function looks for all stacked data events for a
+C> specified data value and level within the portion of the current
+C> subset buffer bounded by the indices INV1 and INV2.  All such
+C> events are accumulated and returned to the calling program within
+C> array USR.  The value of the function itself is the total number
+C> of events found.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     USR      - REAL*8:(I1,I2,I3) STARTING ADDRESS OF DATA VALUES READ
-C>                FROM DATA SUBSET, EVENTS ARE RETURNED IN THE THIRD
-C>                DIMENSION FOR A PARTICULAR DATA VALUE AND LEVEL IN THE
-C>                FIRST AND SECOND DIMENSIONS
-C>     NEVN     - INTEGER: NUMBER OF EVENTS IN STACK (MUST BE LESS THAN
-C>                OR EQUAL TO I3)
+C> @param[in] NODE - integer: jump/link table index of node for which
+C>                   to return stacked values
+C> @param[in] LUN  - integer: I/O stream index into internal memory arrays
+C> @param[in] INV1 - integer: Starting index of the portion of the subset
+C>                   buffer in which to look for stack values
+C> @param[in] INV2 - integer: ending index of the portion of the subset
+C>                   buffer in which to look for stack values
+C> @param[in] I1   - integer: Length of first dimension of USR
+C> @param[in] I2   - integer: Length of second dimension of USR
+C> @param[in] I3   - integer: Length of third dimension of USR
+C> @param[out] USR - real*8(*,*,*): Starting address of data values read
+C>                   from data subset; events are returned in the third
+C>                   dimension for a particular data value and level in the
+C>                   first and second dimensions
+C> @returns NEVN   - integer: Number of events in stack (must be less than
+C>                   or equal to I3)
 C>
-C> REMARKS:
-C>    IMPORTANT: THIS ROUTINE SHOULD ONLY BE CALLED BY ROUTINE UFBIN3,
-C>               WHICH, ITSELF, IS CALLED ONLY BY VERIFICATION
-C>               APPLICATION PROGRAM GRIDTOBS, WHERE IT WAS PREVIOUSLY
-C>               AN IN-LINE SUBROUTINE.  IN GENERAL, NEVN DOES NOT WORK
-C>               PROPERLY IN OTHER APPLICATION PROGRAMS AT THIS TIME.
+C> @note: This routine should only be called by routine ufbin3(),
+C> which itself is called only by verification
+C> application program gridtobs, where it was previously
+C> an in-line subroutine.  In general, nevn() does not work
+C> properly in other application programs at this time.
 C>
-C>    THIS ROUTINE CALLS:        BORT     INVWIN   LSTJPB
-C>    THIS ROUTINE IS CALLED BY: UFBIN3
-C>                               Should NOT be called by any
-C>                               application programs!!!
-C>
+C> @author J. Woollen @date 2003-11-04
       FUNCTION NEVN(NODE,LUN,INV1,INV2,I1,I2,I3,USR)
 
       USE MODA_USRINT


### PR DESCRIPTION
Part of #246

I used a web browser to view the rendered doxygen of everything that's been changed so far, and I ended up making minor documentation updates for things that didn't display correctly, or where brief tags were missing or the history tables were missing some markdown characters.  So minor updates to a lot of routines, but again it's all just documentation changes and no source changes.  A lot of these details show up a lot more clearly when viewing the rendered doxygen output in a web browser, vs. just looking at diffs in GitHub. 

I also started the work on the "n" Fortran routines and made it all the way down through nevn.f.  So the documentation for all of those has now been converted from the legacy format and included in this PR.  I was actually hoping to finish all of the "n" routines today, but I ran out of steam ;-)