### PR TITLE
Spack update for new utils option

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        variants: ["+python ~shared", "~python +shared"]
+        variants: ["+python ~shared ~utils", "~python +shared +utils"]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/spack/package.py
+++ b/spack/package.py
@@ -67,6 +67,7 @@ class Bufr(CMakePackage):
             self.define_from_variant("ENABLE_PYTHON", "python"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_TESTS", self.run_tests),
+            self.define("BUILD_TESTING", self.run_tests),
             self.define_from_variant("BUILD_UTILS", "utils"),
         ]
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -41,6 +41,7 @@ class Bufr(CMakePackage):
     variant("python", default=False, description="Enable Python interface")
     variant("shared", default=True, description="Build shared libraries", when="@11.5:")
     variant("test_files", default="none", description="Path to test files")
+    variant("utils", default=True, description="Build utilities", when="@develop")
 
     extends("python", when="+python")
 
@@ -66,6 +67,7 @@ class Bufr(CMakePackage):
             self.define_from_variant("ENABLE_PYTHON", "python"),
             self.define_from_variant("BUILD_SHARED_LIBS", "shared"),
             self.define("BUILD_TESTS", self.run_tests),
+            self.define_from_variant("BUILD_UTILS", "utils"),
         ]
 
         if not self.spec.satisfies("test_files=none"):


### PR DESCRIPTION
This PR adds Spack-related stuff for the new BUILD_UTILS option, and also adds "BUILD_TESTING" to the recipe logic so that the tests won't get built is tests aren't being run.

To confirm, the following executables are installed in the Spack installation: apxdx  binv  cmpbqm  debufr  gettab  readbp  readmp  sinv  split_by_subset  xbfmg