### PR TITLE
add NaN check to wrtree

### DIFF
--- a/src/wrtree.f
+++ b/src/wrtree.f
@@ -34,10 +34,14 @@ C  -----------------------------------------
       IF(ITP(NODE).EQ.1) THEN
          IVAL(N) = NINT(VAL(N,LUN))
       ELSEIF(TYP(NODE).EQ.'NUM') THEN
-         IF(IBFMS(VAL(N,LUN)).EQ.0) THEN
-            IVAL(N) = IPKS(VAL(N,LUN),NODE)
-         ELSE
+         IF( (IBFMS(VAL(N,LUN)).EQ.1) .OR.
+     .        (VAL(N,LUN).NE.VAL(N,LUN)) ) THEN
+
+C           The user number is either "missing" or NaN.
+
             IVAL(N) = -1
+         ELSE
+            IVAL(N) = IPKS(VAL(N,LUN),NODE)
          ENDIF
       ENDIF
       ENDDO

--- a/test/outtest6.F90
+++ b/test/outtest6.F90
@@ -40,6 +40,12 @@ program outtest6
   r8val = 16.
   call setvalnb ( 11, 'TMDB', 1, 'HOUR', -1, r8val, iersvb )
 
+  ! Try setting the value of the first occurrence of HOUR to NaN.
+  ! It should end up getting encoded as "missing" in the output.
+  r8val = -1
+  r8wind ( 1, 1 ) = sqrt( r8val )  ! r8wind(1,1) is now NaN
+  call ufbint ( 11, r8wind, 2, 1, nlv, 'HOUR' )
+
   r8dbss ( 1, 1 ) = 1.0
   r8dbss ( 2, 1 ) = 34.1
   r8dbss ( 3, 1 ) = 284.7


### PR DESCRIPTION
With NCEPLIBS-bufr versions <= 11.7.0, any NaN values that were passed to any of the writing/encoding subroutines would automatically get encoded into BUFR as "missing", which is what we'd expect.

However, we've now discovered that, with the changes in versions >= 11.7.1, any NaN values are now getting encoded into BUFR as 0.0.  This PR fixes that bug.