### PR TITLE
more doxygen: fixed doxygen warnings in Fortran files starting with 'n', some 'p' files

### DIFF
--- a/src/newwin.f
+++ b/src/newwin.f
@@ -17,13 +17,13 @@ C>
 C> @author Woollen @date 1994-01-06
       
 C> Given an index within the internal jump/link table which
-C> points to the start of an "rpc" window (i.e. iteration of an 8-bit
+C> points to the start of an "rpc" window (which is the iteration of an 8-bit
 C> or 16-bit delayed replication sequence), this subroutine computes
 C> the ending index of the window. Alternatively, if the given index
-C> points to the start of a "sub" window (i.e. the first node of a
-C> subset), the subroutine returns the index of the last node.
+C> points to the start of a "sub" window (which is the first node of a
+C> subset), then the subroutine returns the index of the last node.
 C>
-C> @note See the docblock in bufr archive library subroutine getwin for an
+C> @note See the docblock in bufr archive library subroutine getwin() for an
 C> explanation of "windows" within the context of a bufr data subset.
 C>
 C> @param[in] LUN - integer: i/o stream index into internal memory arrays.

--- a/src/newwin.f
+++ b/src/newwin.f
@@ -1,53 +1,36 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C> @brief Computes the ending index of the window.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced call to cray "abort" with call to bort().
+C> 1999-11-18 | J. Woollen | Increase number of open bufr files to 32.
+C> 2002-05-14 | J. Woollen | Removed old cray compiler directives.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | maxjl increased to 16000; unified/portable for wrf; documentation; outputs more diagnostic info.
+C> 2009-03-31 | J. Woollen | Added documentation.
+C> 2009-05-07 | J. Ator    | Use lstjpb instead of lstrpc.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> GIVEN AN INDEX WITHIN THE INTERNAL JUMP/LINK TABLE WHICH
-C>   POINTS TO THE START OF AN "RPC" WINDOW (I.E. ITERATION OF AN 8-BIT
-C>   OR 16-BIT DELAYED REPLICATION SEQUENCE), THIS SUBROUTINE COMPUTES
-C>   THE ENDING INDEX OF THE WINDOW.  ALTERNATIVELY, IF THE GIVEN INDEX
-C>   POINTS TO THE START OF A "SUB" WINDOW (I.E. THE FIRST NODE OF A
-C>   SUBSET), THE SUBROUTINE RETURNS THE INDEX OF THE LAST NODE.
+C> Given an index within the internal jump/link table which
+C> points to the start of an "rpc" window (i.e. iteration of an 8-bit
+C> or 16-bit delayed replication sequence), this subroutine computes
+C> the ending index of the window. Alternatively, if the given index
+C> points to the start of a "sub" window (i.e. the first node of a
+C> subset), the subroutine returns the index of the last node.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2002-05-14  J. WOOLLEN -- REMOVED OLD CRAY COMPILER DIRECTIVES
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MAXJL (MAXIMUM NUMBER OF JUMP/LINK ENTRIES)
-C>                           INCREASED FROM 15000 TO 16000 (WAS IN
-C>                           VERIFICATION VERSION); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED DOCUMENTATION (INCLUDING
-C>                           HISTORY); OUTPUTS MORE COMPLETE DIAGNOSTIC
-C>                           INFO WHEN ROUTINE TERMINATES ABNORMALLY
-C> 2009-03-31  J. WOOLLEN -- ADDED DOCUMENTATION
-C> 2009-05-07  J. ATOR    -- USE LSTJPB INSTEAD OF LSTRPC
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @note See the docblock in bufr archive library subroutine getwin for an
+C> explanation of "windows" within the context of a bufr data subset.
 C>
-C> USAGE:    CALL NEWWIN (LUN, IWIN, JWIN)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     IWIN     - INTEGER: STARTING INDEX OF WINDOW ITERATION
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] IWIN - integer: starting index of window iteration.
+C> @param[out] JWIN - integer: ending index of window iteration.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     JWIN     - INTEGER: ENDING INDEX OF WINDOW ITERATION
-C>
-C> REMARKS:
-C>
-C>    SEE THE DOCBLOCK IN BUFR ARCHIVE LIBRARY SUBROUTINE GETWIN FOR AN
-C>    EXPLANATION OF "WINDOWS" WITHIN THE CONTEXT OF A BUFR DATA SUBSET.
-C>
-C>    THIS ROUTINE CALLS:        BORT     LSTJPB
-C>    THIS ROUTINE IS CALLED BY: DRSTPL   UFBRW
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author WOOLLEN @date 1994-01-06
       SUBROUTINE NEWWIN(LUN,IWIN,JWIN)
 
       USE MODA_USRINT

--- a/src/numbck.f
+++ b/src/numbck.f
@@ -1,48 +1,31 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C> @brief Check the input character string to determine
+C> whether it contains a valid FXY (descriptor) value.
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 2003-11-04 | J. Ator    | Added documentation.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Split non-zero return; unified/ portable for wrf; documentation.
+C> 2007-01-19 | J. Ator    | Cleaned up and simplified logic.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS FUNCTION CHECKS THE INPUT CHARACTER STRING TO DETERMINE
-C>   WHETHER IT CONTAINS A VALID FXY (DESCRIPTOR) VALUE.
+C> This function checks the input character string to determine
+C> whether it contains a valid FXY (descriptor) value.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 2003-11-04  J. ATOR    -- ADDED DOCUMENTATION
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- SPLIT NON-ZERO RETURN INTO -1 FOR INVALID
-C>                           CHARACTER IN POSITION 1, -2 FOR INVALID
-C>                           CHARACTERS IN POSITIONS 2 THROUGH 6, -3 FOR
-C>                           INVALID CHARACTERS IN POSITIONS 2 AND 3 DUE
-C>                           TO BEING OUT OF RANGE, AND -4 FOR INVALID
-C>                           CHARACTERS IN POSITIONS 4 THROUGH 6 DUE TO
-C>                           BEING OUT OF RANGE (RETURN ONLY -1 BEFORE
-C>                           FOR ALL PROBLEMATIC CASES); UNIFIED/
-C>                           PORTABLE FOR WRF; ADDED HISTORY
-C>                           DOCUMENTATION
-C> 2007-01-19  J. ATOR    -- CLEANED UP AND SIMPLIFIED LOGIC
+C> @param[in] NUMB - character*6: fxy value to be checked.
 C>
-C> USAGE:   NUMBCK (NUMB)
-C>   INPUT ARGUMENT LIST:
-C>     NUMB     - CHARACTER*6: FXY VALUE TO BE CHECKED
+C> @return indicator as to whether numb is valid:.
+C> - 0 YES
+C> - -1 NO - first character ("F" value) is not '0',- '1', '2' OR '3'
+C> - -2 NO - remaining characters (2-6) ("X" and "Y" values) are not all numeric
+C> - -3 NO - characters 2-3 ("X" value) are not between '00' and '63'
+C> - -4 NO - characters 4-6 ("Y" value) are not between '000' and '255'
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     NUMBCK   - INTEGER: INDICATOR AS TO WHETHER NUMB IS VALID:
-C>                       0 = YES
-C>                      -1 = NO - first character ("F" value) is not '0',
-C>                           '1', '2' OR '3'
-C>                      -2 = NO - remaining characters (2-6) ("X" and "Y"
-C>                           values) are not all numeric
-C>                      -3 = NO - characters 2-3 ("X" value) are not
-C>                           between '00' and '63'
-C>                      -4 = NO - characters 4-6 ("Y" value) are not
-C>                           between '000' and '255'
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        DIGIT
-C>    THIS ROUTINE IS CALLED BY: IGETFXY  RDUSDX
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       FUNCTION NUMBCK(NUMB)
 
 

--- a/src/numbck.f
+++ b/src/numbck.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Check the input character string to determine
-C> whether it contains a valid FXY (descriptor) value.
+C> @brief Check the validity of an FXY value
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -16,19 +15,17 @@ C> @author Woollen @date 1994-01-06
 C> This function checks the input character string to determine
 C> whether it contains a valid FXY (descriptor) value.
 C>
-C> @param[in] NUMB - character*6: fxy value to be checked.
+C> @param[in] NUMB - character*6: FXY value to be checked.
 C>
 C> @return indicator as to whether numb is valid:.
-C> - 0 YES
-C> - -1 NO - first character ("F" value) is not '0',- '1', '2' OR '3'
-C> - -2 NO - remaining characters (2-6) ("X" and "Y" values) are not all numeric
-C> - -3 NO - characters 2-3 ("X" value) are not between '00' and '63'
-C> - -4 NO - characters 4-6 ("Y" value) are not between '000' and '255'
+C> - 0 yes
+C> - -1 no, the first character ("F" value) is not '0', '1', '2', or '3'
+C> - -2 no, characters 2-6 ("X" and "Y" values) are not all numeric
+C> - -3 no, characters 2-3 ("X" value) are not between '00' and '63'
+C> - -4 no, characters 4-6 ("Y" value) are not between '000' and '255'
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION NUMBCK(NUMB)
-
-
 
       CHARACTER*6  NUMB
       LOGICAL      DIGIT

--- a/src/nvnwin.f
+++ b/src/nvnwin.f
@@ -1,4 +1,6 @@
 C> @file
+C> @brief Search for all occurrences of a specified node within a
+C> specified portion of the current data subset.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -27,7 +29,7 @@ C> @param[out] INVN - integer: array of stack "event" indices for node.
 C> @param[in] NMAX - integer: dimensioned size of invn; used by the function to ensure
 C> that it does not overflow the invn array.
 C>
-C> @return number of indices returned within invn.
+C> @return number of indices within invn.
 C>
 C> @author Woollen @date 1994-01-06
       FUNCTION NVNWIN(NODE,LUN,INV1,INV2,INVN,NMAX)

--- a/src/nvnwin.f
+++ b/src/nvnwin.f
@@ -1,56 +1,35 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced call to cray "abort" with call to bort().
+C> 1999-11-18 | J. Woollen | Increased number of open bufr files to 32.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | maxjl increased to 16000; unified/portable for wrf; documentation; outputs more info.
+C> 2009-03-23 | J. Ator    | Use 1e9 to prevent overflow when initializing invn; use errwrt.
+C> 2009-03-31 | J. Woollen | Added documentation.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS FUNCTION LOOKS FOR AND RETURNS ALL OCCURRENCES OF A
-C>   SPECIFIED NODE WITHIN THE PORTION OF THE CURRENT SUBSET BUFFER
-C>   BOUNDED BY THE INDICES INV1 AND INV2.  THE RESULTING LIST IS A
-C>   STACK OF "EVENT" INDICES FOR THE REQUESTED NODE. 
+C> This function looks for and returns all occurrences of a
+C> specified node within the portion of the current subset buffer
+C> bounded by the indices inv1 and inv2. The resulting list is a
+C> stack of "event" indices for the requested node. 
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MAXJL (MAXIMUM NUMBER OF JUMP/LINK ENTRIES)
-C>                           INCREASED FROM 15000 TO 16000 (WAS IN
-C>                           VERIFICATION VERSION); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED DOCUMENTATION (INCLUDING
-C>                           HISTORY); OUTPUTS MORE COMPLETE DIAGNOSTIC
-C>                           INFO WHEN ROUTINE TERMINATES ABNORMALLY OR
-C>                           UNUSUAL THINGS HAPPEN
-C> 2009-03-23  J. ATOR    -- USE 1E9 TO PREVENT OVERFLOW WHEN
-C>                           INITIALIZING INVN; USE ERRWRT
-C> 2009-03-31  J. WOOLLEN -- ADDED DOCUMENTATION
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @param[in] NODE - integer: jump/link table index to look for.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] INV1 - integer: starting index of the portion of the subset buffer in which to look.
+C> @param[in] INV2 - integer: ending index of the portion of the subset buffer in which to look.
+C> @param[out] INVN - integer: array of stack "event" indices for node.
+C> @param[in] NMAX - integer: dimensioned size of invn; used by the function to ensure
+C> that it does not overflow the invn array.
 C>
-C> USAGE:    NVNWIN (NODE, LUN, INV1, INV2, INVN, NMAX)
-C>   INPUT ARGUMENT LIST:
-C>     NODE     - INTEGER: JUMP/LINK TABLE INDEX TO LOOK FOR
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     INV1     - INTEGER: STARTING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER IN WHICH TO LOOK
-C>     INV2     - INTEGER: ENDING INDEX OF THE PORTION OF THE SUBSET
-C>                BUFFER IN WHICH TO LOOK
-C>     NMAX     - INTEGER: DIMENSIONED SIZE OF INVN; USED BY THE
-C>                FUNCTION TO ENSURE THAT IT DOES NOT OVERFLOW THE
-C>                INVN ARRAY
+C> @return number of indices returned within invn.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     INVN     - INTEGER: ARRAY OF STACK "EVENT" INDICES FOR NODE
-C>     NVNWIN   - INTEGER: NUMBER OF INDICES RETURNED WITHIN INVN
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     ERRWRT
-C>    THIS ROUTINE IS CALLED BY: UFBEVN
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       FUNCTION NVNWIN(NODE,LUN,INV1,INV2,INVN,NMAX)
 
       USE MODA_USRINT

--- a/src/nwords.f
+++ b/src/nwords.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Adds up the complete length of the delayed
-C> replication sequence beginning at index n of the data subset.      
+C> @brief Compute the length of a delayed replication sequence
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -15,10 +14,10 @@ C>
 C> @author Woollen @date 1996-10-09
       
 C> This function adds up the complete length of the delayed
-C> replication sequence beginning at index n of the data subset.
+C> replication sequence beginning at index N of the data subset.
 C>
 C> @param[in] N - integer: index to start of delayed replication sequence.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C>
 C> @return complete length of delayed replication sequence within data subset.
 C>

--- a/src/nwords.f
+++ b/src/nwords.f
@@ -1,40 +1,28 @@
 C> @file
-C> @author WOOLLEN @date 1996-10-09
+C> @brief Adds up the complete length of the delayed
+C> replication sequence beginning at index n of the data subset.      
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1996-10-09 | J. Woollen | Original author.
+C> 1999-11-18 | J. Woollen | Increased the number of open bufr files to 32.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | maxjl increased to 16000; unified/portable for wrf; documentation.
+C> 2009-03-31 | J. Woollen | Added documentation.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C>
+C> @author Woollen @date 1996-10-09
       
-C> THIS FUNCTION ADDS UP THE COMPLETE LENGTH OF THE DELAYED
-C>   REPLICATION SEQUENCE BEGINNING AT INDEX N OF THE DATA SUBSET.
+C> This function adds up the complete length of the delayed
+C> replication sequence beginning at index n of the data subset.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1996-10-09  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MAXJL (MAXIMUM NUMBER OF JUMP/LINK ENTRIES)
-C>                           INCREASED FROM 15000 TO 16000 (WAS IN
-C>                           VERIFICATION VERSION); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED DOCUMENTATION (INCLUDING
-C>                           HISTORY) (INCOMPLETE)
-C> 2009-03-31  J. WOOLLEN -- ADDED DOCUMENTATION
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @param[in] N - integer: index to start of delayed replication sequence.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
 C>
-C> USAGE:    NWORDS (N, LUN)
-C>   INPUT ARGUMENT LIST:
-C>     N        - INTEGER: INDEX TO START OF DELAYED REPLICATION SEQUENCE
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
+C> @return complete length of delayed replication sequence within data subset.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     NWORDS   - INTEGER: COMPLETE LENGTH OF DELAYED REPLICATION
-C>                SEQUENCE WITHIN DATA SUBSET
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        None
-C>    THIS ROUTINE IS CALLED BY: INVMRG
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1996-10-09
       FUNCTION NWORDS(N,LUN)
 
       USE MODA_USRINT

--- a/src/nxtwin.f
+++ b/src/nxtwin.f
@@ -25,10 +25,10 @@ C> @note See getwin() for an explanation of "windows" within the
 C> context of a bufr data subset.
 C>
 C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[in] IWIN - integer: starting index of current window iteration.
-C> @param[in] JWIN - integer: ending index of current window iteration.
-C> @param[out] IWIN - integer: starting index of next window iteration.
-C> @param[out] JWIN - integer: ending index of next window iteration.
+C> @param[inout] IWIN - integer: in: starting index of current window iteration.
+C> out: starting index of next window iteration.
+C> @param[inout] JWIN - integer: ending index of current window iteration.
+C> out: ending index of next window iteration.
 C>
 C> @author WOOLLEN @date 1994-01-06
       SUBROUTINE NXTWIN(LUN,IWIN,JWIN)

--- a/src/nxtwin.f
+++ b/src/nxtwin.f
@@ -17,7 +17,7 @@ C>
 C> @author WOOLLEN @date 1994-01-06
       
 C> Given indices within the internal jump/link table which
-C> point to the start and end of an "rpc" window (i.e. iteration of
+C> point to the start and end of an "rpc" window (which is an iteration of
 C> an 8-bit or 16-bit delayed replication sequence), this subroutine
 C> computes the start and end indices of the next window.
 C>
@@ -25,10 +25,12 @@ C> @note See getwin() for an explanation of "windows" within the
 C> context of a bufr data subset.
 C>
 C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[inout] IWIN - integer: in: starting index of current window iteration.
-C> out: starting index of next window iteration.
-C> @param[inout] JWIN - integer: ending index of current window iteration.
-C> out: ending index of next window iteration.
+C> @param[inout] IWIN - integer:
+C>  - on input, contains starting index of current window iteration.
+C>  - on output, contains starting index of next window iteration.
+C> @param[inout] JWIN - integer:
+C>  - on input, contains ending index of current window iteration.
+C>  - on output, contains ending index of next window iteration.
 C>
 C> @author WOOLLEN @date 1994-01-06
       SUBROUTINE NXTWIN(LUN,IWIN,JWIN)

--- a/src/nxtwin.f
+++ b/src/nxtwin.f
@@ -1,54 +1,36 @@
 C> @file
+C> @brief Computes the start and end indices of the next window.      
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced cray "abort" with bort().
+C> 1999-11-18 | J. Woollen | Increased the number of open bufr files to 32.
+C> 2002-05-14 | J. Woollen | Removed old cray compiler directives.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | maxjl increased to 16000; unified/portable for wrf; documentation.
+C> 2009-03-31 | J. Woollen | Added additional documentation.
+C> 2009-05-07 | J. Ator    | Use lstjpb instead of lstrpc.
+C> 2014-12-10 | J. Ator    | Use modules instead of common blocks.
+C>
 C> @author WOOLLEN @date 1994-01-06
       
-C> GIVEN INDICES WITHIN THE INTERNAL JUMP/LINK TABLE WHICH
-C>   POINT TO THE START AND END OF AN "RPC" WINDOW (I.E. ITERATION OF
-C>   AN 8-BIT OR 16-BIT DELAYED REPLICATION SEQUENCE), THIS SUBROUTINE
-C>   COMPUTES THE START AND END INDICES OF THE NEXT WINDOW.
+C> Given indices within the internal jump/link table which
+C> point to the start and end of an "rpc" window (i.e. iteration of
+C> an 8-bit or 16-bit delayed replication sequence), this subroutine
+C> computes the start and end indices of the next window.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 1999-11-18  J. WOOLLEN -- THE NUMBER OF BUFR FILES WHICH CAN BE
-C>                           OPENED AT ONE TIME INCREASED FROM 10 TO 32
-C>                           (NECESSARY IN ORDER TO PROCESS MULTIPLE
-C>                           BUFR FILES UNDER THE MPI)
-C> 2002-05-14  J. WOOLLEN -- REMOVED OLD CRAY COMPILER DIRECTIVES
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- MAXJL (MAXIMUM NUMBER OF JUMP/LINK ENTRIES)
-C>                           INCREASED FROM 15000 TO 16000 (WAS IN
-C>                           VERIFICATION VERSION); UNIFIED/PORTABLE FOR
-C>                           WRF; ADDED DOCUMENTATION (INCLUDING
-C>                           HISTORY) (INCOMPLETE); OUTPUTS MORE
-C>                           COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY
-C> 2009-03-31  J. WOOLLEN -- ADDED ADDITIONAL DOCUMENTATION
-C> 2009-05-07  J. ATOR    -- USE LSTJPB INSTEAD OF LSTRPC
-C> 2014-12-10  J. ATOR    -- USE MODULES INSTEAD OF COMMON BLOCKS
+C> @note See getwin() for an explanation of "windows" within the
+C> context of a bufr data subset.
 C>
-C> USAGE:    CALL NXTWIN (LUN, IWIN, JWIN)
-C>   INPUT ARGUMENT LIST:
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     IWIN     - INTEGER: STARTING INDEX OF CURRENT WINDOW ITERATION
-C>     JWIN     - INTEGER: ENDING INDEX OF CURRENT WINDOW ITERATION
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] IWIN - integer: starting index of current window iteration.
+C> @param[in] JWIN - integer: ending index of current window iteration.
+C> @param[out] IWIN - integer: starting index of next window iteration.
+C> @param[out] JWIN - integer: ending index of next window iteration.
 C>
-C>   OUTPUT ARGUMENT LIST:
-C>     IWIN     - INTEGER: STARTING INDEX OF NEXT WINDOW ITERATION
-C>     JWIN     - INTEGER: ENDING INDEX OF NEXT WINDOW ITERATION
-C>
-C> REMARKS:
-C>
-C>    SEE THE DOCBLOCK IN BUFR ARCHIVE LIBRARY SUBROUTINE GETWIN FOR AN
-C>    EXPLANATION OF "WINDOWS" WITHIN THE CONTEXT OF A BUFR DATA SUBSET.
-C>
-C>    THIS ROUTINE CALLS:        BORT     LSTJPB
-C>    THIS ROUTINE IS CALLED BY: UFBEVN   UFBIN3   UFBRW
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author WOOLLEN @date 1994-01-06
       SUBROUTINE NXTWIN(LUN,IWIN,JWIN)
 
       USE MODA_USRINT

--- a/src/pad.f
+++ b/src/pad.f
@@ -1,54 +1,40 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced cray routine "abort" with bort().
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; documentation; outputs more info.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS SUBROUTINE FIRST PACKS THE VALUE FOR THE NUMBER OF
-C>   BITS BEING "PADDED" (WE'LL GET TO THAT LATER), STARTING WITH BIT
-C>   IBIT+1 AND USING EIGHT BITS IN THE PACKED ARRAY IBAY (WHICH
-C>   REPRESENTS A SUBSET PACKED INTO IBIT BITS).  THEN, STARTING WITH
-C>   IBIT+9, IT PACKS ZEROES (I.E., "PADS") TO THE SPECIFIED BIT
-C>   BOUNDARY (IPADB).  (NOTE: IT'S THE NUMBER OF BITS PADDED HERE THAT
-C>   WAS PACKED IN BITS IBIT+1 THROUGH IBIT+8 - THIS IS ACTUALLY A
-C>   DELAYED REPLICATION FACTOR).  IPADB MUST BE A MULTIPLE OF EIGHT AND
-C>   REPRESENTS THE BIT BOUNDARY ON WHICH THE PACKED SUBSET IN IBAY
-C>   SHOULD END AFTER PADDING.  FOR EXAMPLE, IF IPABD IS "8", THEN THE
-C>   NUMBER OF BITS IN IBAY ACTUALLY CONSUMED BY PACKED DATA (INCLUDING
-C>   THE PADDING) WILL BE A MULTIPLE OF EIGHT.  IF IPADB IS "16", IT
-C>   WILL BE A MULTIPLE OF SIXTEEN.  IN EITHER (OR ANY) CASE, THIS
-C>   ENSURES THAT THE PACKED SUBSET WILL ALWAYS END ON A FULL BYTE
-C>   BOUNDARY.
+C> This subroutine first packs the value for the number of
+C> bits being "padded" (we'll get to that later), starting with bit
+C> ibit+1 and using eight bits in the packed array ibay (which
+C> represents a subset packed into ibit bits). Then, starting with
+C> ibit+9, it packs zeroes (i.e., "pads") to the specified bit
+C> boundary (ipadb). (Note: it's the number of bits padded here that
+C> was packed in bits ibit+1 through ibit+8 - this is actually a
+C> delayed replication factor). IPADB must be a multiple of eight and
+C> represents the bit boundary on which the packed subset in ibay
+C> should end after padding. For example, if ipabd is "8", then the
+C> number of bits in ibay actually consumed by packed data (including
+C> the padding) will be a multiple of eight. If ipadb is "16", it
+C> will be a multiple of sixteen.  in either (or any) case, this
+C> ensures that the packed subset will always end on a full byte
+C> boundary.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY
+C> @param[inout] IBAY - integer: *-word packed binary array not yet padded.
+C> Out: *-word packed binary array now padded.
+C> @param[inout] IBIT - integer: bit pointer within ibay to start padding from.
+C> Out: number of bits within ibay containing packed data (including padding, must be a multiple of 8).
+C> @param[out] IBYT - integer: number of bytes within ibay containing packed data
+C> (including padding) (i.e., ibit/8).
+C> @param[in] IPADB - integer: bit boundary to pad to (must be a multiple of 8).
 C>
-C> USAGE:    CALL PAD (IBAY, IBIT, IBYT, IPADB)
-C>   INPUT ARGUMENT LIST:
-C>     IBAY     - INTEGER: *-WORD PACKED BINARY ARRAY NOT YET PADDED
-C>     IBIT     - INTEGER: BIT POINTER WITHIN IBAY TO START PADDING FROM
-C>     IPADB    - INTEGER: BIT BOUNDARY TO PAD TO (MUST BE A MULTIPLE OF
-C>                8)
-C>
-C>   OUTPUT ARGUMENT LIST:
-C>     IBAY     - INTEGER: *-WORD PACKED BINARY ARRAY NOW PADDED
-C>     IBIT     - INTEGER: NUMBER OF BITS WITHIN IBAY CONTAINING PACKED
-C>                DATA (INCLUDING PADDING, MUST BE A MULTIPLE OF 8)
-C>     IBYT     - INTEGER: NUMBER OF BYTES WITHIN IBAY CONTAINING PACKED
-C>                DATA (INCLUDING PADDING) (I.E., IBIT/8)
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     PKB
-C>    THIS ROUTINE IS CALLED BY: MSGUPD
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE PAD(IBAY,IBIT,IBYT,IPADB)
 
 

--- a/src/pad.f
+++ b/src/pad.f
@@ -1,4 +1,6 @@
 C> @file
+C> @brief Pad a BUFR data subset with zeroed-out bits up to the
+C> next byte boundary.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -26,18 +28,18 @@ C> will be a multiple of sixteen.  in either (or any) case, this
 C> ensures that the packed subset will always end on a full byte
 C> boundary.
 C>
-C> @param[inout] IBAY - integer: *-word packed binary array not yet padded.
-C> Out: *-word packed binary array now padded.
-C> @param[inout] IBIT - integer: bit pointer within ibay to start padding from.
-C> Out: number of bits within ibay containing packed data (including padding, must be a multiple of 8).
-C> @param[out] IBYT - integer: number of bytes within ibay containing packed data
-C> (including padding) (i.e., ibit/8).
+C> @param[inout] IBAY - integer(*):
+C>  - on input, contains BUFR data subset to be padded
+C>  - on output, contains BUFR data subset padded with zeroed-out bits up to IPADB
+C> @param[inout] IBIT - integer:
+C>  - on input, contains bit pointer within IBAY after which to begin padding.
+C>  - on output, contains bit pointer within IBAY to last bit that was padded. 
+C> @param[out] IBYT - integer: number of bytes within IBAY containing packed data,
+C> including padding
 C> @param[in] IPADB - integer: bit boundary to pad to (must be a multiple of 8).
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE PAD(IBAY,IBIT,IBYT,IPADB)
-
-
 
       CHARACTER*128 BORT_STR
       DIMENSION     IBAY(*)

--- a/src/padmsg.f
+++ b/src/padmsg.f
@@ -1,30 +1,19 @@
 C> @file
-C> @author ATOR @date 2005-11-29
+C> @brief Pad a bufr message with zeroed-out bytes
+C> from the end of the message up to the next 8-byte boundary.	
+C> @author Ator @date 2005-11-29
 	
-C> THIS SUBROUTINE PADS A BUFR MESSAGE WITH ZEROED-OUT BYTES
-C>  FROM THE END OF THE MESSAGE UP TO THE NEXT 8-BYTE BOUNDARY.
+C> This subroutine pads a bufr message with zeroed-out bytes
+C> from the end of the message up to the next 8-byte boundary.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2005-11-29  J. ATOR    -- ORIGINAL AUTHOR
+C> @param[inout] MESG - integer: *-word packed binary array containing
+C> bufr message out: *-word packed binary array containing bufr message
+C> with npbyt zeroed-out bytes appendebbbd to the end.
+C> @param[in] LMESG - integer: dimensioned size (in integer words) of mesg;
+C> used by the subroutine to ensure that it does not overflow the mesg array.
+C> @param[inout] NPBYT - integer: number of zeroed-out bytes appended to mesg.
 C>
-C> USAGE:    CALL PADMSG (MESG, LMESG, NPBYT )
-C>   INPUT ARGUMENT LIST:
-C>     MESG     - INTEGER: *-WORD PACKED BINARY ARRAY CONTAINING BUFR
-C>                MESSAGE 
-C>     LMESG    - INTEGER: DIMENSIONED SIZE (IN INTEGER WORDS) OF MESG;
-C>                USED BY THE SUBROUTINE TO ENSURE THAT IT DOES NOT
-C>                OVERFLOW THE MESG ARRAY
-C>
-C>   OUTPUT ARGUMENT LIST:
-C>     MESG     - INTEGER: *-WORD PACKED BINARY ARRAY CONTAINING BUFR
-C>                MESSAGE WITH NPBYT ZEROED-OUT BYTES APPENDED TO THE END
-C>     NPBYT    - INTEGER: NUMBER OF ZEROED-OUT BYTES APPENDED TO MESG
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT     IUPBS01  NMWRD    PKB
-C>    THIS ROUTINE IS CALLED BY: MSGWRT
-C>                               Also called by application programs.
-C>
+C> @author Ator @date 2005-11-29
 	SUBROUTINE PADMSG(MESG,LMESG,NPBYT)
 
 

--- a/src/padmsg.f
+++ b/src/padmsg.f
@@ -1,22 +1,21 @@
 C> @file
-C> @brief Pad a bufr message with zeroed-out bytes
-C> from the end of the message up to the next 8-byte boundary.	
+C> @brief Pad a BUFR message with zeroed-out bytes up to the
+C> next 8-byte boundary.
 C> @author Ator @date 2005-11-29
 	
-C> This subroutine pads a bufr message with zeroed-out bytes
+C> This subroutine pads a BUFR message with zeroed-out bytes
 C> from the end of the message up to the next 8-byte boundary.
 C>
-C> @param[inout] MESG - integer: *-word packed binary array containing
-C> bufr message out: *-word packed binary array containing bufr message
-C> with npbyt zeroed-out bytes appendebbbd to the end.
-C> @param[in] LMESG - integer: dimensioned size (in integer words) of mesg;
-C> used by the subroutine to ensure that it does not overflow the mesg array.
-C> @param[inout] NPBYT - integer: number of zeroed-out bytes appended to mesg.
+C> @param[inout] MESG - integer(*):
+C>  - on input, contains BUFR message to be padded
+C>  - on output, contains BUFR message with NPBYT zeroed-out bytes appended
+C>    to the end
+C> @param[in] LMESG - integer: dimensioned size (in integer words) of MESG;
+C> used by the subroutine to ensure that it does not overflow the MESG array.
+C> @param[out] NPBYT - integer: number of zeroed-out bytes appended to MESG.
 C>
 C> @author Ator @date 2005-11-29
 	SUBROUTINE PADMSG(MESG,LMESG,NPBYT)
-
-
 
 	COMMON /HRDWRD/ NBYTW,NBITW,IORD(8)
 

--- a/src/parstr.f
+++ b/src/parstr.f
@@ -1,39 +1,24 @@
 C> @file
+C> @brief Parse a string containing one or more
+C> substrings into an array of substrings.      
 C> @author J @date 2007-01-19
       
-C> THIS SUBROUTINE PARSES A STRING CONTAINING ONE OR MORE
-C>   SUBSTRINGS INTO AN ARRAY OF SUBSTRINGS.  THE SEPARATOR FOR THE
-C>   SUBSTRINGS IS SPECIFIED DURING INPUT, AND MULTIPLE ADJACENT
-C>   OCCURRENCES OF THIS CHARACTER WILL BE TREATED AS A SINGLE
-C>   OCCURRENCE WHEN THE STRING IS ACTUALLY PARSED.
+C> This subroutine parses a string containing one or more
+C> substrings into an array of substrings. The separator for the
+C> substrings is specified during input, and multiple adjacent
+C> occurrences of this character will be treated as a single
+C> occurrence when the string is actually parsed.
 C>
-C> PROGRAM HISTORY LOG:
-C> 2007-01-19  J. ATOR    -- BASED UPON SUBROUTINE PARSEQ
+C> @param[in] STR - character*(*): string.
+C> @param[out] TAGS - character*(*): mtag-word array of substrings (first.
+C> ntag words filled)
+C> @param[in] MTAG - integer: maximum number of substrings to be parsed from string.
+C> @param[out] NTAG - integer: number of substrings returned.
+C> @param[in] SEP - character*1: separator character for substrings.
+C> @param[in] LIMIT80 - logical: .true. if an abort should occur when str is
+C> longer than 80 characters; included for historical consistency with old subroutine parseq.
 C>
-C> USAGE:    CALL PARSTR (STR, TAGS, MTAG, NTAG, SEP, LIMIT80)
-C>   INPUT ARGUMENT LIST:
-C>     STR      - CHARACTER*(*): STRING
-C>     MTAG     - INTEGER: MAXIMUM NUMBER OF SUBSTRINGS TO BE PARSED
-C>                FROM STRING
-C>     SEP      - CHARACTER*1: SEPARATOR CHARACTER FOR SUBSTRINGS
-C>     LIMIT80  - LOGICAL: .TRUE. IF AN ABORT SHOULD OCCUR WHEN STR IS
-C>                LONGER THAN 80 CHARACTERS; INCLUDED FOR HISTORICAL
-C>                CONSISTENCY WITH OLD SUBROUTINE PARSEQ
-C>
-C>   OUTPUT ARGUMENT LIST:
-C>     TAGS     - CHARACTER*(*): MTAG-WORD ARRAY OF SUBSTRINGS (FIRST
-C>                NTAG WORDS FILLED)
-C>     NTAG     - INTEGER: NUMBER OF SUBSTRINGS RETURNED
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT2
-C>    THIS ROUTINE IS CALLED BY: FSTAG    GETCFMNG GETNTBE  GETTBH
-C>                               PARUSR   READLC   SEQSDX   SNTBBE
-C>                               SNTBDE   SNTBFE   UFBSEQ   UFBTAB
-C>                               UFBTAM   WRITLC
-C>                               Normally not called by any application
-C>                               programs but it could be.
-C>
+C> @author J @date 2007-01-19
       SUBROUTINE PARSTR(STR,TAGS,MTAG,NTAG,SEP,LIMIT80)
 
 

--- a/src/parstr.f
+++ b/src/parstr.f
@@ -1,7 +1,6 @@
 C> @file
-C> @brief Parse a string containing one or more
-C> substrings into an array of substrings.      
-C> @author J @date 2007-01-19
+C> @brief Parse a string containing one or more substrings into an array of substrings.
+C> @author J. Ator @date 2007-01-19
       
 C> This subroutine parses a string containing one or more
 C> substrings into an array of substrings. The separator for the
@@ -10,18 +9,16 @@ C> occurrences of this character will be treated as a single
 C> occurrence when the string is actually parsed.
 C>
 C> @param[in] STR - character*(*): string.
-C> @param[out] TAGS - character*(*): mtag-word array of substrings (first.
-C> ntag words filled)
-C> @param[in] MTAG - integer: maximum number of substrings to be parsed from string.
-C> @param[out] NTAG - integer: number of substrings returned.
+C> @param[out] TAGS - character*(*): array of substrings
+C> @param[in] MTAG - integer: dimensioned size of TAGS within calling program;
+C> used by the subroutine to make sure it doesn't overflow the TAGS array.
+C> @param[out] NTAG - integer: number of substrings returned in TAGS
 C> @param[in] SEP - character*1: separator character for substrings.
-C> @param[in] LIMIT80 - logical: .true. if an abort should occur when str is
+C> @param[in] LIMIT80 - logical: .true. if an abort should occur when STR is
 C> longer than 80 characters; included for historical consistency with old subroutine parseq.
 C>
-C> @author J @date 2007-01-19
+C> @author J. Ator @date 2007-01-19
       SUBROUTINE PARSTR(STR,TAGS,MTAG,NTAG,SEP,LIMIT80)
-
-
 
       CHARACTER*(*) STR,TAGS(MTAG)
       CHARACTER*128 BORT_STR1,BORT_STR2

--- a/src/parusr.f
+++ b/src/parusr.f
@@ -1,51 +1,37 @@
 C> @file
-C> @author WOOLLEN @date 1994-01-06
+C> @brief Initate the process to parse out mnemonics
+C> (nodes) from a user-specified character string, and separates them
+C> into store and condition nodes.      
+C>
+C> ### Program History Log
+C> Date | Programmer | Comments
+C> -----|------------|----------
+C> 1994-01-06 | J. Woollen | Original author.
+C> 1998-07-08 | J. Woollen | Replaced call to cray "abort" with bort(); improved machine portability.
+C> 2003-11-04 | S. Bender  | Added remarks/bufrlib routine interdependencies.
+C> 2003-11-04 | D. Keyser  | Unified/portable for wrf; documentation; more diagnostic info; changed to bort2(); change parutg().
+C> 2007-01-19 | J. Ator    | Replaced call to parseq with call to parstr.
+C> 2009-05-07 | J. Ator    | Use lstjpb instead of lstrpc.
+C>
+C> @author Woollen @date 1994-01-06
       
-C> THIS SUBROUTINE INITATES THE PROCESS TO PARSE OUT MNEMONICS
-C>   (NODES) FROM A USER-SPECIFIED CHARACTER STRING, AND SEPARATES THEM
-C>   INTO STORE AND CONDITION NODES.  INFORMATION ABOUT THE STRING
-C>   "PIECES" (I.E., THE MNEMONICS) IS STORED IN ARRAYS IN COMMON BLOCK
-C>   /USRSTR/.  CONDITION NODES ARE SORTED IN THE ORDER EXPECTED IN THE
-C>   INTERNAL JUMP/LINK TABLES AND SEVERAL CHECKS ARE PERFORMED ON THE
-C>   NODES.
+C> This subroutine initates the process to parse out mnemonics
+C> (nodes) from a user-specified character string, and separates them
+C> into store and condition nodes. Information about the string
+C> "pieces" (i.e., the mnemonics) is stored in arrays in common block
+C> /usrstr/. Condition nodes are sorted in the order expected in the
+C> internal jump/link tables and several checks are performed on the
+C> nodes.
 C>
-C> PROGRAM HISTORY LOG:
-C> 1994-01-06  J. WOOLLEN -- ORIGINAL AUTHOR
-C> 1998-07-08  J. WOOLLEN -- REPLACED CALL TO CRAY LIBRARY ROUTINE
-C>                           "ABORT" WITH CALL TO NEW INTERNAL BUFRLIB
-C>                           ROUTINE "BORT"; IMPROVED MACHINE
-C>                           PORTABILITY
-C> 2003-11-04  S. BENDER  -- ADDED REMARKS/BUFRLIB ROUTINE
-C>                           INTERDEPENDENCIES
-C> 2003-11-04  D. KEYSER  -- UNIFIED/PORTABLE FOR WRF; ADDED
-C>                           DOCUMENTATION (INCLUDING HISTORY); OUTPUTS
-C>                           MORE COMPLETE DIAGNOSTIC INFO WHEN ROUTINE
-C>                           TERMINATES ABNORMALLY; CHANGED CALL FROM
-C>                           BORT TO BORT2; RESPONDED TO CHANGE IN
-C>                           PARUTG (WHICH THIS ROUTINE CALLS) TO NO
-C>                           LONGER EXPECT AN ALTERNATE RETURN TO A
-C>                           STATEMENT NUMBER IN THIS ROUTINE WHICH
-C>                           CALLED BORT (BORT IS NOW CALLED IN PARUTG)
-C> 2007-01-19  J. ATOR    -- REPLACED CALL TO PARSEQ WITH CALL TO PARSTR
-C> 2009-05-07  J. ATOR    -- USE LSTJPB INSTEAD OF LSTRPC
+C> @param[in] STR - character*(*): string of blank-separated mnemonics.
+C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] I1 - integer: a number greater than or equal to the number of
+C> blank-separated mnemonics in str.
+C> @param[in] IO - integer: status indicator for bufr file associated with lun:.
+C> - 0 input file
+C> - 1 output file
 C>
-C> USAGE:    CALL PARUSR (STR, LUN, I1, IO)
-C>   INPUT ARGUMENT LIST:
-C>     STR      - CHARACTER*(*): STRING OF BLANK-SEPARATED MNEMONICS
-C>     LUN      - INTEGER: I/O STREAM INDEX INTO INTERNAL MEMORY ARRAYS
-C>     I1       - INTEGER: A NUMBER GREATER THAN OR EQUAL TO THE NUMBER
-C>                OF BLANK-SEPARATED MNEMONICS IN STR
-C>     IO       - INTEGER: STATUS INDICATOR FOR BUFR FILE ASSOCIATED
-C>                WITH LUN:
-C>                       0 = input file
-C>                       1 = output file
-C>
-C> REMARKS:
-C>    THIS ROUTINE CALLS:        BORT2    LSTJPB   PARSTR   PARUTG
-C>    THIS ROUTINE IS CALLED BY: STRING
-C>                               Normally not called by any application
-C>                               programs.
-C>
+C> @author Woollen @date 1994-01-06
       SUBROUTINE PARUSR(STR,LUN,I1,IO)
 
 

--- a/src/parusr.f
+++ b/src/parusr.f
@@ -1,7 +1,5 @@
 C> @file
-C> @brief Initate the process to parse out mnemonics
-C> (nodes) from a user-specified character string, and separates them
-C> into store and condition nodes.      
+C> @brief Initate the process to parse out mnemonics from a character string.
 C>
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -24,17 +22,15 @@ C> internal jump/link tables and several checks are performed on the
 C> nodes.
 C>
 C> @param[in] STR - character*(*): string of blank-separated mnemonics.
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
 C> @param[in] I1 - integer: a number greater than or equal to the number of
-C> blank-separated mnemonics in str.
-C> @param[in] IO - integer: status indicator for bufr file associated with lun:.
+C> blank-separated mnemonics in STR.
+C> @param[in] IO - integer: status indicator for BUFR file associated with LUN:
 C> - 0 input file
 C> - 1 output file
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE PARUSR(STR,LUN,I1,IO)
-
-
 
       COMMON /USRSTR/ NNOD,NCON,NODS(20),NODC(10),IVLS(10),KONS(10)
       COMMON /ACMODE/ IAC

--- a/src/parutg.f
+++ b/src/parutg.f
@@ -1,4 +1,5 @@
 C> @file
+C> @brief Parse a mnemonic from a character string.
 C> 
 C> ### Program History Log
 C> Date | Programmer | Comments
@@ -32,7 +33,7 @@ C> value (numeric characters beyond the condition character in the
 C> user-specified tag input here) is returned.
 C>
 C> As an example of condition character usage, consider the following
-C> example of a call to ufbint:
+C> example of a call to ufbint():
 C>
 C> @code
 C>      REAL*8 USR(4,50)
@@ -41,13 +42,13 @@ C>             ....
 C>      CALL UFBINT(LUNIN,USR,4,50,IRET,'PRLC<50000 TMDB WDIR WSPD')
 C> @endcode
 C>
-C> Assuming that lunin points to a bufr file open for input (reading),
-C> then the usr array now contains iret levels of data (up to a maximum
-C> of 50!) where the value of prlc is/was less than 50000, along with
-C> the corresponding values for tmdb, wdir and wspd at those levels.
+C> Assuming that LUNIN points to a BUFR file open for input (reading),
+C> then the USR array now contains IRET levels of data (up to a maximum
+C> of 50) where the value of PRLC is/was less than 50000, along with
+C> the corresponding values for TMDB, WDIR and WSPD at those levels.
 C>
 C> As another example, consider the following example of a call to
-C> readlc for a long character string:
+C> readlc() for a long character string:
 C>
 C> @code
 C>      CHARACTER*200 LCHR
@@ -56,9 +57,9 @@ C>             ....
 C>      CALL READLC(LUNIN,LCHR,'NUMID#3')
 C> @endcode
 C>
-C> Assuming that lunin points to a bufr file open for input (reading),
-C> then the lchr string now contains the value corresponding to the 
-C> third occurrence of numid within the current subset.
+C> Assuming that LUNIN points to a BUFR file open for input (reading),
+C> then the LCHR string now contains the value corresponding to the 
+C> third occurrence of NUMID within the current subset.
 C>
 C> Valid condition codes include:
 C> - '<' - less than
@@ -67,25 +68,25 @@ C> - '=' - equal to
 C> - '!' - not equal to
 C> - '#' - ordinal identifier for a particular occurrence of a long character string
 C>
-C> @param[in] LUN - integer: i/o stream index into internal memory arrays.
-C> @param[in] IO - integer: status indicator for bufr file associated with lun:.
+C> @param[in] LUN - integer: I/O stream index into internal memory arrays.
+C> @param[in] IO - integer: status indicator for BUFR file associated with LUN:
 C> - 0 input file
 C> - 1 output file
 C> @param[in] UTG character*(*): user-supplied tag representing a value to be
-C> encoded/decoded to/from bufr file.
+C> encoded/decoded to/from BUFR file.
 C> @param[out] NOD - integer: positional index in internal jump/link subset
-C> table for tag. 0 = tag not found in table
-C> @param[out] KON - integer: indicator for type of condition character found in utg:.
-C> - 0 = no condition character found (NOD is a store node)
-C> - 1 = character '=' found
-C> - 2 = character '!' found
-C> - 3 = character '<' found
-C> - 4 = character '>' found
-C> - 5 = character '^' found
-C> - 6 = character '#' found
-C> - (1-6 means NOD is a condition node, and specifically 5 is a "bump" node)
-C> @param[out] VAL - real: condition value associated with condition character found in utg.
-C> 0 = UTG does not have a condition character
+C> table for TAG.
+C> - 0 TAG not found in table
+C> @param[out] KON - integer: indicator for type of condition character found in UTG:
+C> - 0 no condition character found (NOD is a store node)
+C> - 1 character '=' found (NOD is a condition node)
+C> - 2 character '!' found (NOD is a condition node)
+C> - 3 character '<' found (NOD is a condition node)
+C> - 4 character '>' found (NOD is a condition node)
+C> - 5 character '^' found (NOD is a condition node; specifically, a "bump" node)
+C> - 6 character '#' found (NOD is a condition node)
+C> @param[out] VAL - real: condition value associated with condition character found in utg:
+C> - 0 = UTG does not have a condition character
 C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE PARUTG(LUN,IO,UTG,NOD,KON,VAL)


### PR DESCRIPTION
Part of #246 

More doxygen.