### PR TITLE
fixed utils doxygen

### DIFF
--- a/utils/binv.f90
+++ b/utils/binv.f90
@@ -3,7 +3,7 @@
 !>
 !> @author J Woollen @date 1994
 
-!> Usage: binv <bufrfile> will print bufrfile inventory by message type.
+!> Usage: binv \<bufrfile\> will print bufrfile inventory by message type.
 !>
 !> @return 0 for success, error message otherwise.
 !>

--- a/utils/cmpbqm.f90
+++ b/utils/cmpbqm.f90
@@ -3,7 +3,7 @@
 !>
 !> @author J Woollen @date 1997
 
-!> Usage: cmpbqm <prepbufrfile> will print prep inventory by variable, report type, and qc mark.
+!> Usage: cmpbqm \<prepbufrfile\> will print prep inventory by variable, report type, and qc mark.
 !>
 !> @return 0 for success, error message otherwise.
 !>

--- a/utils/sinv.f90.in
+++ b/utils/sinv.f90.in
@@ -3,7 +3,7 @@
 !>
 !> @author J Woollen @date 2010
 
-!> Usage: sinv <satbufrfile> will print inventory of satellites by platform and instrument.
+!> Usage: sinv \<satbufrfile\> will print inventory of satellites by platform and instrument.
 !>
 !> @return 0 for success, error message otherwise.
 !>


### PR DESCRIPTION
Fixes #297 

@jack-woollen and @jbathegit note how the backslash may be used to escape a character in documentation that otherwise would have special meaning...

