### PR TITLE
add testing for igetrfel, rcstpl, and pad

### DIFF
--- a/src/arallocf.F90
+++ b/src/arallocf.F90
@@ -17,7 +17,7 @@ subroutine arallocf
 
   use modv_vars, only: maxcd, maxjl, maxmem, maxmsg, maxss, maxtba, maxtbb, maxtbd, mxbtm, mxbtmse, &
                        mxcdv, mxcsb, mxdxts, mxlcc, mxmsgl, mxmsgld4, mxmtbb, mxmtbd, mxnrv, mxrst, &
-                       mxs01v, mxtamc, mxtco, mxh4wlc, nfiles, mxcnem, maxnc
+                       mxs01v, mxtamc, mxtco, mxh4wlc, nfiles, mxcnem, maxnc, maxrcr
 
   use moda_usrint
   use moda_usrbit

--- a/src/igetrfel.f
+++ b/src/igetrfel.f
@@ -76,10 +76,7 @@ C               operator (if any) corresponding to this element.
                     IF ( FXY(2:3) .EQ. '33' ) CFLWOPR = '222000'
                   END IF
                 END IF
-                IF ( CFLWOPR .EQ. 'XXXXXX' ) THEN
-                  IF ( IMRKOPR(TAG(NODE)) .EQ. 1 ) GOTO 900
-                  RETURN
-                END IF
+                IF ( CFLWOPR .EQ. 'XXXXXX' ) RETURN
 
 C               Now, check whether the appropriate "follow" operator was
 C               actually present in the subset.  If there are multiple
@@ -222,9 +219,6 @@ C                 those of the previous referenced element.
         END IF
 
         RETURN
-900     WRITE(BORT_STR,'("BUFRLB: IGETRFEL - UNABLE TO DETERMINE '//
-     .      'FOLLOW OPERATOR FOR MARKER OPERATOR ",A)') TAG(NODE)
-        CALL BORT(BORT_STR)
 901     WRITE(BORT_STR,'("BUFRLB: IGETRFEL - UNABLE TO FIND FOLLOW '//
      .      'OPERATOR ",A," IN SUBSET")') CFLWOPR
         CALL BORT(BORT_STR)

--- a/src/modules_arrs.F90
+++ b/src/modules_arrs.F90
@@ -813,7 +813,6 @@ end module moda_usrint
 !>
 !> @author J. Woollen 1994-01-06
 module moda_usrtmp
-  parameter ( maxrcr = 100 )
   !> inv array elements for new sections of a growing subset buffer.
   integer, allocatable :: iutmp(:,:)
   !> val array elements for new sections of a growing subset buffer.

--- a/src/modules_vars.F90
+++ b/src/modules_vars.F90
@@ -225,6 +225,9 @@ module modv_vars
   !> Maximum number of entries in the internal string cache.
   integer, parameter :: mxs = 1000
 
+  !> Maximum number of recursion levels when expanding a subset template.
+  integer, parameter :: maxrcr = 100
+
   !> Maximum number of Table A mnemonics in the internal jump/link
   !> table which contain at least one Table C operator with an XX value
   !> of 21 or greater in their definition.

--- a/src/pad.f
+++ b/src/pad.f
@@ -14,7 +14,7 @@ C> Note that it's the number of bits padded here that
 C> was packed in bits ibit+1 through ibit+8 - this is actually a
 C> delayed replication factor! IPADB must be a multiple of eight and
 C> represents the bit boundary on which the packed subset in ibay
-C> should end after padding. For example, if ipabd is "8", then the
+C> should end after padding. For example, if ipadb is "8", then the
 C> number of bits in ibay actually consumed by packed data (including
 C> the padding) will be a multiple of eight. If ipadb is "16", it
 C> will be a multiple of sixteen.  in either (or any) case, this
@@ -51,16 +51,12 @@ c  .... Now pad with zeroes to the byte boundary
       CALL PKB(0,IPAD,IBAY,IBIT)
       IBYT = IBIT/8
 
-      IF(MOD(IBIT,IPADB).NE.0) GOTO 900
-      IF(MOD(IBIT,8    ).NE.0) GOTO 901
+      IF(MOD(IBIT,8).NE.0) GOTO 901
 
 C  EXITS
 C  -----
 
       RETURN
-900   WRITE(BORT_STR,'("BUFRLIB: PAD - THE INPUT BIT BOUNDARY TO PAD '//
-     . 'TO (",I8,") IS NOT A MULTIPLE OF 8")') IPADB
-      CALL BORT(BORT_STR)
 901   WRITE(BORT_STR,'("BUFRLIB: PAD - THE NUMBER OF BITS IN A PACKED'//
      . ' SUBSET AFTER PADDING (",I8,") IS NOT A MULTIPLE OF 8")') IBIT
       CALL BORT(BORT_STR)

--- a/src/rcstpl.f
+++ b/src/rcstpl.f
@@ -16,7 +16,7 @@ C>
 C> @author Woollen @date 1994-01-06
       SUBROUTINE RCSTPL(LUN,IRET)
 
-      use modv_vars, only: bmiss, maxjl, maxss
+      use modv_vars, only: bmiss, maxjl, maxss, maxrcr
 
       use moda_usrint
       use moda_usrbit

--- a/test/run_test_bort.sh
+++ b/test/run_test_bort.sh
@@ -115,6 +115,11 @@ for kind in "4" "d"; do
     # Check igetntbi().
     (./test_bort_$kind igetntbi 1) && exit 1
 
+    # Check igetrfel().
+    (./test_bort_$kind igetrfel 1) && exit 1
+    (./test_bort_$kind igetrfel 2) && exit 1
+    (./test_bort_$kind igetrfel 3) && exit 1
+
     # Check igettdi().
     (./test_bort_$kind igettdi 1) && exit 1
 
@@ -198,6 +203,9 @@ for kind in "4" "d"; do
     # Check openmb().
     (./test_bort_$kind openmb 1) && exit 1
     (./test_bort_$kind openmb 2) && exit 1
+
+    # Check pad().
+    (./test_bort_$kind pad 1) && exit 1
 
     # Check parstr().
     (./test_bort_$kind parstr 1) && exit 1

--- a/test/test_bort.F90
+++ b/test/test_bort.F90
@@ -12,7 +12,6 @@ program test_bort
   use bufr_interface
   implicit none
   integer iret, jret, iunit, iqcd
-  ! integer i1
   integer int_1d(1), int_1d_2(1), int_2d(1,5)
   character char_1
   character*2 char_short
@@ -417,6 +416,31 @@ program test_bort
        if (ios .ne. 0) stop 3
        call openbf(11, 'IN', 12)
      endif
+  elseif (sub_name .eq. 'igetrfel') then
+     filnam = 'testfiles/IN_4'
+     call cobfl_c( filnam, 'r' )
+     open(unit = 31, file = '/dev/null')
+     call openbf(31, 'SEC3', 31)
+     call crbmg_c(bfmg, 200000, msgl, iret)
+     if (test_case .eq. '1') then
+        ! Change the last 2-37-000 operator in Section 3 to 2-35-000, so that the bitmap can't be located
+        ! for any of the subsequent marker operators.
+        ibit = 1016
+        call pkb(163, 8, ibfmg, ibit)
+     elseif (test_case .eq. '2') then
+        ! Change the first 2-24-000 operator in Section 3 to 2-22-000, so that the "follow" operator can't
+        ! be located for any of the subsequent marker operators.
+        ibit = 888
+        call pkb(150, 8, ibfmg, ibit)
+     elseif (test_case .eq. '3') then
+        ! Change the first 2-22-000 operator in Section 3 to 2-35-000, so that the previous referenced
+        ! element can't be located for any of the subsequent marker operators.
+        ibit = 312
+        call pkb(163, 8, ibfmg, ibit)
+     endif
+     call mtinfo('../tables', 80, 81)
+     call readerme(ibfmg, 31, char_val_8, jdate, iret)
+     call readsb(31, iret)
   elseif (sub_name .eq. 'igettdi') then
      if (test_case .eq. '1') then
        iret = igettdi(0)
@@ -686,6 +710,11 @@ program test_bort
         call openmb(11, 'F5FCMESG', 2021022312)
      elseif (test_case .eq. '2') then
         call openmb(11, 'F5FCMESG', 2021022312)
+     endif
+  elseif (sub_name .eq. 'pad') then
+     if (test_case .eq. '1') then
+        ibit = 16
+        call pad(ibay, ibit, ierr, 27)
      endif
   elseif (sub_name .eq. 'parstr') then
      if (test_case .eq. '1') then

--- a/test/test_misc.F90
+++ b/test/test_misc.F90
@@ -178,16 +178,6 @@ program test_misc
   open(unit = 11, file = 'testfiles/IN_2', form = 'UNFORMATTED', iostat = ios)
   if (ios .ne. 0) stop 3
   call openbf(11, 'IN', 11)
-  if (igetprm('MAXSS') .ne. 120000) stop 600
-  if (igetprm('MAXTBA') .ne. 150) stop 601
-  if (igetprm('MAXTBB') .ne. 500) stop 602
-  if (igetprm('MAXTBD') .ne. 500) stop 603
-  if (igetprm('MXBTM') .ne. 5) stop 604
-  if (igetprm('MXBTMSE') .ne. 500) stop 605
-  if (igetprm('MXCDV') .ne. 3000) stop 606
-  if (igetprm('MXCSB') .ne. 4000) stop 607
-  if (igetprm('MXDXTS') .ne. 200) stop 608
-  if (igetprm('MXLCC') .ne. 32) stop 609
   if (igetprm('MXMSGL') .ne. 600006) stop 610
   if (igetprm('MXMTBB') .ne. 4000) stop 611
   if (igetprm('MXMTBD') .ne. 1000) stop 612
@@ -267,6 +257,31 @@ program test_misc
   if (invcon(1, 1, 0, 3) .ne. 0) stop 706
   if (invcon(1, 1, 3, 0) .ne. 0) stop 707
   if (invtag(0, 1, 3, 0) .ne. 0) stop 708
+  call openbf(11, 'QUIET', 0)
+  call closbf(11)
+
+  ! Test rcstpl() passing non-zero iret values back through rdtree and readsb
+  open(unit = 11, file = 'testfiles/IN_3', form = 'UNFORMATTED', iostat = ios)
+  if (ios .ne. 0) stop 3
+  call openbf(11, 'IN', 11)
+  call readmg(11, subset, idate, iret)
+  iret = isetprm('MAXJL', 20)
+  call openbf(11, 'QUIET', 1)
+  call readsb(11, iret)
+  if ( iret .ne. -1 ) stop 709
+  iret = isetprm('MAXJL', 96000)
+  iret = isetprm('MAXSS', 20)
+  call readmg(11, subset, idate, iret)
+  call readsb(11, iret)
+  if ( iret .ne. -1 ) stop 710
+  call closbf(11)
+  open(unit = 11, file = 'testfiles/IN_1', form = 'UNFORMATTED', iostat = ios)
+  if (ios .ne. 0) stop 3
+  call openbf(11, 'SEC3', 11)
+  call mtinfo('../tables', 80, 81)
+  call readns(11, subset, idate, iret)
+  if ( iret .ne. -1 ) stop 711
+  iret = isetprm('MAXSS', 120000)
   call openbf(11, 'QUIET', 0)
   call closbf(11)
 
@@ -377,7 +392,7 @@ program test_misc
   iret = 0
   call sntbbe(0, card, 1, iret, int_1d, char_4, char_12, char_4, char_24, char_8, char_4, char_120)
   if ( char_24(1) .ne. ' ' ) stop 803
-  
+
 #endif
 
   print *, 'SUCCESS'


### PR DESCRIPTION
Part of #445 

Also moves the definition of parameter maxrcr from modules_arrs.F90 to modules_vars.F90.  This had been the last remaining global variable to not be defined in the latter.

I also removed some unreachable bort statements.