### PR TITLE
Various fixes for using NAG

### DIFF
--- a/src/mastertable.F90
+++ b/src/mastertable.F90
@@ -566,7 +566,7 @@ subroutine sntbbe ( ifxyn, line, mxmtbb, nmtbb, imfxyn, cmscl, cmsref, cmbw, cmu
   implicit none
 
   integer, intent(in) :: ifxyn, mxmtbb
-  integer, intent(out) :: nmtbb, imfxyn(*)
+  integer, intent(inout) :: nmtbb, imfxyn(*)
   integer ntag, ii, nemock
 
   character, intent(out) :: cmelem(120,*), cmunit(24,*), cmsref(12,*), cmmnem(8,*), cmscl(4,*), cmbw(4,*), cmdsc(*)*4
@@ -710,7 +710,8 @@ subroutine sntbde ( lunt, ifxyn, line, mxmtbd, mxelem, nmtbd, imfxyn, cmmnem, cm
   implicit none
 
   integer, intent(in) :: lunt, ifxyn, mxmtbd, mxelem
-  integer, intent(out) :: nmtbd, imfxyn(*), nmelem(*), iefxyn(mxmtbd,mxelem)
+  integer, intent(out) :: imfxyn(*), nmelem(*), iefxyn(mxmtbd,mxelem)
+  integer, intent(inout) :: nmtbd
   integer ii, ipt, ntag, nelem, nemock, ifxy, igetfxy, igetntbl
 
   character*(*), intent(in) :: line

--- a/src/missing.F90
+++ b/src/missing.F90
@@ -65,6 +65,7 @@ recursive integer function icbfms ( str, lstr ) result ( iret )
   character*16, parameter :: zm_le = '42374876E8000000'   ! 10E10 stored as hexadecimal on a little-endian system
 
   real*8 rl8z
+  integer*8 il8z
 
   integer, intent(in) :: lstr
   integer my_lstr, numchr, ii, iupm
@@ -96,7 +97,7 @@ recursive integer function icbfms ( str, lstr ) result ( iret )
     do ii = 1, numchr
       strz(ii:ii) = str(ii:ii)
     end do
-    write (zz,'(z16.16)') rl8z
+    write (zz,'(z16.16)') transfer(rl8z,il8z)
     ii = 2*(8-numchr)+1
     if ( zz(ii:16)==zm_be(ii:16) .or. zz(ii:16)==zm_le(ii:16) ) then
       iret = 1

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -650,9 +650,8 @@ recursive subroutine ufbint(lunin,usr,i1,i2,iret,str)
   character*(*), intent(in) :: str
   character*128 bort_str1, bort_str2, errstr
 
-  real*8, intent(inout) :: usr(i1,i2)
-
   integer, intent(in) :: lunin, i1, i2
+  real*8, intent(inout) :: usr(i1,i2)
   integer, intent(out) :: iret
   integer nnod, ncon, nods, nodc, ivls, kons, ifirst1, ifirst2, my_lunin, my_i1, my_i2, lunit, lun, il, im, io
 
@@ -883,9 +882,8 @@ recursive subroutine ufbrep(lunin,usr,i1,i2,iret,str)
   character*(*), intent(in) :: str
   character*128 bort_str1, bort_str2, errstr
 
-  real*8, intent(inout) :: usr(i1,i2)
-
   integer, intent(in) :: lunin, i1, i2
+  real*8, intent(inout) :: usr(i1,i2)
   integer, intent(out) :: iret
   integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, iac_prev
 
@@ -1088,9 +1086,8 @@ recursive subroutine ufbstp(lunin,usr,i1,i2,iret,str)
   character*(*), intent(in) :: str
   character*128 bort_str1, bort_str2, errstr
 
-  real*8, intent(inout) :: usr(i1,i2)
-
   integer, intent(in) :: lunin, i1, i2
+  real*8, intent(inout) :: usr(i1,i2)
   integer, intent(out) :: iret
   integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io
 

--- a/utils/apxdx.F90
+++ b/utils/apxdx.F90
@@ -21,6 +21,10 @@
 !> @author J. Ator @date 2009-07-01
 program apxdx
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   implicit none
 
   character*240 cdxtbl, cbffil

--- a/utils/binv.F90
+++ b/utils/binv.F90
@@ -10,6 +10,10 @@
 !> @author J Woollen @date 1994
 PROGRAM BINV
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   PARAMETER (MAXSUB=100)
 
   CHARACTER*255 FILE

--- a/utils/cmpbqm.F90
+++ b/utils/cmpbqm.F90
@@ -10,6 +10,10 @@
 !> @author J Woollen @date 1997
 PROGRAM CMPBQM
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   CHARACTER*255 FILE
   CHARACTER*50 HEADR,OBSTR,QMSTR
   CHARACTER*20 VARS(7)

--- a/utils/gettab.F90
+++ b/utils/gettab.F90
@@ -12,6 +12,10 @@
 !> @author Woollen @date 2000-01-01
 program gettab
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   implicit none
 
   character(len=255) :: file        !> name of filename to read

--- a/utils/readbp.F90
+++ b/utils/readbp.F90
@@ -17,6 +17,10 @@
 !-----------------------------------------------------------------------
       PROGRAM READBP
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
       character(120) ::  FILE
       character(50)  ::  optarg
       character(40)  ::  HSTR,OSTR,QSTR

--- a/utils/readmp.F90
+++ b/utils/readmp.F90
@@ -12,6 +12,10 @@
 !> @author J. Woollen @date 2002-02-24
   program readmp
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   implicit none
 
   character(255)     :: file        !> name of filename to read

--- a/utils/sinv.F90.in
+++ b/utils/sinv.F90.in
@@ -12,6 +12,10 @@
 !> @author J Woollen @date 2010
 program sinv
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   parameter (maxa=16000000)
   parameter (maxs=1000)
 

--- a/utils/split_by_subset.F90
+++ b/utils/split_by_subset.F90
@@ -14,6 +14,10 @@
 
 program split_by_subset
 
+#ifdef NAGFOR
+  use f90_unix_proc, only: exit
+#endif
+
   implicit none
 
   integer, parameter :: maxsub = 100


### PR DESCRIPTION
I have made some changes to enable the use of NAG.  Changes are:

1)

The changes in mastertable.F90 are related to intent(out) arguments being used without being defined.  For instance in subroutine sntbde, nmtbd is declared as intent(out) and promptly used in a comparison.  Intent(out) arguments become undefined upon subroutine entry so this is undefined.

2)

In missing.F90 there is an attempt to write a real value with a Z edit descriptor.  This is not valid according to the standard, only integers can be used with a Z edit descript.  I have used a transfer to fix this.

3)

In readwriteval.F90 I have re-ordered some declarations.  When declaring something like

integer :: a(b,c)

the b and c have to be declared before a; the rearrangements make sure this is the case.

4)

For the rest the exit function is not standard Fortran and for NAG is accessed via a compiler specific module.  I have done this hidden behind a CPP flag.