### PR TITLE
add timing thresholds to test codes

### DIFF
--- a/test/outtest4.F90
+++ b/test/outtest4.F90
@@ -55,6 +55,20 @@ program outtest4
 
   character cmgtag*8, smid*9, dummystr*9
 
+  real cpu_time_start, cpu_time_end, cpu_secs
+  real*8 wall_secs
+  integer*8 wall_ctr_start, wall_ctr_end, wall_ctr_numpersec, wall_ctr_max, wall_ctr_total
+
+  ! Start the program timings.
+
+  call system_clock ( count_rate = wall_ctr_numpersec, count_max = wall_ctr_max )
+  print *, 'wall_ctr_numpersec, wall_ctr_max = ', wall_ctr_numpersec, wall_ctr_max
+  call system_clock ( count = wall_ctr_start )
+  print *, 'wall_ctr_start = ', wall_ctr_start
+
+  call cpu_time ( cpu_time_start )
+  print *, 'cpu_time_start = ', cpu_time_start
+
   print *, 'Testing writing OUT_4 using OPENBF IO = NODX and IO = QUIET, and using STRCPT, WRDXTB and WRITSA'
 
 #ifdef KIND_8
@@ -249,5 +263,19 @@ program outtest4
   call atrcpt(mgbf, lmgbf, mgbf2)
   ilenb = iupbs01(mgbf2, 'LENM')
   IF (ilenb-ilena .ne. 6) stop 20
+
+  ! End the program timings and check the results.
+
+  call system_clock ( count = wall_ctr_end )
+  print *, 'wall_ctr_end = ', wall_ctr_end
+  wall_ctr_total = wall_ctr_end - wall_ctr_start
+  if ( wall_ctr_total < 0 ) wall_ctr_total = wall_ctr_total + wall_ctr_max
+  wall_secs = real( wall_ctr_total, 8 ) / real( wall_ctr_numpersec, 8 )
+  print '("wall_secs = ",f8.3)', wall_secs
+
+  call cpu_time ( cpu_time_end )
+  print *, 'cpu_time_end = ', cpu_time_end
+  cpu_secs = cpu_time_end - cpu_time_start
+  print '("cpu_secs = ",f8.3)', cpu_secs
 
 end program outtest4


### PR DESCRIPTION
re: some other discussions we've been having in [spack-stack#589](https://github.com/NOAA-EMC/GSI/issues/589), and possibly also related to #527 and elsewhere, here's an idea for how to start moving forward with adding timing thresholds to the NCEPLIBS-bufr test codes.

This is just an example for how to do this in one of our many test codes that I picked at random, and the same thing could be done in all of other test/intest* and test/outtest* codes as well.  The idea is that we could eventually remove the extraneous 'print *,' statements for these values and instead compare each final cpu and wall time to some threshold and then just do a stop with a nonzero return inside of the code if the threshold is exceeded.  Of course we'd also need to do some baseline tests to figure out what those thresholds should even be.  But before doing any of that I wanted to put this out there to give you all a chance to comment, and in case you may have a better idea or know of a better or more standard way of doing this(?)

At some point we should probably set up similar timing tests on all of our utilities via the test_debufr.sh, test_sinv.sh, etc. scripts, but those would be a bit different b/c those are utilities that are used by the wider community, so we wouldn't want to embed any cpu_time or system_clock calls directly in those codes.  Instead, my thinking was maybe we use the UNIX `time` command whenever we run each test of that utility inside of the associated test_(utilityname).sh script, and then check the thresholds that way within the script.  But since the UNIX `time` command writes its results to stderr, we'd probably have to use something a bit kludgey along the lines of `{ time ../utils/debufr $args_n  2> /dev/null; } 2> timings_n` to capture those timings and then compare them to some threshold within the script.  Or maybe there's a better way to do that as well?