### PR TITLE
still more tests

### DIFF
--- a/src/bfrini.F90.in
+++ b/src/bfrini.F90.in
@@ -14,7 +14,7 @@
 !> @authors J. Woollen J. Ator @date 1994-01-06
 subroutine bfrini
 
-use modv_vars, only: maxjl, maxtba, maxtbb, maxtbd, mxmsgl, nfiles
+use modv_vars, only: maxtba, maxtbb, maxtbd, mxmsgl, nfiles
 
 use moda_stbfr
 use moda_idrdm
@@ -24,7 +24,6 @@ use moda_bufrmg
 use moda_bufrsr
 use moda_tababd
 use moda_usrint
-use moda_tables
 use moda_h4wlc
 use moda_dscach
 
@@ -170,10 +169,6 @@ do J=1,10
     call ipkm(DXSTR(J)(I1:I1),2,ifxy(DNDX(I,J)))
   enddo
 enddo
-
-!  Initialize module moda_tables
-
-maxtab = maxjl
 
 !  Initialize module moda_bufrmg
 

--- a/src/inctab.f
+++ b/src/inctab.f
@@ -19,6 +19,8 @@ C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE INCTAB(ATAG,ATYP,NODE)
 
+      use modv_vars, only: maxjl
+
       use moda_tables
 
       CHARACTER*(*) ATAG,ATYP
@@ -28,7 +30,7 @@ C-----------------------------------------------------------------------
 C-----------------------------------------------------------------------
 
       NTAB = NTAB+1
-      IF(NTAB.GT.MAXTAB) GOTO 900
+      IF(NTAB.GT.MAXJL) GOTO 900
       TAG(NTAB) = ATAG
       TYP(NTAB) = ATYP
       NODE = NTAB
@@ -38,6 +40,6 @@ C  -----
 
       RETURN
  900  WRITE(BORT_STR,'("BUFRLIB: INCTAB - THE NUMBER OF JUMP/LINK '//
-     . 'TABLE ENTRIES EXCEEDS THE LIMIT, MAXTAB (",I7,")")') MAXTAB
+     . 'TABLE ENTRIES EXCEEDS THE LIMIT, MAXJL (",I7,")")') MAXJL
       CALL BORT(BORT_STR)
       END

--- a/src/modules_arrs.F90
+++ b/src/modules_arrs.F90
@@ -658,8 +658,6 @@ end module moda_tababd
 !>
 !> @author J. Ator @date 2014-12-10
 module moda_tables
-  !> Maximum number of entries in the jump/link table; equivalent to maxjl.
-  integer :: maxtab
   !> Number of entries in the jump/link table.
   integer :: ntab
   !> Mnemonics in the jump/link table.

--- a/src/ufbovr.f
+++ b/src/ufbovr.f
@@ -38,9 +38,9 @@ C> @author Woollen @date 1994-01-06
       CHARACTER*(*) STR
       REAL*8        USR(I1,I2)
 
-      DATA IFIRST1/0/,IFIRST2/0/
+      DATA IFIRST1/0/
 
-      SAVE IFIRST1, IFIRST2
+      SAVE IFIRST1
 
 C----------------------------------------------------------------------
 C----------------------------------------------------------------------
@@ -118,31 +118,6 @@ C  ----------------------------------------------------
       CALL TRYBUMP(LUN,USR,I1,I2,IO,IRET)
 
       IF(IO.EQ.1 .AND. IRET.NE.I2) GOTO 904
-
-      IF(IRET.EQ.0)  THEN
-         IF(IPRT.EQ.-1)  IFIRST2 = 1
-         IF(IFIRST2.EQ.0 .OR. IPRT.GE.1)  THEN
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      ERRSTR = 'BUFRLIB: UFBOVR - NO SPECIFIED VALUES WRITTEN OUT, ' //
-     .   'SO RETURN WITH 5th ARG. (IRET) = 0; 6th ARG. (STR) ='
-      CALL ERRWRT(ERRSTR)
-      CALL ERRWRT(STR)
-      CALL ERRWRT('MAY NOT BE IN THE BUFR TABLE(?)')
-               IF(IPRT.EQ.0) THEN
-      ERRSTR = 'Note: Only the first occurrence of this WARNING ' //
-     .   'message is printed, there may be more.  To output all ' //
-     .   'such messages,'
-      CALL ERRWRT(ERRSTR)
-      ERRSTR = 'modify your application program to add ' //
-     .   '"CALL OPENBF(0,''QUIET'',1)" prior to the first call ' //
-     .   'to a BUFRLIB routine.'
-      CALL ERRWRT(ERRSTR)
-               ENDIF
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      CALL ERRWRT(' ')
-            IFIRST2 = 1
-         ENDIF
-      ENDIF
 
 C  EXITS
 C  -----

--- a/src/ufbrep.f
+++ b/src/ufbrep.f
@@ -124,9 +124,9 @@ C> @author J. Woollen @date 1994-01-06
       CHARACTER*128 BORT_STR1,BORT_STR2,ERRSTR
       REAL*8        USR(I1,I2)
 
-      DATA IFIRST1/0/,IFIRST2/0/
+      DATA IFIRST1/0/
 
-      SAVE IFIRST1, IFIRST2
+      SAVE IFIRST1
 
 C----------------------------------------------------------------------
 C----------------------------------------------------------------------
@@ -233,29 +233,6 @@ C  -------------------------------
       CALL ERRWRT(STR)
       CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
       CALL ERRWRT(' ')
-            ENDIF
-         ELSE
-            IF(IPRT.EQ.-1)  IFIRST2 = 1
-            IF(IFIRST2.EQ.0 .OR. IPRT.GE.1)  THEN
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      ERRSTR = 'BUFRLIB: UFBREP - NO SPECIFIED VALUES WRITTEN OUT, ' //
-     .   'SO RETURN WITH 5th ARG. (IRET) = 0; 6th ARG. (STR) ='
-      CALL ERRWRT(ERRSTR)
-      CALL ERRWRT(STR)
-      CALL ERRWRT('MAY NOT BE IN THE BUFR TABLE(?)')
-               IF(IPRT.EQ.0) THEN
-      ERRSTR = 'Note: Only the first occurrence of this WARNING ' //
-     .   'message is printed, there may be more.  To output all ' //
-     .   'such messages,'
-      CALL ERRWRT(ERRSTR)
-      ERRSTR = 'modify your application program to add ' //
-     .   '"CALL OPENBF(0,''QUIET'',1)" prior to the first call ' //
-     .   'to a BUFRLIB routine.'
-      CALL ERRWRT(ERRSTR)
-               ENDIF
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      CALL ERRWRT(' ')
-               IFIRST2 = 1
             ENDIF
          ENDIF
       ENDIF

--- a/src/ufbstp.f
+++ b/src/ufbstp.f
@@ -125,9 +125,9 @@ C> @author J. Woollen @date 1994-01-06
       CHARACTER*128 BORT_STR1,BORT_STR2,ERRSTR
       REAL*8        USR(I1,I2)
 
-      DATA IFIRST1/0/,IFIRST2/0/
+      DATA IFIRST1/0/
 
-      SAVE IFIRST1, IFIRST2
+      SAVE IFIRST1
 
 C----------------------------------------------------------------------
 C----------------------------------------------------------------------
@@ -231,29 +231,6 @@ C  -------------------------------
       CALL ERRWRT(STR)
       CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
       CALL ERRWRT(' ')
-            ENDIF
-         ELSE
-            IF(IPRT.EQ.-1)  IFIRST2 = 1
-            IF(IFIRST2.EQ.0 .OR. IPRT.GE.1)  THEN
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      ERRSTR = 'BUFRLIB: UFBSTP - NO SPECIFIED VALUES WRITTEN OUT, ' //
-     .   'SO RETURN WITH 5th ARG. (IRET) = 0; 6th ARG. (STR) ='
-      CALL ERRWRT(ERRSTR)
-      CALL ERRWRT(STR)
-      CALL ERRWRT('MAY NOT BE IN THE BUFR TABLE(?)')
-               IF(IPRT.EQ.0) THEN
-      ERRSTR = 'Note: Only the first occurrence of this WARNING ' //
-     .   'message is printed, there may be more.  To output all ' //
-     .   'such messages,'
-      CALL ERRWRT(ERRSTR)
-      ERRSTR = 'modify your application program to add ' //
-     .   '"CALL OPENBF(0,''QUIET'',1)" prior to the first call ' //
-     .   'to a BUFRLIB routine.'
-      CALL ERRWRT(ERRSTR)
-               ENDIF
-      CALL ERRWRT('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
-      CALL ERRWRT(' ')
-               IFIRST2 = 1
             ENDIF
          ENDIF
       ENDIF

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -467,6 +467,7 @@ for kind in "4" "d"; do
     # Check ufbrep().
     (./test_bort_$kind ufbrep 1) && exit 1
     (./test_bort_$kind ufbrep 2) && exit 1
+    (./test_bort_$kind ufbrep 3) && exit 1
 
     # Check ufbrms().
     (./test_bort_$kind ufbrms 1) && exit 1
@@ -485,6 +486,7 @@ for kind in "4" "d"; do
     (./test_bort_$kind ufbstp 1) && exit 1
     (./test_bort_$kind ufbstp 2) && exit 1
     (./test_bort_$kind ufbstp 3) && exit 1
+    (./test_bort_$kind ufbstp 4) && exit 1
 
     # Check ufdump().
     (./test_bort_$kind ufdump 1) && exit 1

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -9,9 +9,10 @@
 #
 # Ed Hartnett 3/12/23
 
-# For now, don't run on _8 version of the library, because not all
-# functions tested here handle _8 calls well, since they are not
-# intended to be called directly by the user.
+# Don't run on the _8 version of the library, because many of the routines
+# tested below aren't intended to ever be called directly by users, and
+# therefore those routines aren't configured to handle the passing of
+# 8-byte integer arguments.
 for kind in "4" "d"; do
     # Check adn30().
     (./test_bort_$kind adn30 1) && exit 1
@@ -113,6 +114,9 @@ for kind in "4" "d"; do
 
     # Check igetntbi().
     (./test_bort_$kind igetntbi 1) && exit 1
+
+    # Check igettdi().
+    (./test_bort_$kind igettdi 1) && exit 1
 
     # Check inctab().
     (./test_bort_$kind inctab 1) && exit 1

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -1750,6 +1750,14 @@ program test_bort
         if (ios .ne. 0) stop 3
         call openbf(12, 'IN', 10)
         call ufbrep(12, real_2d, 1, 2, iret, 'c')
+     elseif (test_case .eq. '3') then
+        open(unit = 12, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
+        if (ios .ne. 0) stop 3
+        open(unit = 11, file = 'testfiles/IN_7_bufrtab', iostat = ios)
+        if (ios .ne. 0) stop 3
+        call openbf(12, 'OUT', 11)
+        call openmb(12, 'NC008023', 2021022312)
+        call ufbrep(12, real_2d, 1, 2, iret, 'TOST')
      endif
   elseif (sub_name .eq. 'ufbrms') then
      if (test_case .eq. '1') then
@@ -1789,6 +1797,14 @@ program test_bort
         if (ios .ne. 0) stop 3
         call openbf(12, 'OUT', 10)
         call ufbstp(11, real_2d, 1, 1, iret, 'LALAL1')
+     elseif (test_case .eq. '4') then
+        open(unit = 12, file = 'testfiles/test_bort_OUT', form = 'UNFORMATTED', iostat = ios)
+        if (ios .ne. 0) stop 3
+        open(unit = 11, file = 'testfiles/IN_7_bufrtab', iostat = ios)
+        if (ios .ne. 0) stop 3
+        call openbf(12, 'OUT', 11)
+        call openmb(12, 'NC008023', 2021022312)
+        call ufbstp(12, real_2d, 1, 2, iret, 'TOST')
      endif
   elseif (sub_name .eq. 'ufbseq') then
      if (test_case .eq. '1') then

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -46,7 +46,7 @@ program test_bort
   integer imt, imtv, iogce, iltv
   integer*8 nval
 
-  integer*4 isize, iupm, iupvs01, isetprm, nmsub
+  integer*4 isize, iupm, iupvs01, isetprm, nmsub, igettdi
 
   character*25 filnam
   character bfmg(200000)
@@ -417,10 +417,18 @@ program test_bort
        if (ios .ne. 0) stop 3
        call openbf(11, 'IN', 12)
      endif
+  elseif (sub_name .eq. 'igettdi') then
+     if (test_case .eq. '1') then
+       iret = igettdi(0)
+       do u = 1, 257
+         iret = igettdi(1)
+       enddo
+     endif
   elseif (sub_name .eq. 'inctab') then
      if (test_case .eq. '1') then
-       if (isetprm('MAXJL',10) .ne. 0) stop 3
        open(unit = 11, file = 'testfiles/OUT_1', iostat = ios)
+       if (ios .ne. 0) stop 3
+       if (isetprm('MAXJL',10) .ne. 0) stop 3
        call openbf(11, 'IN', 11)
      endif
   elseif (sub_name .eq. 'isize') then


### PR DESCRIPTION
Part of #445

FYI, I removed unreachable lines from ufbrep() and ufbstp().  In both of those routines, whenever IO=1 and either ufbrp() or ufbsp() returns with IRET=0 (or any other value not equal to I2), then control immediately drops to the bort 903 message, bypassing those print lines.

Similarly, in ufbovr() the same print lines are unreachable because any situation where IO=1 and IRET!=I2 will end up aborting from lstjpb() within the prior call to trybump().  So in the case of ufbovr(), I'm not sure if the bort 904 case is itself even reachable, but for now at least I left it in.

I also simplified the code by removing the global variable MAXTAB, since it's nothing more than a copy of MAXJL.