### PR TITLE
testing bort()

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
         cd bufr
         mkdir build 
         cd build
-        cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
+        cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=OFF ..
         make -j2 VERBOSE=1
         make install
         cd python

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
         cd bufr
         mkdir build 
         cd build
-        cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=OFF ..
+        cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
         make VERBOSE=1
         make install
         cd python

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -45,7 +45,7 @@ jobs:
         mkdir build 
         cd build
         cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=OFF ..
-        make -j2 VERBOSE=1
+        make VERBOSE=1
         make install
         cd python
         sudo python3 setup.py install

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -45,7 +45,7 @@ jobs:
         mkdir build 
         cd build
         cmake -DTEST_FILE_DIR=/Users/runner/data -DCMAKE_INSTALL_PREFIX=./install -DENABLE_PYTHON=ON ..
-        make VERBOSE=1
+        make -j2 VERBOSE=1
         make install
         cd python
         sudo python3 setup.py install

--- a/src/bort.f
+++ b/src/bort.f
@@ -9,7 +9,7 @@ C>
 C> It is similar to subroutine bort2(), except that bort2() logs
 C> two error messages instead of one.
 C>
-C> @param[in] STR   -- character*(*): Error message
+C> @param[in] STR - character*(*): Error message
 C>
 C> @author J. Woollen @date 1998-07-08
       SUBROUTINE BORT(STR)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -86,7 +86,7 @@ endforeach()
 file(COPY "${CMAKE_SOURCE_DIR}/test/run_test_bort.sh"
     DESTINATION ${CMAKE_BINARY_DIR}/test
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-add_test(NAME test_bort COMMAND ${CMAKE_BINARY_DIR}/test/run_test_bort.sh)
+add_test(NAME run_test_bort COMMAND ${CMAKE_BINARY_DIR}/test/run_test_bort.sh)
 
 # These are the C API tests.
 list(APPEND test_c_interface_srcs

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,9 @@
 #
 # Rahul Mahajan, Jeff Ator, Ed Hartnett
 
+# These are the kinds of tests we're going to build and run.
+list(APPEND test_kinds 4 8 d)
+
 # Fetch test data from: https://ftp.emc.ncep.noaa.gov/static_files/public/bufr.tar
 set(BUFR_URL "https://ftp.emc.ncep.noaa.gov/static_files/public")
 if(${PROJECT_VERSION} VERSION_GREATER_EQUAL 11.6.0)
@@ -70,6 +73,22 @@ function(create_test name kind num)
   endif()
 endfunction()
 
+# This is for testing bort().
+foreach(kind ${test_kinds})
+  add_executable(test_bort_${kind} test_bort.F90)
+  set_target_properties(test_bort_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  target_compile_definitions(test_bort_${kind} PUBLIC -DKIND_${kind})
+  target_link_libraries(test_bort_${kind} PRIVATE bufr_4)
+  add_dependencies(test_bort_${kind} bufr_4)
+endforeach()
+
+# Test the borts.
+file(COPY "${CMAKE_SOURCE_DIR}/test/run_test_bort.sh"
+    DESTINATION ${CMAKE_BINARY_DIR}/test
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+add_test(NAME test_bort COMMAND ${CMAKE_BINARY_DIR}/test/run_test_bort.sh)
+
+# These are the C API tests.
 list(APPEND test_c_interface_srcs
   test_c_interface.c
   test_c_interface_2.c
@@ -94,8 +113,6 @@ foreach(test_script ${test_scripts})
     ${CMAKE_CURRENT_SOURCE_DIR}/test_scripts/${test_script}
     ${CMAKE_BINARY_DIR}/bin/${test_script} )
 endforeach()
-
-list(APPEND test_kinds 4 8 d)
 
 foreach(kind ${test_kinds})
   foreach(innum RANGE 1 9)

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -6,11 +6,11 @@
 # Ed Hartnett 3/12/23
 
 ./test_bort_4 bort 1
-[ $? != 1 ] &&  return 1
+[ $? != 1 ] &&  exit 1
 
 ./test_bort_4 bort 2
-[ $? != 1 ] && return 1
+[ $? != 1 ] && exit 1
 
 # If we made it here, all error codes were correctly returned, and the
 # test passed!
-return 0
+exit 0

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -1,0 +1,21 @@
+# This is a test script for NCEPLIBS-bufr.
+#
+# This script tests aborts.
+#
+# Ed Hartnett 3/12/23
+
+./test_bort_4 bort 1
+if [[ $? != 1 ]]
+then
+    exit 1
+fi
+
+./test_bort_4 bort 2
+if [[ $? != 1 ]]
+then
+    exit 1
+fi
+
+# If we made it here, all error codes were correctly returned, and the
+# test passed!
+return 0

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -5,10 +5,10 @@
 # Ed Hartnett 3/12/23
 
 ./test_bort_4 bort 1
-[ $? != 1 ] &&  exit 1
+[ $? != 1 ] &&  return 1
 
 ./test_bort_4 bort 2
-[ $? != 1 ] && exit 1
+[ $? != 1 ] && return 1
 
 # If we made it here, all error codes were correctly returned, and the
 # test passed!

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 # This is a test script for NCEPLIBS-bufr.
 #
 # This script tests aborts.

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -5,16 +5,10 @@
 # Ed Hartnett 3/12/23
 
 ./test_bort_4 bort 1
-if [[ $? != 1 ]]
-then
-    exit 1
-fi
+[ $? != 1 ] &&  exit 1
 
 ./test_bort_4 bort 2
-if [[ $? != 1 ]]
-then
-    exit 1
-fi
+[ $? != 1 ] && exit 1
 
 # If we made it here, all error codes were correctly returned, and the
 # test passed!

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -1,0 +1,35 @@
+! This is a test for NCEPLIBS-bufr library.
+!
+! This tests the bort() calls of openbf().
+!
+! Ed Hartnett 3/12/23
+program test_bort
+  implicit none
+
+  integer :: num_args, len, status
+  character(len=32) :: sub_name, test_case
+  
+  num_args = command_argument_count()
+  if (num_args /= 2) then
+     print *, "Two command line arguments expected: subroutine name and test case"
+     stop 2
+  end if
+
+  ! Read the command line arguments, a name of subroutine, and a test
+  ! case number.
+  call get_command_argument(1, sub_name, len, status)
+  if (status .ne. 0) stop 3
+  call get_command_argument(2, test_case, len, status)
+  if (status .ne. 0) stop 4
+  print *, 'Testing ', sub_name, ' case ', test_case
+
+  ! Run the test for the subroutine and test case.
+  if (sub_name .eq. 'bort') then
+     if (test_case .eq. '1') then
+        call bort('goodbye!')
+     else if (test_case .eq. '2') then
+        call bort2('goodbye!', 'goodbye again!')
+     endif
+  endif
+  
+end program test_bort

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -1,6 +1,7 @@
 ! This is a test for NCEPLIBS-bufr library.
 !
-! This tests the bort() calls of openbf().
+! This tests the bort() and bort2() subroutines. It will also test the
+! bort() calls of other subroutines.
 !
 ! Ed Hartnett 3/12/23
 program test_bort


### PR DESCRIPTION
Part of #33 
Fixes #377

Testing bort() and bort2().

This PR also provides the way to test other bort() calls. In the program test_bort.F90, each abort case can be set up and run.

