### PR TITLE
added module doc

### DIFF
--- a/src/bufr_interface.F90
+++ b/src/bufr_interface.F90
@@ -4,6 +4,10 @@
 !>
 !> @author J. Ator @date 2023-03-22
 
+!> @brief Define signatures to enable a number of BUFRLIB functions to be called
+!>        via wrapper functions from Fortran application programs.
+!>
+!> @author J. Ator @date 2023-03-22
 module bufr_interface
 
 interface


### PR DESCRIPTION
Part of #397 

@jbathegit I forgot to mention this in code review, but we need doxygen documentation for every module as well. Even if it's a repeat of the file documentation block, as in this case.

Doxygen needs a brief description of the module as well as the file.