### PR TITLE
using standard fortran internal read to demonstrate how strnum() may be replaced

### DIFF
--- a/test/test_misc.F90
+++ b/test/test_misc.F90
@@ -9,15 +9,17 @@ program test_bort
   character*5 char5
   character*5 adn30
   integer a, idn30
+  integer i1, i2, ios
+  character*8 st1, st2
 
   print *, 'Testing misc subroutines.'
   char5 = adn30(42, 5)
   if (char5 .ne. '00042') stop 1
   a = idn30(char5, 5)
   if (a .ne. 42) stop 2
-  print *, 'SUCCESS'
 
   ! Demonstrate how internal read can be used to replace strnum().
+  ! These work.
   st1 = '12'
   st2 = '10001'
   read(st1, '(I6)', iostat = ios) i1
@@ -27,23 +29,39 @@ program test_bort
   if (ios .ne. 0) stop 500
   if (i2 .ne. 10001) stop 501
 
+  ! THis fails because  the string is not numeric.
   st1 = 'slsls'
   read(st1, '(I6)', iostat = ios) i1
   if (ios .eq. 0) stop 500
 
+  ! This works.
   st1 = '+12'
   read(st1, '(I6)', iostat = ios) i1
   if (ios .ne. 0) stop 500
   if (i1 .ne. 12) stop 500
 
+  ! This works.
   st1 = '-12'
   read(st1, '(I6)', iostat = ios) i1
   if (ios .ne. 0) stop 500
   if (i1 .ne. -12) stop 500
 
+  ! THis fails because  the string is not numeric.
   st1 = '-12-'
   read(st1, '(I6)', iostat = ios) i1
   if (ios .eq. 0) stop 500
+
+  ! Blank input returns 0 just as we desire.
+  st1 = ' '
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. 0) stop 500
   
+  ! Blank input returns 0 just as we desire.
+  st1 = '   '
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. 0) stop 500
   
+  print *, 'SUCCESS'
 end program test_bort

--- a/test/test_misc.F90
+++ b/test/test_misc.F90
@@ -51,14 +51,20 @@ program test_bort
   read(st1, '(I6)', iostat = ios) i1
   if (ios .eq. 0) stop 500
 
-  ! Blank input returns 0 just as we desire.
+  ! One space for input returns 0 just as we desire.
   st1 = ' '
   read(st1, '(I6)', iostat = ios) i1
   if (ios .ne. 0) stop 500
   if (i1 .ne. 0) stop 500
   
-  ! Blank input returns 0 just as we desire.
+  ! Multiple spaces for input returns 0 just as we desire.
   st1 = '   '
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. 0) stop 500
+
+  ! Empty input returns 0 just as we desire.
+  st1 = ''
   read(st1, '(I6)', iostat = ios) i1
   if (ios .ne. 0) stop 500
   if (i1 .ne. 0) stop 500

--- a/test/test_misc.F90
+++ b/test/test_misc.F90
@@ -16,5 +16,34 @@ program test_bort
   a = idn30(char5, 5)
   if (a .ne. 42) stop 2
   print *, 'SUCCESS'
+
+  ! Demonstrate how internal read can be used to replace strnum().
+  st1 = '12'
+  st2 = '10001'
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. 12) stop 500
+  read(st2, '(I6)', iostat = ios) i2
+  if (ios .ne. 0) stop 500
+  if (i2 .ne. 10001) stop 501
+
+  st1 = 'slsls'
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .eq. 0) stop 500
+
+  st1 = '+12'
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. 12) stop 500
+
+  st1 = '-12'
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .ne. 0) stop 500
+  if (i1 .ne. -12) stop 500
+
+  st1 = '-12-'
+  read(st1, '(I6)', iostat = ios) i1
+  if (ios .eq. 0) stop 500
+  
   
 end program test_bort


### PR DESCRIPTION
Part of https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/369

@jbathegit take a look at the code in test_misc.F90. Doesn't it do everything that strnum() does, using only standard Fortran internal reads?