### PR TITLE
final updates for next v12.1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,16 +51,24 @@ make install
 </pre>
 
 Both `path1` and `path2` may be full or relative pathnames
-on the system, up to a maximum of 90 characters each.
+on the system, up to a maximum of 240 characters each.
 
 Installation of the library and utilities will be under `path1`.
 Installation of the master BUFR tables will be under `path2`, or
 under `path1` if `-DMASTER_TABLE_DIR=path2` is omitted
 from the above cmake command.
 
-If Python interoperability is desired, `-DENABLE_PYTHON=ON` can also
+If Python interoperability is desired, then `-DENABLE_PYTHON=ON` can also
 be added to the above cmake command.  However, version 3 of Python
 must be installed and available on the system.
+
+When building the library, automated CI testing is included by default.
+If this is not desired, then it can be disabled by adding `-DBUILD_TESTING=OFF`
+to the above cmake command.
+
+When building the library, associated utilities are included by default.
+If these are not desired, then they can be disabled by adding `-DBUILD_UTILS=OFF`
+to the above cmake command.
 
 ## References
 

--- a/docs/ReleaseNotes.md
+++ b/docs/ReleaseNotes.md
@@ -2,6 +2,37 @@
 # Release Notes
 @brief Detailed description of changes included within each new release.
 
+## Version 12.1.0 - July 10, 2024
+
+* Added support for IntelLLVM (OneAPI) compilers.
+[[Issue #538](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/538)]
+
+* Added logic to optimize decoding for the majority of data values which are encoded in 32 bits or less.
+[[Issue #534](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/534)]
+[[Issue #543](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/543)]
+
+* Increased length limits for master table directory and filenames.
+[[Issue #533](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/533)]
+
+* Fixed some build issues related to Python interoperability.
+[[Issue #524](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/524)]
+[[Issue #537](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/537)]
+
+* Fixed a bug to ensure that any user input data values of NaN are encoded as "missing" in BUFR.
+[[Issue #550](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/550)]
+
+* Modified the ufdump() subroutine to print subset data values to their true scale precision, so that values
+with a non-positive scale factor will now display as integers, including when printed via the debufr utility.
+[[Issue #513](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/513)]
+
+* Added a new print verbosity level of 3 which can be activated when calling subroutine openbf()
+with IO='QUIET'. [[Issue #567](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/567)]
+
+* Added apxdx to project as new utility. [[Issue #585](https://github.com/NOAA-EMC/NCEPLIBS-bufr/issues/585)]
+
+* Fixed a bug in subroutine rewnbf() to ensure that it points to the correct subset in a BUFR message
+after a restore call. [[Issue #599](https://github.com/NOAA-EMC/NCEPLIBS-bufr/pull/599)]
+
 ## Version 12.0.1 - September 15, 2023
 
 * An extension was added to support the query interface for C++ IODA

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -2,6 +2,7 @@
 
 ## Documentation for Previous Versions of NCEPLIBS-bufr
 
+* [NCEPLIBS-bufr-12.0.l](https://noaa-emc.github.io/NCEPLIBS-bufr/previous_versions/v12.0.l/index.html)
 * [NCEPLIBS-bufr-12.0.0](https://noaa-emc.github.io/NCEPLIBS-bufr/previous_versions/v12.0.0/index.html)
 * [NCEPLIBS-bufr-11.7.1](https://noaa-emc.github.io/NCEPLIBS-bufr/previous_versions/v11.7.1/index.html)
 * [NCEPLIBS-bufr-11.7.0](https://noaa-emc.github.io/NCEPLIBS-bufr/previous_versions/v11.7.0/index.html)


### PR DESCRIPTION
Fixes #586

@AlexanderRichert-NOAA @edwardhartnett As noted in some other threads, I'm still unsure about how (or whether?) to update the `spack/package.py` file to add a new entry for this new release.  Or is that something that needs to be done post-release?  I know the sha256 values in `spack/package.py` are different from the commit ids which correspond to the github tags for each release, but again I'm unsure about how or when to make that corresponding update to the file.  Please let me know ASAP, or else I guess I'll just go ahead and do the next release after this PR is merged and with what we have for now.