### PR TITLE
Feature/expose readlc c

### DIFF
--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -589,23 +589,23 @@ module bufr_c2f_interface
 
     !> Function used to get long strings from the BUFR file.
     !>
-    !> @param lun - File ID.
+    !> @param lunit - Fortran logical unit.
     !> @param str_id - Mnemonic for the string for the source field plus the index number
     !>                 (ex: 'IDMN#2')
     !> @param output_str - The pre-allocated result string
     !> @param output_str_len - The length of the result string
     !>
     !> @author Ronald McLaren @date 2023-07-03
-    subroutine readlc_c(lun, str_id, output_str, output_str_len) bind(C, name='readlc_f')
+    subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')
       use moda_rlccmn
-      integer(c_int), value, intent(in) :: lun
+      integer(c_int), value, intent(in) :: lunit
       character(kind=c_char, len=1), intent(in) :: str_id
-      character(kind=c_char, len=1), intent(out) :: output_str
+      character(kind=c_char), intent(out) :: output_str(*)
       integer(c_int), intent(out) :: output_str_len
 
       character(len=120) :: output_str_f
 
-      call readlc(lun, output_str_f , c_f_string(str_id))
+      call readlc(lunit, output_str_f , c_f_string(str_id))
       call copy_f_c_str(output_str_f, output_str, len(output_str_f))
       output_str_len = len(trim(output_str_f))
     end subroutine readlc_c

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -599,7 +599,7 @@ module bufr_c2f_interface
     subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')
       use moda_rlccmn
       integer(c_int), value, intent(in) :: lunit
-      character(kind=c_char, len=1), intent(in) :: str_id
+      character(kind=c_char, len=1), intent(in) :: str_id(*)
       character(kind=c_char, len=1), intent(out) :: output_str(*)
       integer(c_int), intent(out) :: output_str_len
 

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -610,51 +610,6 @@ module bufr_c2f_interface
       output_str_len = len(trim(output_str_f))
     end subroutine readlc_c
 
-!    !> Get pointer to the moda_usrint INV array.
-!    !>
-!    !> @param lun - File ID.
-!    !> @param inv_ptr - C-style pointer to the INV array
-!    !> @param inv_size - Length of the array
-!    !>
-!    !> @author Ronald McLaren @date 2022-03-23
-!    subroutine get_long_str_c(lun, node_idx, str_ptr, str_len) bind(C, name='get_long_str_f')
-!      use moda_usrint
-!      use moda_usrbit
-!      use moda_unptyp
-!      use moda_bitbuf
-!      use moda_tables
-!      use moda_rlccmn
-!
-!      integer(c_int), value, intent(in) :: lun
-!      integer(c_int), intent(in) :: node_idx
-!      character(kind=c_char, len=1), intent(inout) :: c_str(*)
-!      integer(c_int), intent(out) :: str_len
-!
-!      character f_str(*)
-!      integer str_idx
-!      integer kbit
-!
-!      if (msgunp(lun) .eq. 0 .or. msgunp(lun).eq.1) then
-!        ! The message is uncompressed
-!        str_len = nbit(node_idx)/8
-!        kbit = mbit(node_idx)
-!      elseif (msgunp(lun) .eq. 2) then
-!        ! The message is compressed
-!        do str_idx=1,nrst
-!          if (tag(node_idx) .eq. crtag(str_idx)) then
-!            str_len = irnch(str_idx)
-!            kbit = irbit(str_idx)
-!          end if
-!        end do
-!      endif
-!
-!      call upc(f_str, str_len, mbay(1, lun), kbit, .true.)
-!      call copy_f_c_str(f_str, c_str, str_len)
-!
-!    end subroutine get_long_str_c
-
-
-
     !> Deletes the copies of the moda_tables arrays.
     !>
     !> @author Ronald McLaren @date 2022-03-23

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -587,6 +587,74 @@ module bufr_c2f_interface
       inv_ptr = c_loc(inv(1, lun))
     end subroutine get_inv_c
 
+    !> Function used to get long strings from the BUFR file.
+    !>
+    !> @param lun - File ID.
+    !> @param str_id - Mnemonic for the string for the source field plus the index number
+    !>                 (ex: 'IDMN#2')
+    !> @param output_str - The pre-allocated result string
+    !> @param output_str_len - The length of the result string
+    !>
+    !> @author Ronald McLaren @date 2023-07-03
+    subroutine readlc_c(lun, str_id, output_str, output_str_len) bind(C, name='readlc_f')
+      use moda_rlccmn
+      integer(c_int), value, intent(in) :: lun
+      character(kind=c_char, len=1), intent(in) :: str_id
+      character(kind=c_char, len=1), intent(out) :: output_str
+      integer(c_int), intent(out) :: output_str_len
+
+      character(len=120) :: output_str_f
+
+      call readlc(lun, output_str_f , c_f_string(str_id))
+      call copy_f_c_str(output_str_f, output_str, len(output_str_f))
+      output_str_len = len(trim(output_str_f))
+    end subroutine readlc_c
+
+!    !> Get pointer to the moda_usrint INV array.
+!    !>
+!    !> @param lun - File ID.
+!    !> @param inv_ptr - C-style pointer to the INV array
+!    !> @param inv_size - Length of the array
+!    !>
+!    !> @author Ronald McLaren @date 2022-03-23
+!    subroutine get_long_str_c(lun, node_idx, str_ptr, str_len) bind(C, name='get_long_str_f')
+!      use moda_usrint
+!      use moda_usrbit
+!      use moda_unptyp
+!      use moda_bitbuf
+!      use moda_tables
+!      use moda_rlccmn
+!
+!      integer(c_int), value, intent(in) :: lun
+!      integer(c_int), intent(in) :: node_idx
+!      character(kind=c_char, len=1), intent(inout) :: c_str(*)
+!      integer(c_int), intent(out) :: str_len
+!
+!      character f_str(*)
+!      integer str_idx
+!      integer kbit
+!
+!      if (msgunp(lun) .eq. 0 .or. msgunp(lun).eq.1) then
+!        ! The message is uncompressed
+!        str_len = nbit(node_idx)/8
+!        kbit = mbit(node_idx)
+!      elseif (msgunp(lun) .eq. 2) then
+!        ! The message is compressed
+!        do str_idx=1,nrst
+!          if (tag(node_idx) .eq. crtag(str_idx)) then
+!            str_len = irnch(str_idx)
+!            kbit = irbit(str_idx)
+!          end if
+!        end do
+!      endif
+!
+!      call upc(f_str, str_len, mbay(1, lun), kbit, .true.)
+!      call copy_f_c_str(f_str, c_str, str_len)
+!
+!    end subroutine get_long_str_c
+
+
+
     !> Deletes the copies of the moda_tables arrays.
     !>
     !> @author Ronald McLaren @date 2022-03-23

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -600,7 +600,7 @@ module bufr_c2f_interface
       use moda_rlccmn
       integer(c_int), value, intent(in) :: lunit
       character(kind=c_char, len=1), intent(in) :: str_id
-      character(kind=c_char), intent(out) :: output_str(*)
+      character(kind=c_char, len=1), intent(out) :: output_str(*)
       integer(c_int), intent(out) :: output_str_len
 
       character(len=120) :: output_str_f

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -606,7 +606,7 @@ module bufr_c2f_interface
       character(len=120) :: output_str_f
       integer :: output_str_len_f
 
-      call readlc(lunit, output_str_f , c_f_string(str_id))
+      call readlc(lunit, output_str_f, c_f_string(str_id))
       output_str_len_f = len(trim(output_str_f)) + 1  ! add 1 for the null terminator
       call copy_f_c_str(output_str_f, output_str, min(output_str_len_f, output_str_len))
     end subroutine readlc_c

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -26,7 +26,7 @@ module bufr_c2f_interface
   public :: ufbint_c, ufbrep_c, ufbseq_c
   public :: mtinfo_c, bvers_c, status_c, ibfms_c
   public :: get_isc_c, get_link_c, get_itp_c, get_typ_c, get_tag_c, get_jmpb_c
-  public :: get_inode_c, get_nval_c, get_val_c, get_inv_c, get_irf_c
+  public :: get_inode_c, get_nval_c, get_val_c, get_inv_c, get_irf_c, readlc_c
   public :: delete_table_data_c
   public :: iupbs01_c, iupb_c, imrkopr_c, istdesc_c, ifxy_c
   public :: igetntbi_c, igettdi_c, stntbi_c

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -593,7 +593,7 @@ module bufr_c2f_interface
     !> @param str_id - Mnemonic for the string for the source field plus the index number
     !>                 (ex: 'IDMN#2')
     !> @param output_str - The pre-allocated result string
-    !> @param output_str_len - The length of the result string
+    !> @param output_str_len - Size of the result string buffer
     !>
     !> @author Ronald McLaren @date 2023-07-03
     subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -601,13 +601,14 @@ module bufr_c2f_interface
       integer(c_int), value, intent(in) :: lunit
       character(kind=c_char, len=1), intent(in) :: str_id(*)
       character(kind=c_char, len=1), intent(out) :: output_str(*)
-      integer(c_int), intent(out) :: output_str_len
+      integer(c_int), intent(in), value :: output_str_len
 
       character(len=120) :: output_str_f
+      integer :: output_str_len_f
 
       call readlc(lunit, output_str_f , c_f_string(str_id))
-      call copy_f_c_str(output_str_f, output_str, len(output_str_f))
-      output_str_len = len(trim(output_str_f))
+      output_str_len_f = len(trim(output_str_f)) + 1  ! add 1 for the null terminator
+      call copy_f_c_str(output_str_f, output_str, min(output_str_len_f, output_str_len))
     end subroutine readlc_c
 
     !> Deletes the copies of the moda_tables arrays.

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -372,9 +372,19 @@ extern "C" {
  */
   void get_inv_f(int lun, int** inv_ptr, int* inv_size);
 
+/**
+ *  Function used to get long strings from the BUFR file.
+ *
+ * @param lunit - Fortran logical unit.
+ * @param str_id - Mnemonic for the string for the source field plus the index number
+ *                  (ex: 'IDMN#2')
+ * @param output_str - The pre-allocated result string
+ * @param output_str_len - The length of the result string
+ *
+ * @author Ronald McLaren @date 2023-07-03
+ */
 
   void readlc_f(int lun, const char* str_id, char* output_str, int* output_str_len);
-
 
 /**
  * Deletes the copies of the moda_tables arrays.

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -379,7 +379,7 @@ extern "C" {
  * @param str_id - Mnemonic for the string for the source field plus the index number
  *                  (ex: 'IDMN#2')
  * @param output_str - The pre-allocated result string
- * @param output_str_len - The length of the result string
+ * @param output_str_len - Size of the result string buffer
  *
  * @author Ronald McLaren @date 2023-07-03
  */

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -373,7 +373,7 @@ extern "C" {
   void get_inv_f(int lun, int** inv_ptr, int* inv_size);
 
 
-  void readlc_f(int lun, char* str_id, char** output_str, int* output_str_len);
+  void readlc_f(int lun, const char* str_id, char* output_str, int* output_str_len);
 
 
 /**

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -372,6 +372,10 @@ extern "C" {
  */
   void get_inv_f(int lun, int** inv_ptr, int* inv_size);
 
+
+  void readlc_f(int lun, char* str_id, char** output_str, int* output_str_len);
+
+
 /**
  * Deletes the copies of the moda_tables arrays.
  *

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -384,7 +384,7 @@ extern "C" {
  * @author Ronald McLaren @date 2023-07-03
  */
 
-  void readlc_f(int lunit, const char* str_id, char* output_str, int* output_str_len);
+  void readlc_f(int lunit, const char* str_id, char* output_str, int output_str_len);
 
 /**
  * Deletes the copies of the moda_tables arrays.

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -384,7 +384,7 @@ extern "C" {
  * @author Ronald McLaren @date 2023-07-03
  */
 
-  void readlc_f(int lun, const char* str_id, char* output_str, int* output_str_len);
+  void readlc_f(int lunit, const char* str_id, char* output_str, int* output_str_len);
 
 /**
  * Deletes the copies of the moda_tables arrays.

--- a/src/irev.F
+++ b/src/irev.F
@@ -44,15 +44,9 @@ C----------------------------------------------------------------------
       IREV = N
 #else
       INT = N
-
-      DINT(1:1) = CINT(4:4)
-      DINT(2:2) = CINT(3:3)
-      DINT(3:3) = CINT(2:2)
-      DINT(4:4) = CINT(1:1)
-
-!     DO I=1,NBYTW
-!       DINT(I:I) = CINT(IORD(I):IORD(I))
-!     ENDDO
+      DO I=1,NBYTW
+        DINT(I:I) = CINT(IORD(I):IORD(I))
+      ENDDO
       IREV = JNT
 #endif
 

--- a/src/irev.F
+++ b/src/irev.F
@@ -44,9 +44,15 @@ C----------------------------------------------------------------------
       IREV = N
 #else
       INT = N
-      DO I=1,NBYTW
-        DINT(I:I) = CINT(IORD(I):IORD(I))
-      ENDDO
+
+      DINT(1:1) = CINT(4:4)
+      DINT(2:2) = CINT(3:3)
+      DINT(3:3) = CINT(2:2)
+      DINT(4:4) = CINT(1:1)
+
+!     DO I=1,NBYTW
+!       DINT(I:I) = CINT(IORD(I):IORD(I))
+!     ENDDO
       IREV = JNT
 #endif
 

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -126,7 +126,7 @@ void test_longStrings()
     int bufrLoc;
     int il, im; // throw away
 
-    char* long_str_ptr[120];
+    char long_str[120];
     int long_str_len_ptr;
 
     int subset_idx = 0;
@@ -135,13 +135,13 @@ void test_longStrings()
         while ((ireadsb_f(BUFR_FILE_UNIT) == 0) && (subset_idx < MAX_SUBSETS))
         {
             status_f(BUFR_FILE_UNIT, &bufrLoc, &il, &im);
-            readlc_f(BUFR_FILE_UNIT, mnemonic, &long_str_ptr, &long_str_len_ptr);
+            readlc_f(BUFR_FILE_UNIT, mnemonic, &long_str, &long_str_len_ptr);
             break;
         }
         break;
     }
 
-    if (strncmp(long_str_ptr, "MW41 2.17.0", 11) != 0)
+    if (strncmp(long_str, "MW41 2.17.0", 11) != 0)
     {
         printf("%s", "Didn't read the correct long string for SOFTV.");
         exit(1);

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -17,13 +17,14 @@ static const int BUFR_FILE_UNIT = 12;
 static const int SUBSET_STRING_LEN = 10;
 
 static const char* INPUT_FILE = "testfiles/data/1bamua";
+static const char* INPUT_FILE_LONG_STR = "testfiles/OUT_10";
 
 
 // Supporting functions
 
-unsigned int countSubsets(const char* subset)
+unsigned int countSubsets(const char* filePath, const char* subset)
 {
-    open_f(BUFR_FILE_UNIT, INPUT_FILE);
+    open_f(BUFR_FILE_UNIT, filePath);
     openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);
 
     int iddate;
@@ -58,7 +59,7 @@ void test_basicInterface()
     int iret;
     int iddate;
     char msg_subset[SUBSET_STRING_LEN];
-    unsigned int subset_cnt = countSubsets(subset);
+    unsigned int subset_cnt = countSubsets(INPUT_FILE, subset);
     unsigned int idx;
 
     open_f(BUFR_FILE_UNIT, INPUT_FILE);
@@ -106,6 +107,54 @@ void test_basicInterface()
             printf("%s", "Data from ufbint didn't match ufbrep!");
             exit(1);
         }
+    }
+
+    closbf_f(BUFR_FILE_UNIT);
+    close_f(BUFR_FILE_UNIT);
+}
+
+void test_longStrings()
+{
+    const char* subset = "NC002104";
+    const char* mnemonic = "SOFTV";
+
+    int iret;
+    int iddate;
+    char msg_subset[SUBSET_STRING_LEN];
+    unsigned int subset_cnt = countSubsets(INPUT_FILE_LONG_STR, subset);
+    unsigned int idx;
+
+    open_f(BUFR_FILE_UNIT, INPUT_FILE_LONG_STR);
+    openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);
+
+    int bufrLoc;
+    int il, im; // throw away
+
+    char* long_str_ptr[120];
+    int long_str_len_ptr;
+
+    int subset_idx = 0;
+    while (ireadmg_f(BUFR_FILE_UNIT, msg_subset, &iddate, SUBSET_STRING_LEN) == 0)
+    {
+        while ((ireadsb_f(BUFR_FILE_UNIT) == 0) && (subset_idx < MAX_SUBSETS))
+        {
+            status_f(BUFR_FILE_UNIT, &bufrLoc, &il, &im);
+            readlc_f(BUFR_FILE_UNIT, mnemonic, &long_str_ptr, &long_str_len_ptr);
+            break;
+        }
+        break;
+    }
+
+    if (strncmp(long_str_ptr, "MW41 2.17.0", 11) != 0)
+    {
+        printf("%s", "Didn't read the correct long string for SOFTV.");
+        exit(1);
+    }
+
+    if (long_str_len_ptr != 11)
+    {
+        printf("%s", "Didn't read the correct long string length for SOFTV.");
+        exit(1);
     }
 
     closbf_f(BUFR_FILE_UNIT);
@@ -478,6 +527,7 @@ void test_getTypeInfo()
 int main()
 {
     test_basicInterface();
+    test_longStrings();
     test_intrusiveInterface();
     test_getTypeInfo();
 

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -115,14 +115,10 @@ void test_basicInterface()
 
 void test_longStrings()
 {
-    const char* subset = "NC002104";
     const char* mnemonic = "SOFTV";
 
-    int iret;
     int iddate;
     char msg_subset[SUBSET_STRING_LEN];
-    unsigned int subset_cnt = countSubsets(INPUT_FILE_LONG_STR, subset);
-    unsigned int idx;
 
     open_f(BUFR_FILE_UNIT, INPUT_FILE_LONG_STR);
     openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -115,6 +115,7 @@ void test_basicInterface()
 
 void test_longStrings()
 {
+    static const int LONG_STR_LEN = 120;
     const char* mnemonic = "SOFTV";
 
     int iddate;
@@ -126,8 +127,7 @@ void test_longStrings()
     int bufrLoc;
     int il, im; // throw away
 
-    char long_str[120];
-    int long_str_len_ptr;
+    char long_str[LONG_STR_LEN];
 
     int subset_idx = 0;
     while (ireadmg_f(BUFR_FILE_UNIT, msg_subset, &iddate, SUBSET_STRING_LEN) == 0)
@@ -135,21 +135,21 @@ void test_longStrings()
         while ((ireadsb_f(BUFR_FILE_UNIT) == 0) && (subset_idx < MAX_SUBSETS))
         {
             status_f(BUFR_FILE_UNIT, &bufrLoc, &il, &im);
-            readlc_f(BUFR_FILE_UNIT, mnemonic, long_str, &long_str_len_ptr);
+            readlc_f(BUFR_FILE_UNIT, mnemonic, long_str, LONG_STR_LEN);
             break;
         }
         break;
     }
 
-    if (strncmp(long_str, "MW41 2.17.0", 11) != 0)
+    if (strlen(long_str) != 11)
     {
-        printf("%s", "Didn't read the correct long string for SOFTV.");
+        printf("%s", "Didn't read the correct long string length for SOFTV.");
         exit(1);
     }
 
-    if (long_str_len_ptr != 11)
+    if (strncmp(long_str, "MW41 2.17.0", 11) != 0)
     {
-        printf("%s", "Didn't read the correct long string length for SOFTV.");
+        printf("%s", "Didn't read the correct long string for SOFTV.");
         exit(1);
     }
 

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -135,7 +135,7 @@ void test_longStrings()
         while ((ireadsb_f(BUFR_FILE_UNIT) == 0) && (subset_idx < MAX_SUBSETS))
         {
             status_f(BUFR_FILE_UNIT, &bufrLoc, &il, &im);
-            readlc_f(BUFR_FILE_UNIT, mnemonic, &long_str, &long_str_len_ptr);
+            readlc_f(BUFR_FILE_UNIT, mnemonic, long_str, &long_str_len_ptr);
             break;
         }
         break;


### PR DESCRIPTION
Exposes the readlc method in the C interface. The function is used to retrieve long strings from the BUFR file (strings longer than an octet). 

Will need new tag after the merge in order to support ioda-converters unfortunately.