### PR TITLE
Add cache directory option for test data, use it to cache data for all CIs

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -45,6 +45,13 @@ jobs:
         path: bufr
         submodules: true
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v2
+      with:
+        path: ~/data
+        key: data-1
+
     - name: build
       run: |
         cd bufr
@@ -58,3 +65,11 @@ jobs:
       run: |
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
+
+    - name: cache-data
+      if: steps.cache-data.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/data
+        cp $GITHUB_WORKSPACE/bufr/build/test/bufr-11.6.0.tgz ~/data
+        
+        

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -57,7 +57,7 @@ jobs:
         cd bufr
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=OFF ..
+        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=OFF ..
         make -j2 VERBOSE=1
         make install
 

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -36,6 +36,13 @@ jobs:
         path: bufr
         submodules: true
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v2
+      with:
+        path: ~/data
+        key: data-1
+
     - name: build
       run: |
         if [[ ${{ matrix.ccompiler }} == "clang" ]]; then
@@ -60,3 +67,10 @@ jobs:
       run: |
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
+
+    - name: cache-data
+      if: steps.cache-data.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/data
+        cp $GITHUB_WORKSPACE/bufr/build/test/bufr-11.6.0.tgz ~/data
+        

--- a/.github/workflows/Linux.yml
+++ b/.github/workflows/Linux.yml
@@ -57,7 +57,7 @@ jobs:
         cd bufr
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
+        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2 VERBOSE=1
         make install
         cd python

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -41,13 +41,10 @@ jobs:
 
     - name: build-bufr
       run: |
-        ls -l ~/data
-        cd ~
-        pwd
         cd bufr
         mkdir build 
         cd build
-        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
+        cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2 VERBOSE=1
         make install
         cd python

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -41,6 +41,7 @@ jobs:
 
     - name: build-bufr
       run: |
+        ls -l /home/runner/data
         cd bufr
         mkdir build 
         cd build

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -41,7 +41,9 @@ jobs:
 
     - name: build-bufr
       run: |
-        ls -l /home/runner/data
+        ls -l ~/data
+        cd ~
+        pwd
         cd bufr
         mkdir build 
         cd build

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,6 +1,6 @@
 # This is a GitHub CI workflow for the NCEPLIBS-bufr project.
 #
-# This workflow tests on MacOS. 
+# This workflow tests on MacOS.
 #
 # Ed Hartnett, 1/10/23
 name: MacOS

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -37,7 +37,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/data
-        key: data-1
+        key: data-2
 
     - name: build-bufr
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,6 +1,6 @@
 # This is a GitHub CI workflow for the NCEPLIBS-bufr project.
 #
-# This workflow tests on MacOS.
+# This workflow tests on MacOS. 
 #
 # Ed Hartnett, 1/10/23
 name: MacOS

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -32,6 +32,13 @@ jobs:
       with: 
         path: bufr
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v2
+      with:
+        path: ~/data
+        key: data-1
+
     - name: build-bufr
       run: |
         cd bufr
@@ -48,3 +55,9 @@ jobs:
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
 
+    - name: cache-data
+      if: steps.cache-data.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/data
+        cp $GITHUB_WORKSPACE/bufr/build/test/bufr-11.6.0.tgz ~/data
+        

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
         cd bufr
         mkdir build 
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
+        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make -j2 VERBOSE=1
         make install
         cd python

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -33,6 +33,13 @@ jobs:
         path: bufr
         submodules: true
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v2
+      with:
+        path: ~/data
+        key: data-1
+
     - name: build
       run: |
         export CC=gcc-10
@@ -40,7 +47,7 @@ jobs:
         cd bufr
         mkdir build
         cd build
-        cmake -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0" -DCMAKE_C_FLAGS="-g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0" -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=On ..
+        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_Fortran_FLAGS="-g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0" -DCMAKE_C_FLAGS="-g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0" -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=On ..
         make -j2 VERBOSE=1
         make install
 
@@ -50,6 +57,12 @@ jobs:
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary -o test-coverage.html
 
+    - name: cache-data
+      if: steps.cache-data.outputs.cache-hit != 'true'
+      run: |
+        mkdir ~/data
+        cp $GITHUB_WORKSPACE/bufr/build/tests/bufr-11.6.0.tgz ~/data
+        
     - uses: actions/upload-artifact@v2
       with:
         name: test-coverage

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -61,7 +61,7 @@ jobs:
       if: steps.cache-data.outputs.cache-hit != 'true'
       run: |
         mkdir ~/data
-        cp $GITHUB_WORKSPACE/bufr/build/tests/bufr-11.6.0.tgz ~/data
+        cp $GITHUB_WORKSPACE/bufr/build/test/bufr-11.6.0.tgz ~/data
         
     - uses: actions/upload-artifact@v2
       with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,12 @@ option(ENABLE_PYTHON "Enable building python module 'ncepbufr'" OFF)
 option(BUILD_SHARED_LIBS "Enable building shared libraries" OFF)
 option(BUILD_TESTS "Build tests" ON)
 
+# Developers can use this option to specify a local directory which
+# holds the test files. They will be copied instead of fetching the
+# files via FTP.
+SET(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
+message(STATUS "Finding test data files in directory ${TEST_FILE_DIR}.")
+
 set(MASTER_TABLE_DIR "${CMAKE_INSTALL_PREFIX}/tables" CACHE STRING "Installation location of Master BUFR Tables")
 
 string(LENGTH "${MASTER_TABLE_DIR}" _lenmtd)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,9 +1,25 @@
+# This is the cmake build file for the tests directory of the
+# NCEPLIBS-bufr project.
+#
+# Rahul, Jeff Ator, Ed Hartnett
+
 # Fetch test data from: https://ftp.emc.ncep.noaa.gov/static_files/public/bufr.tar
 set(BUFR_URL "https://ftp.emc.ncep.noaa.gov/static_files/public")
 if(${PROJECT_VERSION} VERSION_GREATER_EQUAL 11.6.0)
   set(BUFR_TAR "bufr-11.6.0.tgz")
 else()
   set(BUFR_TAR "bufr.tar")
+endif()
+
+# If the TEST_FILE_DIR was specified, look for our test data files
+# there before FTPing them. Developers can keep all test files on
+# their machines, and save the time of downloading them every time.
+if(NOT ${TEST_FILE_DIR} STREQUAL ".")
+  if (EXISTS ${TEST_FILE_DIR}/${BUFR_TAR})
+    message(STATUS "Copying file ${TEST_FILE_DIR}/${BUFR_TAR} to test data directory.")
+    FILE(COPY ${TEST_FILE_DIR}/${BUFR_TAR}
+      DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+  endif()
 endif()
 
 if(NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${BUFR_TAR}")


### PR DESCRIPTION
Part of #281.
Fixes #241 

Add a cache directory for developer to store the data files so they don't have to be fetched by FTP. This can also be used in the CI to reduce the number of times that it has to download the data file.

Also hopefully this will solve at least some of the CI instability problems...