### PR TITLE
add testing for inctab, nemtbax and parutg

### DIFF
--- a/src/makestab.f
+++ b/src/makestab.f
@@ -250,12 +250,10 @@ C  -----------------------------------------
          VALI(NODE) = BMISS
          KNTI(NODE) = 1
          ITP (NODE) = 2
-      ELSEIF(TYP(NODE).EQ.'CHR') THEN
+      ELSE ! TYP(NODE).EQ.'CHR'
          VALI(NODE) = BMISS
          KNTI(NODE) = 1
          ITP (NODE) = 3
-      ELSE
-         GOTO 901
       ENDIF
       ENDDO
 
@@ -319,8 +317,6 @@ C  EXITS
 C  -----
 
       RETURN
-901   WRITE(BORT_STR,'("BUFRLIB: MAKESTAB - UNKNOWN TYPE ",A)')TYP(NODE)
-      CALL BORT(BORT_STR)
 902   WRITE(BORT_STR,'("BUFRLIB: MAKESTAB - NUMBER OF JSEQ ENTRIES IN'//
      . ' JUMP/LINK TABLE EXCEEDS THE LIMIT (",I6,")")') MAXJL
       CALL BORT(BORT_STR)

--- a/src/openbf.f
+++ b/src/openbf.f
@@ -114,9 +114,9 @@ C>                 - If IO is set to 'QUIET' = indicator for degree of
 C>                   printout:
 C>                      - -1 = no printout except for ABORT messages
 C>                      -  0 = limited printout (default)
-C>                      -  1 = all warning messages are printed out
+C>                      -  1 = all warning messages are printed
 C>                      -  2 = all warning and info messages are printed
-C>                      -  3 = high volume low level debug output prints
+C>                      -  3 = all warning, info and debug messages are printed
 C>
 C> @authors J. Woollen, J. Ator,  D. Keyser @date 1994-01-06
 

--- a/src/parutg.f
+++ b/src/parutg.f
@@ -12,7 +12,7 @@ C> not, nothing happens at this point. If it does, then the type of
 C> condition character is noted and the tag is stripped of all
 C> characters at and beyond the condition character. In either event,
 C> the resultant tag is checked against those in the internal jump/
-C> link subset table (in module tables). If found, the node
+C> link subset table (in module @ref moda_tables). If found, the node
 C> associated with the tag is returned (and it is either a "condition"
 C> node or a "store" node depending of the presence or absence of a
 C> condition character in UTG). Otherwise the node is returned as
@@ -217,7 +217,6 @@ C  -----
      . 'FOR MNEMONIC ",A)') ATYP,ATAG
       CALL BORT(BORT_STR1)
 903   WRITE(BORT_STR1,'("BUFRLIB: PARUTG - CONDITION VALUE IN '//
-     . 'MNEMONIC ",A," ILLEGAL BECAUSE ALL OTHER CHARACTERS IN '//
-     . 'MNEMONIC MUST BE NUMERIC")') UTG
+     . 'MNEMONIC ",A," CONTAINS NON-NUMERIC CHARACTERS")') UTG
       CALL BORT(BORT_STR1)
       END

--- a/src/tabent.f
+++ b/src/tabent.f
@@ -33,7 +33,6 @@ C     initialized within subroutine BFRINI.
 
       COMMON /TABCCC/ ICDW,ICSC,ICRV,INCW
 
-      CHARACTER*128 BORT_STR
       CHARACTER*24  UNIT
       CHARACTER*10  RTAG
       CHARACTER*8   NEMO
@@ -63,7 +62,6 @@ C  ---------------------------------------------
             GOTO 1
          ENDIF
          ENDDO
-         GOTO 900
       ENDIF
 
 C  MAKE AN JUMP/LINK ENTRY FOR AN ELEMENT OR A SEQUENCE
@@ -109,7 +107,7 @@ C           This node contains a new (redefined) reference value.
             IBT(NODE) = INCW * 8
          ENDIF
 
-      ELSEIF(TAB.EQ.'D') THEN
+      ELSE  ! TAB.EQ.'D'
 
          IF(IREP.EQ.0) THEN
             TYPT = 'SEQ'
@@ -124,21 +122,11 @@ C           This node contains a new (redefined) reference value.
          IRF (NODE) = 0
          ISC (NODE) = 0
 
-      ELSE
-
-         GOTO 901
-
       ENDIF
 
 C  EXITS
 C  -----
 
       RETURN
-900   WRITE(BORT_STR,'("BUFRLIB: TABENT - REPLICATOR ERROR FOR INPUT '//
-     . 'MNEMONIC ",A,", RTAG IS ",A)') NEMO,RTAG
-      CALL BORT(BORT_STR)
-901   WRITE(BORT_STR,'("BUFRLIB: TABENT - UNDEFINED TAG (",A,") FOR '//
-     . 'INPUT MNEMONIC ",A)') TAB,NEMO
-      CALL BORT(BORT_STR)
 902   CALL BORT('BUFRLIB: TABENT - MXNRV OVERFLOW')
       END

--- a/test/intest10.F90
+++ b/test/intest10.F90
@@ -63,10 +63,10 @@ program intest10
 
   ! Test some various out-of-bounds verbosity settings, and test the errwrt branch in arallocf.
   ! The verbosity level is the 3rd argument whenever the 2nd argument to openbf is 'QUIET'.  Any
-  ! request greater than 3 should automatically reset internally to the max value of 2, and any
+  ! request greater than 3 should automatically reset internally to the max value of 3, and any
   ! request less than -1 should automatically reset internally to the min value of -1.
   errstr_len = 0
-  call openbf ( 21, 'QUIET', 3 )
+  call openbf ( 21, 'QUIET', 4 )
   if ( index( errstr(1:errstr_len), 'ARRAYS WILL BE DYNAMICALLY ALLOCATED USING THE FOLLOWING VALUES' ) .eq. 0 ) stop 3
   call openbf ( 21, 'QUIET', -2 )
   call openbf ( 21, 'QUIET', 1 )

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -110,6 +110,9 @@ for kind in "4" "d"; do
     (./test_bort_$kind ifbget 2) && exit 1
     (./test_bort_$kind ifbget 3) && exit 1
 
+    # Check inctab().
+    (./test_bort_$kind inctab 1) && exit 1
+
     # Check isize().
     (./test_bort_$kind isize 1) && exit 1
     (./test_bort_$kind isize 2) && exit 1
@@ -144,6 +147,10 @@ for kind in "4" "d"; do
     # Check nemtba().
     (./test_bort_$kind nemtba 1) && exit 1
 
+    # Check nemtbax().
+    (./test_bort_$kind nemtbax 1) && exit 1
+    (./test_bort_$kind nemtbax 2) && exit 1
+
     # Check nemtbb().
     (./test_bort_$kind nemtbb 1) && exit 1
     (./test_bort_$kind nemtbb 2) && exit 1
@@ -173,8 +180,7 @@ for kind in "4" "d"; do
 
     # Check openmg().
     (./test_bort_$kind openmg 1) && exit 1
-    # Commented out. See https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/395.    
-    # (./test_bort_$kind openmg 2) && exit 1
+    (./test_bort_$kind openmg 2) && exit 1
 
     # Check parstr().
     (./test_bort_$kind parstr 1) && exit 1
@@ -188,6 +194,12 @@ for kind in "4" "d"; do
     (./test_bort_$kind parusr 4) && exit 1
     (./test_bort_$kind parusr 5) && exit 1
     (./test_bort_$kind parusr 6) && exit 1
+    (./test_bort_$kind parusr 7) && exit 1
+
+    # Check parutg().
+    (./test_bort_$kind parutg 1) && exit 1
+    (./test_bort_$kind parutg 2) && exit 1
+    (./test_bort_$kind parutg 3) && exit 1
 
     # Check pkb().
     (./test_bort_$kind pkb 1) && exit 1

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -394,6 +394,12 @@ program test_bort
         call openbf(12, 'OUT', 10)
         call ifbget(11)
      endif
+  elseif (sub_name .eq. 'inctab') then
+     if (test_case .eq. '1') then
+       if (isetprm('MAXJL',10) .ne. 0) stop 3
+       open(unit = 11, file = 'testfiles/OUT_1', iostat = ios)
+       call openbf(11, 'IN', 11)
+     endif
   elseif (sub_name .eq. 'isize') then
      if (test_case .eq. '1') then
         iret = isize(1000000)
@@ -475,6 +481,29 @@ program test_bort
         call openbf(11, 'IN', 11)
         call nemtba(11, 'SPOCK', mtyp, msbt, inod)
      endif
+  elseif (sub_name .eq. 'nemtbax') then
+     open(unit = 11, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
+     if (ios .ne. 0) stop 3
+     open(unit = 12, file = 'testfiles/test_bort_DX', iostat = ios)
+     if (ios .ne. 0) stop 3
+     if (test_case .eq. '1') then
+       char_val_8 = 'NC337200'
+     elseif (test_case .eq. '2') then
+       char_val_8 = 'NC007300'
+     endif
+     card = '| ' // char_val_8 // ' | A54124 | MTYPE TESTING                                            |'
+     write (12,'(A)') card
+     card = '| YEAR     | 004001 | YEAR                                                     |'
+     write (12,'(A)') card
+     card = '| NC337200 | YEAR                                                              |'
+     card = '| ' // char_val_8 // ' | YEAR                                                              |'
+     write (12,'(A)') card
+     card = '| YEAR     |    0 |           0 |  12 | YEAR                     |-------------|'
+     write (12,'(A)') card
+     close (12)
+     open(unit = 12, file = 'testfiles/test_bort_DX', iostat = ios)
+     call openbf(11, 'OUT', 12)
+     call openmg(11, char_val_8, 2024020112)
   elseif (sub_name .eq. 'nemtbb') then
      open(unit = 11, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
      if (ios .ne. 0) stop 3
@@ -598,14 +627,13 @@ program test_bort
         end do
      endif
   elseif (sub_name .eq. 'openmg') then
+     open(unit = 11, file = 'testfiles/IN_2', form = 'UNFORMATTED', iostat = ios)
+     if (ios .ne. 0) stop 3
      if (test_case .eq. '1') then
-        open(unit = 11, file = 'testfiles/IN_2', form = 'UNFORMATTED', iostat = ios)
-        if (ios .ne. 0) stop 3
         call openbf(11, 'IN', 11)
         call openmg(11, 'F5FCMESG', 2021022312)
-        ! Commented out. See https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/395.
-        !     elseif (test_case .eq. '2') then
-        !        call openmg(11, 'F5FCMESG', 2021022312)        
+     elseif (test_case .eq. '2') then
+        call openmg(11, 'F5FCMESG', 2021022312)
      endif
   elseif (sub_name .eq. 'parstr') then
      if (test_case .eq. '1') then
@@ -620,13 +648,23 @@ program test_bort
   elseif (sub_name .eq. 'parusr') then
      if (test_case .eq. '6') then
         open(unit = 11, file = 'testfiles/IN_3', form = 'UNFORMATTED', iostat = ios)
+     else if (test_case .eq. '7') then
+        open(unit = 11, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
      else
         open(unit = 11, file = 'testfiles/data/prepbufr', form = 'UNFORMATTED', iostat = ios)
      endif
      if (ios .ne. 0) stop 3
-     call openbf(11, 'IN', 11)
-     call readns(11, char_val_8, jdate, iret)
-     if (iret .ne. 0) stop 3
+     if (test_case .eq. '7') then
+        open(unit = 12, file = 'testfiles/OUT_7_bufrtab', iostat = ios)
+        if (ios .ne. 0) stop 3
+        call openbf(11, 'OUT', 12)
+        call openmg(11, 'NC002104', 2024020112)
+        call ufbint(11, real_2d, 1, 2, iret, 'RASCN>20')
+     else
+        call openbf(11, 'IN', 11)
+        call readns(11, char_val_8, jdate, iret)
+        if (iret .ne. 0) stop 3
+     endif
      if (test_case .eq. '1') then
         call parusr(char_85, 1, 1, 1)
      elseif (test_case .eq. '2') then
@@ -644,6 +682,20 @@ program test_bort
      elseif (test_case .eq. '6') then
         card = 'HGTSIG DCHSIG                                                                   '
         call parusr(card, 1, 2, 0)
+     endif
+  elseif (sub_name .eq. 'parutg') then
+     open(unit = 12, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
+     if (ios .ne. 0) stop 3
+     open(unit = 10, file = 'testfiles/OUT_7_bufrtab', iostat = ios)
+     if (ios .ne. 0) stop 3
+     call openbf(12, 'OUT', 10)
+     call openmg(12, 'NC002104', 2024020112)
+     if (test_case .eq. '1') then
+        call ufbint(12, real_2d, 1, 2, iret, 'RATCN>20')
+     elseif (test_case .eq. '2') then
+        call ufbint(12, real_2d, 1, 2, iret, 'RASCN>2t')
+     elseif (test_case .eq. '3') then
+        call ufbint(12, real_2d, 1, 2, iret, 'UARLVB')
      endif
   elseif (sub_name .eq. 'pkb') then
      if (test_case .eq. '1') then


### PR DESCRIPTION
Part of #445

This PR also removes some unreachable bort tests:
- In makestab, there's no way to have an illegal/unknown typ value for the 901 case, since all of its possible values are already controlled inside of the library via prior calls to tabsub and tabent.  I suspect the 902 case may also be unreachable, since any overflow of MAXJL would likely have been flagged earlier by the similar bort within inctab.
- In tabent, there's no way to hit the 900 case, since this could only happen if a mnemonic was longer than 8 characters, but that would have already been flagged earlier by calling nemock from within rdusdx, seqsdx, sntbbe or sntbde.  Similarly, the 901 case is also unreachable since tabent is only ever called internally by tabsub with a tab value of either 'B' or 'D'.
