### PR TITLE
Update python/CMakeLists.txt to fix Python version

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,8 +8,7 @@ configure_file(setup.py.in setup.py @ONLY)
 file( COPY ncepbufr utils DESTINATION . )
 
 # Library installation directory
-execute_process(COMMAND ${Python3_EXECUTABLE} -c "from __future__ import print_function; import sys; print(sys.version[:3], end='')"
-                  OUTPUT_VARIABLE _PYVER)
+set(_PYVER "${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}")
 set(_install_dir "${CMAKE_INSTALL_FULL_LIBDIR}/python${_PYVER}/site-packages")
 
 # Build the extension module for use in install tree


### PR DESCRIPTION
The current logic in `python/CMakeLists.txt` detects incorrect Python versions. `3.10` gets truncated to `3.1`.

This fixes it