### PR TITLE
add bort catching capability for C and Python applications

### DIFF
--- a/python/_bufrlib.pyf
+++ b/python/_bufrlib.pyf
@@ -2,112 +2,99 @@ python module _bufrlib
     interface
 
 subroutine bvers(cverstr) ! in misc.F90
-    character*12,intent(out) :: cverstr
+    character*12, intent(out) :: cverstr
 end subroutine bvers
 subroutine closbf(lunit) ! in openclosebf.F90
-    integer :: lunit
+    integer, intent(in) :: lunit
 end subroutine closbf
 subroutine closmg(lunin) ! in readwritemg.F90
-    integer :: lunin
+    integer, intent(in) :: lunin
 end subroutine closmg
 subroutine copymg(lunin,lunot) ! in copydata.F90
-    integer :: lunin
-    integer :: lunot
+    integer, intent(in) :: lunin, lunot
 end subroutine copymg
 subroutine datelen(len_bn) ! in s013vals.F90
-    integer :: len_bn
+    integer, intent(in) :: len_bn
 end subroutine datelen
 subroutine dxdump(lunit,ldxot) ! in dumpdata.F90
-    integer :: lunit
-    integer :: ldxot
+    integer, intent(in) :: lunit, ldxot
 end subroutine dxdump
 subroutine fortran_open(filename, lunit, format, position, iret) ! in openclosebf.F90
     character*(*), intent(in) :: filename, format, position
-    integer,intent(in) :: lunit
-    integer,intent(out) :: iret
+    integer, intent(in) :: lunit
+    integer, intent(out) :: iret
 end subroutine fortran_open
 subroutine fortran_close(lunit,iret) ! in openclosebf.F90
-    integer,intent(in) :: lunit
-    integer,intent(out) :: iret
+    integer, intent(in) :: lunit
+    integer, intent(out) :: iret
 end subroutine fortran_close
 function getbmiss() ! in missing.F90
-    real*8 :: getbmiss
+    real*8, intent(out) :: getbmiss
 end function getbmiss
 function igetprm(cprmnm) ! in arallocf.F90
     character*(*), intent(in) :: cprmnm
     integer, intent(out) :: igetprm
 end function igetprm
 function ireadsb(lunit) ! in readwritesb.F90
-    integer :: lunit
-    integer :: ireadsb
+    integer, intent(in) :: lunit
+    integer, intent(out) :: ireadsb
 end function ireadsb
 function isetprm(cprmnm, ipval) ! in arallocf.F90
     character*(*), intent(in) :: cprmnm
     integer, intent(in) :: ipval
 end function isetprm
 function nmsub(lunit) ! in readwritemg.F90
-    integer :: lunit
-    integer :: nmsub
+    integer, intent(in) :: lunit
+    integer, intent(out) :: nmsub
 end function nmsub
 subroutine openbf(lunit,io,lundx) ! in openclosebf.F90
-    integer :: lunit
-    character*(*) :: io
-    integer :: lundx
+    integer, intent(in) :: lunit, lundx
+    character*(*), intent(in) :: io
 end subroutine openbf
 subroutine openmb(lunit,subset,jdate) ! in readwritemg.F90
-    integer :: lunit
-    character*(*) :: subset
-    integer :: jdate
+    integer, intent(in) :: lunit, jdate
+    character*(*), intent(in) :: subset
 end subroutine openmb
 subroutine readmg(lunxx,subset,jdate,iret) ! in readwritemg.F90
-    integer :: lunxx
+    integer, intent(in) :: lunxx
     character*8, intent(out) :: subset
-    integer,intent(out) :: jdate
-    integer,intent(out) :: iret
+    integer, intent(out) :: jdate, iret
 end subroutine readmg
 subroutine rewnbf(lunit,isr) ! in openclosebf.F90
-    integer,intent(in) :: lunit
-    integer,intent(in) :: isr
+    integer, intent(in) :: lunit
+    integer, intent(in) :: isr
 end subroutine rewnbf
 subroutine rtrcpt(lunit,iyr,imo,idy,ihr,imi,iret) ! in tankrcpt.F90
-    integer,intent(in) :: lunit
-    integer,intent(out) :: iyr,imo,idy,ihr,imi,iret
+    integer, intent(in) :: lunit
+    integer, intent(out) :: iyr, imo, idy, ihr, imi, iret
 end subroutine rtrcpt
 subroutine setbmiss(xmiss) ! in missing.F90
-    real*8 :: xmiss
+    real*8, intent(in) :: xmiss
 end subroutine setbmiss
 subroutine strcpt(cf,iyr,imo,idy,ihr,imi) ! in tankrcpt.F90
-    character*1 :: cf
-    integer :: iyr
-    integer :: imo
-    integer :: idy
-    integer :: ihr
-    integer :: imi
+    character*1, intent(in) :: cf
+    integer, intent(in) :: iyr, imo, idy, ihr, imi
 end subroutine strcpt
 subroutine ufbcpy(lubin,lubot) ! in copydata.F90
-    integer :: lubin
-    integer :: lubot
+    integer, intent(in) :: lubin, lubot
 end subroutine ufbcpy
 subroutine ufbdmp(lunin,luprt) ! in dumpdata.F90
-    integer :: lunin
-    integer :: luprt
+    integer, intent(in) :: lunin, luprt
 end subroutine ufbdmp
 subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str) ! in readwriteval.F90
-    integer,intent(in) :: lunit
+    integer, intent(in) :: lunit, i1, i2, i3
     real*8, intent(inout), dimension(i1,i2,i3) :: usr
-    integer, intent(in) :: i1,i2,i3
     integer, intent(out) :: iret
     character*(*), intent(in) :: str
 end subroutine ufbevn
 subroutine ufbint(lunin,usr,i1,i2,iret,str) ! in readwriteval.F90
-    integer,intent(in) :: lunin
+    integer, intent(in) :: lunin, i1, i2
     real*8, intent(inout), dimension(i1,i2) :: usr
-    integer, intent(in) :: i1,i2
     integer, intent(out) :: iret
     character*(*), intent(in) :: str
 end subroutine ufbint
 subroutine readlc(lunit, chr, str) ! in readwriteval.F90
-    integer,intent(in) :: lunit
+    integer, intent(in) :: lunit
     character*64, intent(out) :: chr
     character*(*), intent(in) :: str
 end subroutine readlc
@@ -117,53 +104,57 @@ subroutine ufbqcd(lunit,nemo,qcd) ! in cftbvs.F90
     real, intent(out) :: qcd
 end subroutine ufbqcd
 subroutine ufbrep(lunio,usr,i1,i2,iret,str) ! in readwriteval.F90
-    integer,intent(in) :: lunio
+    integer, intent(in) :: lunio, i1, i2
     real*8, intent(inout), dimension(i1,i2) :: usr
-    integer, intent(in) :: i1,i2
     integer, intent(out) :: iret
     character*(*),intent(in) :: str
 end subroutine ufbrep
 subroutine ufbseq(lunin,usr,i1,i2,iret,str) ! in readwriteval.F90
-    integer, intent(in) :: lunin
+    integer, intent(in) :: lunin, i1, i2
     real*8, intent(inout), dimension(i1,i2) :: usr
-    integer, intent(in) :: i1,i2
     integer, intent(out) :: iret
     character*(*), intent(in) :: str
 end subroutine ufbseq
 subroutine ufdump(lunit,luprt) ! in datadump.F90
-    integer :: lunit
-    integer :: luprt
+    integer intent(in) :: lunit, luprt
 end subroutine ufdump
 subroutine upftbv(lunit,nemo,val,mxib,ibit,nib) ! in cftbvs.F90
-    integer,intent(in) :: lunit
+    integer, intent(in) :: lunit, mxib
     character*(*),intent(in) :: nemo
     real*8, intent(in) :: val
-    integer, intent(in) :: mxib
-    integer, intent(out) :: ibit(mxib)
-    integer, intent(out) :: nib
+    integer, intent(out) :: ibit(mxib), nib
 end subroutine upftbv
 subroutine writsb(lunit) ! in readwritesb.F90
-    integer :: lunit
+    integer, intent(in) :: lunit
 end subroutine writsb
 subroutine cmpmsg(cmp) ! in compress.F90
-    character*(*),intent(in) :: cmp
+    character*(*), intent(in) :: cmp
 end subroutine cmpmsg
 subroutine stdmsg(std) ! in standard.F90
-    character*(*),intent(in) :: std
+    character*(*), intent(in) :: std
 end subroutine stdmsg
 subroutine pkvs01(s01mnem,ival) ! in s013vals.F90
-    character*(*),intent(in) :: s01mnem
-    integer,intent(in) :: ival
+    character*(*), intent(in) :: s01mnem
+    integer, intent(in) :: ival
 end subroutine pkvs01
 function iupvs01(lunit,s01mnem) ! in s013vals.F90
-    integer,intent(in) :: lunit
-    character*(*),intent(in) :: s01mnem
+    integer, intent(in) :: lunit
+    character*(*), intent(in) :: s01mnem
+    integer, intent(out) :: iupvs01
 end function iupvs01
 subroutine writlc(lunit,chr,st) ! in readwriteval.F90
     integer,intent(in) :: lunit
-    character*(*),intent(in) :: chr
-    character*(*),intent(in) :: st
+    character*(*), intent(in) :: chr
+    character*(*), intent(in) :: st
 end subroutine writlc
+function catch_borts(cbc) ! in borts.F90
+    character*(*), intent(in) :: cbc
+    integer, intent(out) :: catch_borts
+end function catch_borts
+subroutine check_for_bort(bort_str,bort_str_len) ! in borts.F90
+    integer, intent(out) :: bort_str_len
+    character*300, intent(out) :: bort_str
+end subroutine check_for_bort
 
     end interface 
 end python module _bufrlib

--- a/python/ncepbufr/__init__.py
+++ b/python/ncepbufr/__init__.py
@@ -52,6 +52,22 @@ def standardize(std='N'):
     """
     _bufrlib.stdmsg(std)
 
+def bortcatch(cbc='N'):
+    """
+    Enable catching of any future bort error for return to application program via bortcheck.
+    `cbc`: `'Y'` for Yes, default is `'N'` for No, and in which case any bort error will
+    terminate the application program.
+    """
+    return _bufrlib.catch_borts(cbc)
+
+def bortcheck():
+    """
+    Check if a bort error occurred within the most-recently called BUFRLIB subroutine or function.
+    If so, then an error message is returned.  If not, then an empty string is returned.
+    """
+    bstr, bstr_len = _bufrlib.check_for_bort()
+    return bstr.strip().decode('utf-8')
+
 def set_Section01_value(s01_mnemonic, value):
     """
     Set a custom Section 0 or Section 1 message value for all subsequent writes to all bufr files,

--- a/python/test/test_misc.py
+++ b/python/test/test_misc.py
@@ -186,23 +186,40 @@ np.testing.assert_array_almost_equal(oer_save.filled(), oer2.filled())
 np.testing.assert_array_almost_equal(qcf_save.filled(), qcf2.filled())
 bufr.close()
 
-# test reading long strings
+# test reading long strings, and using bort catching
+assert ncepbufr.bortcatch('Y') == 0
 bufr = ncepbufr.open('data/xx103')
+bortstr = ncepbufr.bortcheck()
+assert len(bortstr) == 0
 test_station_names = ['BOUEE_LION', 'BOUEE_ANTILLES',
                       'BOUEE_COTE D\'AZUR',
                       'GULF OF MAINE', 'TENERIFE']
 test_report_ids = ['6100002', '4100300', '6100001', '4400005', '1300131']
 i_msg = 0
 while bufr.advance() == 0:
+    bortstr = ncepbufr.bortcheck()
+    assert len(bortstr) == 0
     # Just read the first subset from each message.
     if bufr.load_subset() == 0:
+        bortstr = ncepbufr.bortcheck()
+        assert len(bortstr) == 0
+        stsnrpid = bufr.read_long_string(mnemonic='CLATH') # This should catch and return a bort error
+        bortstr = ncepbufr.bortcheck()
+        assert len(bortstr) != 0
+        assert "BUFRLIB: READLC - MNEMONIC CLATH          DOES NOT REPRESENT A CHARACTER ELEMENT" in bortstr
         stsn = bufr.read_long_string(mnemonic='STSN')
-        rpid = bufr.read_long_string(mnemonic='RPID')
+        bortstr = ncepbufr.bortcheck()
+        assert len(bortstr) == 0
         assert stsn == test_station_names[i_msg]
+        rpid = bufr.read_long_string(mnemonic='RPID')
+        bortstr = ncepbufr.bortcheck()
+        assert len(bortstr) == 0
         assert rpid == test_report_ids[i_msg]
         i_msg = i_msg + 1
     # only loop over first 5 subsets
     if i_msg == 5: break
 bufr.close()
+bortstr = ncepbufr.bortcheck()
+assert len(bortstr) == 0
 
 print("SUCCESS!")

--- a/src/borts.F90
+++ b/src/borts.F90
@@ -157,9 +157,9 @@ end function catch_borts
 !>
 !> @param bort_str - Error string, if such a bort error occurred; otherwise empty.
 !> @param bort_str_len - Length of bort_str:
-!>  -1 = Subroutine catch_borts() was not previously called
-!>   0 = No bort error occurred
-!>  >0 = Length of bort_str, up to a maximum of 300 characters
+!>  - -1 = Subroutine catch_borts() was not previously called
+!>  -  0 = No bort error occurred
+!>  - >0 = Length of bort_str, up to a maximum of 300 characters
 !>
 !> @author J. Ator @date 2025-08-25
 recursive subroutine check_for_bort(bort_str, bort_str_len)

--- a/src/borts.c
+++ b/src/borts.c
@@ -206,3 +206,30 @@ catch_bort_ufbseq(int lunin, double *usr, int i1, int i2, int *iret, char *cstr,
     /* Recursively call the subroutine. */
     ufbseq_f(lunin, (void**) &usr, i1, i2, iret, cstr);
 }
+
+/**
+ * Catch any bort error inside of subroutine readlc().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param cstr - Mnemonic of long character string to read from data subset
+ * @param cstr_len - Length of cstr
+ * @param chr - Long character string corresponding to cstr
+ * @param chr_len - Allocated length of chr
+ * @param nchr - Number of characters returned in chr
+ *
+ * @author J. Ator @date 2025-10-15
+*/
+void
+catch_bort_readlc(int lunit, char *cstr, int cstr_len, char *chr, int chr_len, int *nchr)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if ( setjmp(context) == 1 ) return;
+
+    /* Add a trailing null to cstr, for use with get_c_string_length inside of readlc_f. */
+    cstr[cstr_len] = '\0';
+
+    /* Recursively call the subroutine. */
+    readlc_f(lunit, cstr, chr, chr_len);
+
+    *nchr = (int) strlen(chr);
+}

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -27,7 +27,7 @@ module bufr_c2f_interface
   public :: mtinfo_c, bvers_c, status_c, ibfms_c
   public :: get_isc_c, get_link_c, get_itp_c, get_typ_c, get_tag_c, get_jmpb_c
   public :: get_inode_c, get_nval_c, get_val_c, get_inv_c, get_irf_c, readlc_c
-  public :: delete_table_data_c
+  public :: delete_table_data_c, cmpmsg_c, catch_borts_c, check_for_bort_c
   public :: iupbs01_c, imrkopr_c, istdesc_c, ifxy_c
   public :: igetntbi_c, igettdi_c, stntbi_c
   public :: igetprm_c, isetprm_c, maxout_c, igetmxby_c
@@ -664,7 +664,7 @@ module bufr_c2f_interface
       inv_ptr = c_loc(inv(1, lun))
     end subroutine get_inv_c
 
-    !> Function used to get long strings from the BUFR file.
+    !> Get a long string from the BUFR file.
     !>
     !> @param lunit - Fortran logical unit.
     !> @param str_id - Mnemonic for the string for the source field plus the index number
@@ -674,7 +674,6 @@ module bufr_c2f_interface
     !>
     !> @author Ronald McLaren @date 2023-07-03
     subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')
-      use moda_rlccmn
       integer(c_int), value, intent(in) :: lunit, output_str_len
       character(kind=c_char), intent(in) :: str_id(*)
       character(kind=c_char), intent(out) :: output_str(*)
@@ -1210,5 +1209,47 @@ module bufr_c2f_interface
       ch = cf(1)
       call cmpmsg(ch)
     end subroutine cmpmsg_c
+
+    !> Specify whether subsequent bort errors should be caught and returned to
+    !> the application program
+    !>
+    !> Wraps catch_borts() function.
+    !>
+    !> @param cf - Flag indicating whether subsequent bort errors should be caught
+    !> and returned to the application program ('Y' = Yes, 'N' = No).
+    !>
+    !> @return catch_borts_c - -1 if cf contained an illegal value, otherwise 0
+    !>
+    !> @author J. Ator @date 2025-10-15
+    function catch_borts_c(cf) result(ires) bind(C, name='catch_borts_f')
+      character(kind=c_char), intent(in) :: cf(*)
+      character :: ch
+      integer(c_int) :: ires
+      integer :: catch_borts
+
+      ch = cf(1)
+      ires = catch_borts(ch)
+    end function catch_borts_c
+
+    !> Check whether a bort error was caught during a previous call to a library
+    !> function or subroutine
+    !>
+    !> Wraps check_for_bort() subroutine.
+    !>
+    !> @param error_str - Error string if a bort error occurred; otherwise empty
+    !> @param error_str_len - Allocated size of error_str
+    !>
+    !> @author J. Ator @date 2025-10-15
+    subroutine check_for_bort_c(error_str, error_str_len) bind(C, name='check_for_bort_f')
+      integer(c_int), value, intent(in) :: error_str_len
+      character(kind=c_char), intent(out) :: error_str(*)
+      character(len=310) :: error_str_f
+      integer :: error_str_len_f
+
+      call check_for_bort(error_str_f, error_str_len_f)
+
+      error_str_len_f = error_str_len_f + 1  ! add 1 for the null terminator
+      call copy_f_c_str(error_str_f, error_str, min(error_str_len_f, error_str_len))
+    end subroutine check_for_bort_c
 
 end module bufr_c2f_interface

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -673,11 +673,11 @@ module bufr_c2f_interface
     !> @param output_str_len - Size of the result string buffer
     !>
     !> @author Ronald McLaren @date 2023-07-03
-    subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')
+    recursive subroutine readlc_c(lunit, str_id, output_str, output_str_len) bind(C, name='readlc_f')
       integer(c_int), value, intent(in) :: lunit, output_str_len
       character(kind=c_char), intent(in) :: str_id(*)
       character(kind=c_char), intent(out) :: output_str(*)
-      character(len=120) :: output_str_f
+      character(len=256) :: output_str_f
       character(len=14) :: str
       integer :: output_str_len_f, lstr
 

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -407,7 +407,7 @@ void get_val_f(int lun, double **val_ptr, int *val_size);
 void get_inv_f(int lun, int **inv_ptr, int *inv_size);
 
 /**
- *  Function used to get long strings from the BUFR file.
+ * Read a long string from the BUFR file.
  *
  * @param lunit - Fortran logical unit.
  * @param str_id - Mnemonic for the string for the source field plus the index number
@@ -589,6 +589,33 @@ void bvers_f(char *cverstr, int cverstr_len);
  * @author J. Ator @date 2023-04-07
  */
 void cmpmsg_f(char *cf);
+
+/**
+ * Specify the use of compression when writing BUFR messages.
+ *
+ * Wraps catch_borts() function.
+ *
+ * @param cf - Flag indicating whether subsequent bort errors should be caught
+ * and returned to the application program ('Y' = Yes, 'N' = No).
+ *
+ * @return - -1 if cf contained an illegal value, otherwise 0
+ *
+ * @author J. Ator @date 2025-10-15
+ */
+int catch_borts_f(char *cf);
+
+/**
+ * Check whether a bort error was caught during a previous call to a library
+ * function or subroutine
+ *
+ * Wraps check_for_bort() subroutine.
+ *
+ * @param error_str - Error string if a bort error occurred; otherwise empty
+ * @param error_str_len - Allocated size of error_str
+ *
+ * @author J. Ator @date 2025-10-15
+ */
+void check_for_bort_f(char *error_str, int error_str_len);
 
 #ifdef __cplusplus
 }

--- a/src/bufrlib.F90
+++ b/src/bufrlib.F90
@@ -355,7 +355,7 @@ module bufrlib
     subroutine catch_bort_openbf_c(lunit,cio,lundx,cio_str_len) bind(C, name='catch_bort_openbf')
       use iso_c_binding
       integer(c_int), value, intent(in) :: lunit, lundx, cio_str_len
-      character(kind=c_char), intent(in) :: cio
+      character(kind=c_char), intent(inout) :: cio(*)
     end subroutine catch_bort_openbf_c
 
     !> @fn bufrlib::catch_bort_closbf_c::catch_bort_closbf_c(lunit)
@@ -442,7 +442,7 @@ module bufrlib
       use iso_c_binding
       integer(c_int), value, intent(in) :: lunin, i1, i2, cstr_len
       integer(c_int), intent(out) :: iret
-      character(kind=c_char), intent(in) :: cstr
+      character(kind=c_char), intent(inout) :: cstr(*)
       real(c_double), intent(inout) :: usr(i1,*)
     end subroutine catch_bort_ufbint_c
 
@@ -464,7 +464,7 @@ module bufrlib
       use iso_c_binding
       integer(c_int), value, intent(in) :: lunin, i1, i2, cstr_len
       integer(c_int), intent(out) :: iret
-      character(kind=c_char), intent(in) :: cstr
+      character(kind=c_char), intent(inout) :: cstr(*)
       real(c_double), intent(inout) :: usr(i1,*)
     end subroutine catch_bort_ufbrep_c
 
@@ -486,9 +486,30 @@ module bufrlib
       use iso_c_binding
       integer(c_int), value, intent(in) :: lunin, i1, i2, cstr_len
       integer(c_int), intent(out) :: iret
-      character(kind=c_char), intent(in) :: cstr
+      character(kind=c_char), intent(inout) :: cstr(*)
       real(c_double), intent(inout) :: usr(i1,*)
     end subroutine catch_bort_ufbseq_c
+
+    !> @fn bufrlib::catch_bort_readlc_c::catch_bort_readlc_c(lunit,cstr,cstr_len,chr,chr_len,nchr)
+    !> Catch any bort error inside of subroutine readlc().
+    !>
+    !> Wraps catch_bort_readlc() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param cstr - Mnemonic of long character string to read from data subset
+    !> @param cstr_len - Length of cstr
+    !> @param chr - Long character string corresponding to cstr
+    !> @param chr_len - Allocated length of chr
+    !> @param nchr - Number of characters returned in chr
+    !>
+    !> @author J. Ator @date 2025-10-15
+    subroutine catch_bort_readlc_c(lunit,cstr,cstr_len,chr,chr_len,nchr) bind(C, name='catch_bort_readlc')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, cstr_len, chr_len
+      integer(c_int), intent(out) :: nchr
+      character(kind=c_char), intent(inout) :: cstr(*)
+      character(kind=c_char), intent(out) :: chr(*)
+    end subroutine catch_bort_readlc_c
 
   end interface
 

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -409,6 +409,8 @@ end subroutine writlc
 !> @authors J. Woollen, J. Ator @date 2003-11-04
 recursive subroutine readlc(lunit,chr,str)
 
+  use bufrlib
+
   use modv_vars, only: im8b, iprt
 
   use moda_usrint
@@ -417,11 +419,12 @@ recursive subroutine readlc(lunit,chr,str)
   use moda_bitbuf
   use moda_tables
   use moda_rlccmn
+  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
-  integer my_lunit, maxtg, lchr, lun, il, im, ntg, nnod, kon, ii, n, nod, ioid, itagct, nchr, kbit
+  integer my_lunit, maxtg, lchr, lun, il, im, ntg, nnod, kon, ii, n, nod, ioid, itagct, nchr, kbit, lcstr, lcchr, ncchr
 
   character*(*), intent(in) :: str
   character*(*), intent(out) :: chr
@@ -429,6 +432,8 @@ recursive subroutine readlc(lunit,chr,str)
   character*128 bort_str, errstr
   character*10 ctag
   character*14 tgs(10)
+  character*15 cstr
+  character*(:), allocatable :: cchr
 
   real roid
 
@@ -445,6 +450,20 @@ recursive subroutine readlc(lunit,chr,str)
 
   chr = ' '
   lchr=len(chr)
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call strsuc(str,cstr,lcstr)
+    lcchr = lchr + 1  ! Allow extra byte in cchr for the trailing null in C
+    allocate(character*(lcchr) :: cchr)
+    call catch_bort_readlc_c(lunit,cstr,lcstr,cchr,lcchr,ncchr)
+    chr(1:ncchr) = cchr(1:ncchr)
+    deallocate(cchr)
+    bort_target_is_unset = .true.
+    return
+  endif
 
   ! Check the file status
   call status(lunit,lun,il,im)

--- a/test/test_c_interface_2.c
+++ b/test/test_c_interface_2.c
@@ -16,6 +16,7 @@ static const int BUFR_OUTPUT_FILE_UNIT = 51;
 static const int TABLE_1_FILE_UNIT = 90;
 static const int TABLE_2_FILE_UNIT = 91;
 static const int SUBSET_STRING_LEN = 12;
+static const int BORT_STRING_LEN = 200;
 
 static const char* INPUT_FILE = "testfiles/IN_4";
 static const char* OUTPUT_FILE = "testfiles/test_c_interface_2.out";
@@ -26,6 +27,7 @@ int main() {
     int iret;
     int iddate;
     char msg_subset[SUBSET_STRING_LEN];
+    char bort_string[BORT_STRING_LEN];
 
     double r8arr[180][15];
     double* r8arr_ptr = &r8arr[0][0];
@@ -37,6 +39,9 @@ int main() {
     /* Set and confirm a global library parameter. */
     if ( ( iret = isetprm_f( "NFILES" ,5 ) ) != 0 ) exit(1);
     if ( ( iret = igetprm_f( "NFILES" ) ) != 5 ) exit(1);
+
+    /* Turn on bort catching. */
+    if ( ( iret = catch_borts_f("Y") ) != 0 ) exit(1);
 
     /* Open the input file to the library. */
     openbf_f( BUFR_INPUT_FILE_UNIT, "SEC3", BUFR_INPUT_FILE_UNIT );
@@ -55,11 +60,21 @@ int main() {
         exit(1);
     }
 
-    /* Read the first data subset from the BUFR message and check some values. */
+    /* Test catching a bort from ireadsb by intentionally passing in a bad unit number. */
+    iret = ireadsb_f( BUFR_INPUT_FILE_UNIT*10 );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) == 0 ) ||
+         ( strcmp( bort_string, "BUFRLIB: STATUS - INPUT UNIT NUMBER (110) OUTSIDE LEGAL RANGE OF 1-99" ) != 0 ) ) {
+        printf( "%s\n", "ireadsb check_for_bort check FAILED!" );
+        exit(1);
+    }
+    /* Now pass in the correct unit number to ireadsb in order to read the first data subset from the BUFR message. */
     if ( ireadsb_f( BUFR_INPUT_FILE_UNIT ) != 0 ) {
         printf( "%s\n", "ireadsb check FAILED!" );
         exit(1);
     }
+
+    /* Check some data values. */
     ufbint_f( BUFR_INPUT_FILE_UNIT, (void**) &r8arr_ptr, 15, 180, &iret, "CLONH SAID SAZA" );
     if ( ( ( (int) round( r8arr[0][0] * 100000 ) ) != -4246453 ) ||
          ( ( (int) round( r8arr[0][1] ) ) != 57 ) ||
@@ -73,6 +88,12 @@ int main() {
          ( ( (int) round( r8arr[101][0] ) ) != 88 ) ||
          ( ( (int) round( r8arr[140][0] ) ) != 10 ) ) {
         printf( "%s\n", "ufbrep check FAILED!" );
+        exit(1);
+    }
+    /* Confirm that a bort was *NOT* caught during the just-completed call to ufbrep_f */
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf( "%s\n", "ufbrep check_for_bort check FAILED!" );
         exit(1);
     }
 


### PR DESCRIPTION
Part of #340
Part of #675

This adds the needed functionality to catch bort errors from within C and Python applications, as shown within the included modifications to the `test/test_c_interface_2.c` and `python/test/test_misc.py` test codes, respectively.

The only reason I didn't go ahead and close either of the above issues as fully "Fix"ed is because there are still a number of library routines which need bort catching wrappers, and so that part of the overall task isn't complete yet.  But FWIW, this PR does include such a wrapper for subroutine readlc(), so at least that's one more we can check off the list :-)