### PR TITLE
Build pdoc

### DIFF
--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -40,6 +40,13 @@ jobs:
         path: ~/data
         key: data-10
 
+    - name: build-docs
+      run: |
+        mkdir bufr/build-docs
+        cd bufr/build-docs
+        cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=ON -DENABLE_PYTHON=ON ..
+        make doc python_docs
+
     - name: build
       run: |
         cd bufr
@@ -54,13 +61,6 @@ jobs:
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary --exclude-unreachable-branches --exclude-throw-branches --decisions -o test-coverage.html
-
-    - name: build-docs
-      run: |
-        mkdir bufr/build-docs
-        cd build-docs
-        cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=ON -DENABLE_PYTHON=ON ..
-        make doc python_docs
 
     - name: cache-data
       if: steps.cache-data.outputs.cache-hit != 'true'

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -24,7 +24,7 @@ jobs:
     - name: install-deps
       run: |
           sudo apt-get update
-          sudo apt-get install doxygen
+          sudo apt-get install doxygen python3-numpy
           sudo python3 -m pip install -U gcovr pdoc
 
     - name: checkout

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -25,7 +25,7 @@ jobs:
       run: |
           sudo apt-get update
           sudo apt-get install doxygen
-          sudo python3 -m pip install -U gcovr
+          sudo python3 -m pip install -U gcovr pdoc
 
     - name: checkout
       uses: actions/checkout@v3
@@ -45,7 +45,7 @@ jobs:
         cd bufr
         mkdir build
         cd build
-        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_Fortran_FLAGS="-Werror -g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0 -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_C_FLAGS="-Werror -g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0 -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=On ..
+        cmake -DTEST_FILE_DIR=/home/runner/data -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_Fortran_FLAGS="-Werror -g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0 -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_C_FLAGS="-Werror -g -fprofile-arcs -ftest-coverage -fprofile-abs-path -O0 -fsanitize=address -fno-omit-frame-pointer" -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=OFF ..
         make -j2 VERBOSE=1
         make install
 
@@ -54,6 +54,13 @@ jobs:
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary --exclude-unreachable-branches --exclude-throw-branches --decisions -o test-coverage.html
+
+    - name: build-docs
+      run: |
+        mkdir bufr/build-docs
+        cd build-docs
+        cmake -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=./install -DCMAKE_BUILD_TYPE=Debug -DENABLE_DOCS=ON -DENABLE_PYTHON=ON ..
+        make doc python_docs
 
     - name: cache-data
       if: steps.cache-data.outputs.cache-hit != 'true'
@@ -72,4 +79,4 @@ jobs:
       with:
         name: docs
         path: |
-          bufr/build/docs/html
+          bufr/build-docs/docs/html

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -10,7 +10,7 @@
 
 ## Documentation for the Python API for NCEPLIBS-bufr
 
-* [The Python API documentation](https://noaa-emc.github.io/NCEPLIBS-bufr/python/index.html)
+* [The Python API documentation](python/index.html)
 
 ## Introduction
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -37,6 +37,7 @@ if(ENABLE_DOCS)
     ${CMAKE_COMMAND} -E env PYTHONPATH=${_lib_dir}:$ENV{PYTHONPATH}
     ${PDOC_EXECUTABLE} -o ../docs/html/python ./ncepbufr
   )
+  add_dependencies(python_docs doc python_mod)
 endif()
 
 install(DIRECTORY ${_lib_dir} DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}/python${_PYVER})


### PR DESCRIPTION
This PR enables python documentation through pdoc in the developer CI. It gets placed under the rest of the docs directory structure so it's in the same output artifact.

One caveat is that I've put the doc build in a separate CI step from the rest of the testing. This is because the use of the memory sanitizer and gcov don't play nicely with python. pdoc, for whatever reason, needs to load the python module, but when asan and gcov are enabled they put a bunch of special functions in the bufr library, so the python module load fails with "undefined reference" errors. I think the easiest solution is to put them in separate steps (as opposed to trying to hack together some LD_PRELOAD magic).

Fixes #230