### PR TITLE
Add ncepbufr._bufrlib.writlc and write_long_string to Python API.

### DIFF
--- a/python/_bufrlib.pyf
+++ b/python/_bufrlib.pyf
@@ -148,6 +148,11 @@ end subroutine writsb
 subroutine cmpmsg(cmp) ! in cmpmsg.f
     character*(*),intent(in) :: cmp
 end subroutine cmpmsg
+subroutine writlc(lunit,chr,st) ! in readwriteval.F90
+    integer,intent(in) :: lunit
+    character*(*),intent(in) :: chr
+    character*(*),intent(in) :: st
+end subroutine writelc
 
     end interface 
 end python module _bufrlib

--- a/python/ncepbufr/__init__.py
+++ b/python/ncepbufr/__init__.py
@@ -446,6 +446,27 @@ class open:
         except Exception as error:
             print(f"An exception occurred {error}")
         return result
+    def write_long_string(self,s,mnemonic,first=False):
+        """
+        Encode long character string and write to the current message.
+        String must be ASCII encodable otherwise an exception will be
+        raised.
+
+        If first is true then writsb will be called first.
+
+        Example:
+
+            :::python
+            >>> bufr = ncepbufr.open(filename)
+            >>> bufr.write_long_string('test123',mnemonic='PTIDC',end=True)
+        """
+        if len(mnemonic.split()) > 1:
+            raise ValueError('only one mnemonic per call to write_long_string')
+        if first:
+            _bufrlib.writsb(self.lunit)
+        dat = s.encode('ASCII')
+        _bufrlib.writlc(self.lunit,dat,mnemonic)
+
     def read_subset(self,mnemonics,rep=False,seq=False,events=False):
         """
         decode the data from the currently loaded message subset


### PR DESCRIPTION
I needed this to put PTIDC into a file - it has only had very light testing.
