### PR TITLE
documentation, more testing for adn30()/idn30(), changes in gcovr output

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -55,7 +55,7 @@ jobs:
       run: |
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
-        gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary -o test-coverage.html
+        gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary --exclude-unreachable-branches --exclude-throw-branches --decisions -o test-coverage.html
 
     - name: cache-data
       if: steps.cache-data.outputs.cache-hit != 'true'

--- a/src/adn30.f
+++ b/src/adn30.f
@@ -1,12 +1,11 @@
 C> @file
-C> @brief Convert an FXY value from its bit-wise (integer)
-C> representation to its five or six character representation.
+C> @brief Convert an FXY value from an integer
+C> to a character string of length 5 or 6.
 C>
 C> @author J. Woollen @date 1994-01-06
 
-C> This function converts an FXY value from its bit-wise
-C> (integer) representation to its 5 or 6 character
-C> representation.
+C> This function converts an FXY value from an integer
+C> to a character string of length 5 or 6.
 C>
 C> This function is the logical inverse of function idn30().
 C>
@@ -26,7 +25,6 @@ C> @author J. Woollen @date 1994-01-06
 
 C----------------------------------------------------------------------
 C----------------------------------------------------------------------
-
       IF(LEN(ADN30).LT.L30         ) GOTO 900
       IF(IDN.LT.0 .OR. IDN.GT.65535) GOTO 901
       IF(L30.EQ.5) THEN

--- a/src/arallocc.c
+++ b/src/arallocc.c
@@ -17,15 +17,8 @@
  * dynamically allocate internal C language arrays based on parameter
  * values set during one or more previous calls to function isetprm().
  *
- * This subroutine isn't normally called directly from an application
- * program, since it's automatically called internally during the first
- * call to subroutine openbf() from an application program.
- *
- * @remarks
  * All memory allocated within this subroutine can be freed via a
- * subsequent call to subroutine exitbufr() from within the
- * application program, or else it will be freed automatically by the
- * operating system once the application program terminates.
+ * subsequent call to subroutine exitbufr().
  *
  * @author J. Ator @date 2014-12-04
  */

--- a/src/arallocf.f
+++ b/src/arallocf.f
@@ -1,6 +1,5 @@
 C> @file
-C> @brief Dynamically allocate Fortran language arrays within internal
-C> memory.
+C> @brief Dynamically allocate Fortran language arrays.
 C>
 C> @author J. Ator @date 2014-12-04
 
@@ -10,15 +9,8 @@ C> dynamically allocate internal Fortran language arrays based on
 C> parameter values set during one or more previous calls to function
 C> isetprm().
 C>
-C> This subroutine isn't normally called directly from an application
-C> program, since it's automatically called internally during the first
-C> call to subroutine openbf() from an application program.
-C>
-C> @remarks
-C> - All memory allocated within this subroutine can be freed via a
-C> subsequent call to subroutine exitbufr() from within the
-C> application program, or else it will be freed automatically by the
-C> operating system once the application program terminates.
+C> All memory allocated within this subroutine can be freed via a
+C> subsequent call to subroutine exitbufr(). 
 C>
 C> @author J. Ator @date 2014-12-04
         SUBROUTINE ARALLOCF

--- a/src/cwbmg.c
+++ b/src/cwbmg.c
@@ -7,19 +7,9 @@
 #include "cobfl.h"
 
 /**
- *  This subroutine writes a BUFR message to the system
- *  file that was opened via the most recent call to subroutine
- *  cobfl() with io = 'w'.
- *
- *  @author J. Ator
- *  @date 2005-11-29
- *
- *  @param[in] bmg    -- char*: BUFR message to be written
- *  @param[in] nmb    -- f77int*: Size (in bytes) of BUFR message
- *                        in bmg
- *  @param[out] iret  -- f77int*: return code
- *                         - 0 = normal return
- *                         - -1 = I/O error encountered while writing
+ * This subroutine writes a BUFR message to the system
+ * file that was opened via the most recent call to subroutine
+ * cobfl() with io = 'w'.
  *
  * This subroutine is designed to be easily callable from
  * application program written in either C or Fortran.
@@ -27,6 +17,13 @@
  * The file to which the message is to be written must have already
  * been opened for writing via a previous call to subroutine cobfl()
  * with io = 'w'.
+ *
+ * @param bmg - char *: pointer to BUFR message to be written.
+ * @param nmb - f77int *: pointer to the size (in bytes) of BUFR message
+ * in bmg
+ * @param iret - f77int *: pointer that gets the return code:
+ * - 0 normal return
+ * - -1 I/O error encountered while writing
  *
  * @author J. Ator @date 2005-11-29
  */

--- a/src/idn30.f
+++ b/src/idn30.f
@@ -1,19 +1,18 @@
 C> @file
-C> @brief Convert an FXY value from its five or six character
-C> representation to its bit-wise (integer) representation
+C> @brief Convert an FXY value from a character string of length 5
+C> or 6 to an integer.
 C>
 C> @author J. Woollen @date 1994-01-06
 
-C> This function converts an FXY value from its 5 or 6 character
-C> representation to its bit-wise (integer) representation.
+C> This function converts an FXY value from a character string of length 5
+C> or 6 to an integer.
 C>
-C> @param[in] ADN30 -- character*(*): FXY value
+C> This function is the logical inverse of function adn30().
+C>
+C> @param[in] ADN30 -- character*(*): FXY value. Must be of length 5 or 6.
 C> @param[in] L30 -- integer: Length of ADN30; can be either 5 or 6
-C>                   characters
-C> @returns idn30 -- integer: Bit-wise representation of FXY value
-C>
-C> @remarks
-C> - This function is the logical inverse of function adn30().
+C>                   characters.
+C> @returns idn30 -- integer: FXY integer value.
 C>
 C> @author J. Woollen @date 1994-01-06
       FUNCTION IDN30(ADN30,L30)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -88,6 +88,8 @@ endfunction()
 foreach(kind ${test_kinds})
   add_executable(test_bort_${kind} test_bort.F90)
   set_target_properties(test_bort_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  # Need to turn off a warning for test_bort, so it can do stupid things needed to fail.
+  set_target_properties(test_bort_${kind} PROPERTIES COMPILE_FLAGS -Wno-character-truncation)
   target_compile_definitions(test_bort_${kind} PUBLIC -DKIND_${kind})
   target_link_libraries(test_bort_${kind} PRIVATE bufr_4)
   add_dependencies(test_bort_${kind} bufr_4)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -58,6 +58,17 @@ add_custom_command(
 
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testrun)
 
+# This function builds, links, and runs an ordinary Fortran test.
+function(create_test_plain name kind)
+  set(testID "${name}_${kind}")
+  add_executable(${testID} ${name}.F90)
+  set_target_properties(${testID} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags}")
+  target_compile_definitions(${testID} PUBLIC -DKIND_${kind})
+  target_link_libraries(${testID} PRIVATE bufr_4)
+  add_dependencies(${testID} bufr_4)
+  add_test(NAME ${testID} COMMAND ${testID})
+endfunction()
+
 # This function builds, links, and runs an intest or outtest program.
 function(create_test name kind num)
   set(testID "${name}${num}_${kind}")
@@ -82,7 +93,9 @@ foreach(kind ${test_kinds})
   add_dependencies(test_bort_${kind} bufr_4)
 endforeach()
 
-# Test the borts.
+# Test the borts. This runs test script run_test_bort.sh, which
+# repeatedly calls program test_bort, and expects each time for the
+# program to be aborted.
 file(COPY "${CMAKE_SOURCE_DIR}/test/run_test_bort.sh"
     DESTINATION ${CMAKE_BINARY_DIR}/test
     FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
@@ -114,7 +127,9 @@ foreach(test_script ${test_scripts})
     ${CMAKE_BINARY_DIR}/bin/${test_script} )
 endforeach()
 
+# Create our IN and OUT tests, plus any other tests we want to run.
 foreach(kind ${test_kinds})
+  create_test_plain(test_misc ${kind})
   foreach(innum RANGE 1 10)
     create_test(intest ${kind} ${innum})
   endforeach()

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -1,7 +1,11 @@
 #!/bin/sh
 # This is a test script for NCEPLIBS-bufr.
 #
-# This script tests aborts.
+# This script tests aborts. It does this by calling the program
+# test_bort.F90 with two arguments, the subroutine name and the test
+# case (a number). The program test_bort.F90 has code for each
+# subroutine name and test case, which causes an abort. This script
+# then checks that test_bort.F90 aborted as expected.
 #
 # Ed Hartnett 3/12/23
 

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -14,6 +14,8 @@
 [ $? != 1 ] &&  exit 1
 ./test_bort_4 adn30 2
 [ $? != 1 ] &&  exit 1
+./test_bort_4 adn30 3
+[ $? != 1 ] &&  exit 1
 
 # Check bort().
 ./test_bort_4 bort 1

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -18,6 +18,8 @@
 [ $? != 1 ] &&  exit 1
 ./test_bort_4 adn30 4
 [ $? != 1 ] &&  exit 1
+./test_bort_4 adn30 5
+[ $? != 1 ] &&  exit 1
 
 # Check bort().
 ./test_bort_4 bort 1
@@ -57,6 +59,8 @@
 ./test_bort_4 idn30 2
 [ $? != 1 ] &&  exit 1
 ./test_bort_4 idn30 3
+[ $? != 1 ] &&  exit 1
+./test_bort_4 idn30 4
 [ $? != 1 ] &&  exit 1
 
 # Check sntbbe().

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -16,6 +16,8 @@
 [ $? != 1 ] &&  exit 1
 ./test_bort_4 adn30 3
 [ $? != 1 ] &&  exit 1
+./test_bort_4 adn30 4
+[ $? != 1 ] &&  exit 1
 
 # Check bort().
 ./test_bort_4 bort 1

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -51,6 +51,14 @@
 ./test_bort_4 copysb 1
 [ $? != 1 ] &&  exit 1
 
+# Check idn30().
+./test_bort_4 idn30 1
+[ $? != 1 ] &&  exit 1
+./test_bort_4 idn30 2
+[ $? != 1 ] &&  exit 1
+./test_bort_4 idn30 3
+[ $? != 1 ] &&  exit 1
+
 # Check sntbbe().
 ./test_bort_4 sntbbe 1
 [ $? != 1 ] &&  exit 1

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -3,6 +3,10 @@
 ! This tests the bort() and bort2() subroutines. It will also test the
 ! bort() calls of other subroutines.
 !
+! This program is called (repeatedly) by run_test_bort.sh, which
+! passes in a series of subroutine names and test case numbers, and
+! expects each case to cause an abort.
+!
 ! Ed Hartnett 3/12/23
 program test_bort
   implicit none

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -52,6 +52,8 @@ program test_bort
      elseif (test_case .eq. '3') then
         char_30 = adn30(-1, 5)
      elseif (test_case .eq. '4') then
+        char_30 = adn30(65536, 5)
+     elseif (test_case .eq. '5') then
         char_30 = adn30(0, 3)
      endif
   elseif (sub_name .eq. 'bort') then
@@ -92,7 +94,9 @@ program test_bort
      elseif (test_case .eq. '2') then
         idn30_val = idn30(adn30_val_5, 2)
      elseif (test_case .eq. '3') then
-        idn30_val = idn30('-0042', 2)
+        idn30_val = idn30('-0042', 5)
+     elseif (test_case .eq. '4') then
+        idn30_val = idn30('65536', 5)
      endif
   elseif (sub_name .eq. 'sntbbe') then
      if (test_case .eq. '1') then

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -50,6 +50,8 @@ program test_bort
         char_30 = adn30(0, 9)
      elseif (test_case .eq. '3') then
         char_30 = adn30(-1, 5)
+     elseif (test_case .eq. '4') then
+        char_30 = adn30(0, 3)
      endif
   elseif (sub_name .eq. 'bort') then
      if (test_case .eq. '1') then
@@ -199,5 +201,5 @@ program test_bort
      print *, "Unknown test function"
      stop 2
   endif
-  
+
 end program test_bort

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -26,7 +26,7 @@ program test_bort
 
   integer :: num_args, len, status
   character(len=32) :: sub_name, test_case
-  character adn30
+  character*5 adn30
   
   num_args = command_argument_count()
   if (num_args /= 2) then
@@ -45,9 +45,11 @@ program test_bort
   ! Run the test for the subroutine and test case.
   if (sub_name .eq. 'adn30') then
      if (test_case .eq. '1') then
-        char_short = adn30(0, 5)
+        char_short = adn30(0, 6)
      elseif (test_case .eq. '2') then
         char_30 = adn30(0, 9)
+     elseif (test_case .eq. '3') then
+        char_30 = adn30(-1, 5)
      endif
   elseif (sub_name .eq. 'bort') then
      if (test_case .eq. '1') then

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -20,10 +20,11 @@ program test_bort
   character*12 char_12(1)
   character*24 char_24(1)
   character*120 char_120(1)
+  character*5 adn30_val_5
   real r, valx
   real*8 real_1d(1)
   real*8 real_2d(1,1)
-
+  integer idn30, idn30_val
   integer :: num_args, len, status
   character(len=32) :: sub_name, test_case
   character*5 adn30
@@ -84,6 +85,14 @@ program test_bort
   elseif (sub_name .eq. 'copysb') then
      if (test_case .eq. '1') then
         call copysb(0, 0, iret)     
+     endif
+  elseif (sub_name .eq. 'idn30') then
+     if (test_case .eq. '1') then
+        idn30_val = idn30(adn30_val_5, 6)
+     elseif (test_case .eq. '2') then
+        idn30_val = idn30(adn30_val_5, 2)
+     elseif (test_case .eq. '3') then
+        idn30_val = idn30('-0042', 2)
      endif
   elseif (sub_name .eq. 'sntbbe') then
      if (test_case .eq. '1') then

--- a/test/test_misc.F90
+++ b/test/test_misc.F90
@@ -1,0 +1,20 @@
+! This is a test for NCEPLIBS-bufr library.
+!
+! This tests random subroutines that needed some tests to complete
+! test code coverage.
+!
+! Ed Hartnett 3/17/23
+program test_bort
+  implicit none
+  character*5 char5
+  character*5 adn30
+  integer a, idn30
+
+  print *, 'Testing misc subroutines.'
+  char5 = adn30(42, 5)
+  if (char5 .ne. '00042') stop 1
+  a = idn30(char5, 5)
+  if (a .ne. 42) stop 2
+  print *, 'SUCCESS'
+  
+end program test_bort


### PR DESCRIPTION
Fixes #389

Some documentation fixes, adding tests for adn30()/idn30() to bring them to full testing.

Also some changes to the gcovr run, adding some new parameters, which results in better tracking of branches testes, and a new column, "decisions", which is supposed to better help us ensure that all decisions are fully covered. We'll have to use this a bit to see how it helps.

See https://gcovr.com/en/stable/faq.html for info about the new gcovr options.
