### PR TITLE
update spack/package.py

### DIFF
--- a/spack/package.py
+++ b/spack/package.py
@@ -23,6 +23,7 @@ class Bufr(CMakePackage):
     maintainers("AlexanderRichert-NOAA", "edwardhartnett", "Hang-Lei-NOAA", "jbathegit")
 
     version("develop", branch="develop")
+    version("12.2.0", sha256="a0dad13b905f3e0311e2b50df47418660b47442dfc3843232712044b47f26a71")
     version("12.1.0", sha256="b5eae61b50d4132b2933b6e6dfc607e5392727cdc4f46ec7a94a19109d91dcf3")
     version("12.0.1", sha256="525f26238dba6511a453fc71cecc05f59e4800a603de2abbbbfb8cbb5adf5708")
     version("12.0.0", sha256="d01c02ea8e100e51fd150ff1c4a1192ca54538474acb1b7f7a36e8aeab76ee75")


### PR DESCRIPTION
Fixes #642

I just did the v12.2.0 release and will open a new install ticket momentarily.  In the meantime, this is the next commit for the develop branch, to add the hashcode for the new v12.2.0 release to the spack/package.py file.