### PR TITLE
Add test file caching for Spack CI

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -37,6 +37,13 @@ jobs:
       run: |
         sudo apt install python3 python3-numpy
 
+    - name: cache-data
+      id: cache-data
+      uses: actions/cache@v3
+      with:
+        path: ~/data
+        key: data-13
+
     - name: spack-build-and-test
       run: |
         git clone -c feature.manyFiles=true https://github.com/spack/spack
@@ -44,7 +51,7 @@ jobs:
         spack env create bufr-env $GITHUB_WORKSPACE/bufr/spack/spack.yaml
         spack env activate bufr-env
         cp $GITHUB_WORKSPACE/bufr/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/bufr/package.py
-        spack develop --no-clone --path $GITHUB_WORKSPACE/bufr bufr@develop
+        spack develop --no-clone --path $GITHUB_WORKSPACE/bufr bufr@develop test_files=/home/runner/data
         spack add bufr@develop%gcc@11 ${{ matrix.variants }}
         spack external find cmake gmake python py-numpy
         spack concretize

--- a/spack/package.py
+++ b/spack/package.py
@@ -40,6 +40,7 @@ class Bufr(CMakePackage):
 
     variant("python", default=False, description="Enable Python interface")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")
+    variant("test_files", default=None, description="Path to test files")
 
     extends("python", when="+python")
 
@@ -65,6 +66,7 @@ class Bufr(CMakePackage):
             self.define_from_variant("ENABLE_PYTHON", "python"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_TESTS", self.run_tests),
+            self.define_from_variant("TEST_FILE_DIR", "test_files"),
         ]
 
         return args

--- a/spack/package.py
+++ b/spack/package.py
@@ -40,7 +40,7 @@ class Bufr(CMakePackage):
 
     variant("python", default=False, description="Enable Python interface")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")
-    variant("test_files", default=None, description="Path to test files")
+    variant("test_files", default="none", description="Path to test files")
 
     extends("python", when="+python")
 
@@ -66,8 +66,10 @@ class Bufr(CMakePackage):
             self.define_from_variant("ENABLE_PYTHON", "python"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_TESTS", self.run_tests),
-            self.define_from_variant("TEST_FILE_DIR", "test_files"),
         ]
+
+        if not self.spec.satisfies("test_files=none"):
+            args.append(self.define_from_variant("TEST_FILE_DIR", "test_files"))
 
         return args
 


### PR DESCRIPTION
This PR uses the cached test files in the Spack CI workflow.

This PR fixes the spack+python failure: https://github.com/NOAA-EMC/NCEPLIBS-bufr/actions/runs/8708694736/job/23890654670?pr=587