### PR TITLE
more bort catching updates

### DIFF
--- a/.github/workflows/MacOS.yaml
+++ b/.github/workflows/MacOS.yaml
@@ -16,8 +16,8 @@ jobs:
   MacOS:
     runs-on: macos-latest
     env:
-      FC: gfortran-12
-      F90: gfortran-12
+      FC: gfortran-13
+      F90: gfortran-13
 
     steps:
 
@@ -33,7 +33,7 @@ jobs:
         pip3 install ninja
         pip3 install netCDF4
         pip3 install protobuf
-        sudo ln -sf /usr/local/bin/gfortran-12 /usr/local/bin/gfortran
+        sudo ln -sf /usr/local/bin/gfortran-13 /usr/local/bin/gfortran
           
     - name: checkout-bufr
       uses: actions/checkout@v4

--- a/src/borts.F90
+++ b/src/borts.F90
@@ -149,6 +149,44 @@ integer function catch_borts(cbc) result (iret)
   return
 end function catch_borts
 
+!> Sets a new bort target, if bort catching is enabled and such a target doesn't already exist.
+!>
+!> @returns bort_target_set - Return code:
+!>  - 0 = a new bort target was not set during this call, or bort catching is disabled
+!>  - 1 = a new bort target was set during this call
+!>
+!> @author J. Ator @date 2025-11-05
+integer function bort_target_set() result (iret)
+
+  use moda_borts
+
+  implicit none
+
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    iret = 1
+  else
+    iret = 0
+  endif
+
+  return
+end function bort_target_set
+
+!> Clear any existing bort target.
+!>
+!> @author J. Ator @date 2025-11-05
+subroutine bort_target_unset
+
+  use moda_borts
+
+  implicit none
+
+  bort_target_is_unset = .true.
+
+  return
+end subroutine bort_target_unset
+
 !> Check whether a bort error occurred during a previous call to an NCEPLIBS-bufr
 !> subroutine or function.
 !>
@@ -175,7 +213,6 @@ recursive subroutine check_for_bort(bort_str, bort_str_len)
   integer, intent(out) :: bort_str_len
 
   ! Check for I8 integers
-
   if(im8b) then
     im8b = .false.
     call check_for_bort(bort_str,bort_str_len)

--- a/src/borts.c
+++ b/src/borts.c
@@ -625,3 +625,51 @@ catch_bort_cwbmg(char *bmg, int nmb, int *iret)
     /* Recursively call the subroutine. */
     cwbmg(bmg, nmb, iret);
 }
+
+/**
+ * Catch any bort error inside of subroutine ufbtab().
+ *
+ * @param lunin - Absolute value is Fortran logical unit number for BUFR file
+ * @param tab - Data values
+ * @param i1 - First dimension of tab
+ * @param i2 - Second dimension of tab
+ * @param iret - Number of data subsets returned
+ * @param cstr - String of mnemonics to read from each data subset
+ * @param cstr_len - Length of cstr
+ *
+ * @author J. Ator @date 2025-11-13
+*/
+void
+catch_bort_ufbtab(int lunin, double *tab, int i1, int i2, int *iret, char *cstr, int cstr_len)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if ( setjmp(context) == 1 ) return;
+
+    /* Add a trailing null to cstr, for use with get_c_string_length inside of ufbtab_f. */
+    cstr[cstr_len] = '\0';
+
+    /* Recursively call the subroutine. */
+    ufbtab_f(lunin, (void**) &tab, i1, i2, iret, cstr);
+}
+
+/**
+ * Catch any bort error inside of subroutine ufbpos().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param irec - Ordinal number of message to be read
+ * @param isub - Ordinal number of subset to be read from (irec)th message
+ * @param subset - Table A mnemonic for type of BUFR message that was read
+ * @param jdate - Date-time stored within Section 1 of BUFR message that was read
+ * @param subset_str_len - Allocated length of subset string
+ *
+ * @author J. Ator @date 2025-11-13
+*/
+void
+catch_bort_ufbpos(int lunit, int irec, int isub, char *subset, int *jdate, int subset_str_len)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if ( setjmp(context) == 1 ) return;
+
+    /* Recursively call the subroutine. */
+    ufbpos_f(lunit, irec, isub, subset, jdate, subset_str_len);
+}

--- a/src/borts.c
+++ b/src/borts.c
@@ -565,3 +565,63 @@ catch_bort_upftbv(int lunit, char *cnemo, int lcn, double val, int *ibit, int mx
     /* Recursively call the subroutine. */
     upftbv_f(lunit, cnemo, val, ibit, mxib, nib);
 }
+
+/**
+ * Catch any bort error inside of function cobfl().
+ *
+ * @param bfl - System file to be opened
+ * @param io - Flag indicating how bfl is to be opened
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_cobfl(char *bfl, char io)
+{
+
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Recursively call the subroutine. */
+    cobfl(bfl, io);
+}
+
+/**
+ * Catch any bort error inside of function crbmg().
+ *
+ * @param bmg - BUFR message
+ * @param mxmb - Allocated length of bmg
+ * @param nmb - Number of characters returned in bmg
+ * @param iret - Return code
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_crbmg(char *bmg, int mxmb, int *nmb, int *iret)
+{
+
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Recursively call the subroutine. */
+    crbmg(bmg, mxmb, nmb, iret);
+}
+
+/**
+ * Catch any bort error inside of function cwbmg().
+ *
+ * @param bmg - BUFR message
+ * @param nmb - Number of characters in bmg
+ * @param iret - Return code
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_cwbmg(char *bmg, int nmb, int *iret)
+{
+
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Recursively call the subroutine. */
+    cwbmg(bmg, nmb, iret);
+}

--- a/src/borts.c
+++ b/src/borts.c
@@ -505,3 +505,63 @@ catch_bort_ufbqcp(int lunit, int iqcp, char *cnemo, int cnemo_len, int *ncn)
 
     *ncn = (int) strlen(cnemo);
 }
+
+/**
+ * Catch any bort error inside of subroutine getcfmng().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param cnemoi - Mnemonic to search for
+ * @param lcni - Length of cnemoi
+ * @param ivali - Value associated with cnemoi
+ * @param cnemod - Optional second mnemonic upon which cnemoi may depend
+ * @param lcnd - Length of cnemod
+ * @param ivald - Value associated with cnemod
+ * @param cmeang_c - Meaning associated with cnemoi and ivali (and possibly cnemod and ivald as well)
+ * @param lcmgc - Allocated length of cmeang_c
+ * @param lnmng - Number of characters returned in cmeang_c
+ * @param iret - Return code from call to getcfmng_f
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_getcfmng(int lunit, char *cnemoi, int lcni, int ivali, char *cnemod, int lcnd, int ivald,
+                    char *cmeang_c, int lcmgc, int *lnmng, int *iret)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Add trailing nulls to input strings, for use with get_c_string_length inside of getcfmng_f. */
+    cnemoi[lcni] = '\0';
+    cnemod[lcnd] = '\0';
+
+    /* Recursively call the subroutine. */
+    getcfmng_f(lunit, cnemoi, ivali, cnemod, ivald, cmeang_c, lcmgc, iret);
+
+    *lnmng = (int) strlen(cmeang_c);
+}
+
+/**
+ * Catch any bort error inside of subroutine upftbv().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param cnemo - Mnemonic with flag table units
+ * @param lcn - Length of cnemo
+ * @param val - Value corresponding to cnemo
+ * @param ibit - Bit numbers which were set to "On" in val
+ * @param mxib - Allocated size of ibit
+ * @param nib - Number of bit numbers returned in ibit
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_upftbv(int lunit, char *cnemo, int lcn, double val, int *ibit, int mxib, int *nib)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Add a trailing null to cnemo, for use with get_c_string_length inside of upftbv_f. */
+    cnemo[lcn] = '\0';
+
+    /* Recursively call the subroutine. */
+    upftbv_f(lunit, cnemo, val, ibit, mxib, nib);
+}

--- a/src/borts.c
+++ b/src/borts.c
@@ -309,6 +309,34 @@ catch_bort_ufbstp(int lunin, double *usr, int i1, int i2, int *iret, char *cstr,
     /* Recursively call the subroutine. */
     ufbstp_f(lunin, (void**) &usr, i1, i2, iret, cstr);
 }
+
+/**
+ * Catch any bort error inside of subroutine ufbevn().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param usr - Data values
+ * @param i1 - First dimension of usr
+ * @param i2 - Second dimension of usr
+ * @param i3 - Third dimension of usr
+ * @param iret - Number of replications of cstr that were read from the data subset
+ * @param cstr - String of mnemonics to read from the data subset
+ * @param cstr_len - Length of cstr
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_ufbevn(int lunit, double *usr, int i1, int i2, int i3, int *iret, char *cstr, int cstr_len)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if ( setjmp(context) == 1 ) return;
+
+    /* Add a trailing null to cstr, for use with get_c_string_length inside of ufbevn_f. */
+    cstr[cstr_len] = '\0';
+
+    /* Recursively call the subroutine. */
+    ufbevn_f(lunit, (void**) &usr, i1, i2, i3, iret, cstr);
+}
+
 /**
  * Catch any bort error inside of subroutine drfini().
  *
@@ -411,4 +439,69 @@ catch_bort_writlc(int lunit, char *cstr, int cstr_len, char *cchr, int cchr_len)
 
     /* Recursively call the subroutine. */
     writlc_f(lunit, cstr, cchr);
+}
+
+/**
+ * Catch any bort error inside of subroutine ufbcnt().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param kmsg - Message number
+ * @param ksub - Subset number
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_ufbcnt(int lunit, int *kmsg, int *ksub)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Recursively call the subroutine. */
+    ufbcnt_f(lunit, kmsg, ksub);
+}
+
+/**
+ * Catch any bort error inside of subroutine ufbqcd().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param cnemo - Mnemonic associated with a Category 63 Table D descriptor
+ * @param iqcd - Y value of descriptor associated with mnemonic
+ * @param cnemo_len - Length of cnemo
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_ufbqcd(int lunit, char *cnemo, int *iqcd, int cnemo_len)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Add a trailing null to cnemo, for use with get_c_string_length inside of ufbqcd_f. */
+    cnemo[cnemo_len] = '\0';
+
+    /* Recursively call the subroutine. */
+    ufbqcd_f(lunit, cnemo, iqcd);
+}
+
+/**
+ * Catch any bort error inside of subroutine ufbqcp().
+ *
+ * @param lunit - Fortran logical unit number for BUFR file
+ * @param iqcp - Y value of a Category 63 Table D descriptor
+ * @param cnemo - Mnemonic associated with iqcp
+ * @param cnemo_len - Allocated length of cnemo string
+ * @param ncn - Number of characters returned in cnemo
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void
+catch_bort_ufbqcp(int lunit, int iqcp, char *cnemo, int cnemo_len, int *ncn)
+{
+    /* Set the target location to which to return if a bort error is caught. */
+    if (setjmp(context) == 1) return;
+
+    /* Recursively call the subroutine. */
+    ufbqcp_f(lunit, iqcp, cnemo, cnemo_len);
+
+    *ncn = (int) strlen(cnemo);
 }

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -26,7 +26,7 @@ module bufr_c2f_interface
   public :: get_inv_c, get_irf_c, readlc_c, delete_table_data_c, cmpmsg_c, catch_borts_c, check_for_bort_c, iupbs01_c
   public :: imrkopr_c, istdesc_c, ifxy_c, igetntbi_c, igettdi_c, stntbi_c, igetprm_c, isetprm_c, maxout_c, igetmxby_c
   public :: elemdx_c, cadn30_c, strnum_c, uptdd_c, pktdd_c, nemdefs_c, nemspecs_c, nemtab_c, nemtbb_c, numtbd_c
-  public :: writsb_c, writsa_c, ufbstp_c, writlc_c, drfini_c
+  public :: writsb_c, writsa_c, ufbstp_c, writlc_c, drfini_c, ufbcnt_c, ufbevn_c, ufbqcd_c, ufbqcp_c
 
   integer, allocatable, target, save :: isc_f(:), link_f(:), itp_f(:), jmpb_f(:), irf_f(:)
   character(len=10), allocatable, target, save :: tag_f(:)
@@ -81,7 +81,7 @@ module bufr_c2f_interface
     !>
     !> @author Ronald McLaren @date 2020-07-29
     subroutine copy_f_c_str(f_str, c_str, c_str_len)
-      character(len=*), target, intent(in) :: f_str
+      character(len=*), intent(in) :: f_str
       character(kind=c_char), intent(inout) :: c_str(*)
       integer, intent(in) :: c_str_len
       integer :: ii
@@ -176,10 +176,9 @@ module bufr_c2f_interface
     !>
     !> @author Ronald McLaren @date 2020-07-29
     function ireadmg_c(bufr_unit, c_subset, iddate, subset_str_len) result(ires) bind(C, name='ireadmg_f')
-      integer(c_int), value, intent(in) :: bufr_unit
+      integer(c_int), value, intent(in) :: bufr_unit, subset_str_len
       character(kind=c_char), intent(out) :: c_subset(*)
       integer(c_int), intent(out) :: iddate
-      integer(c_int), value, intent(in) :: subset_str_len
       integer(c_int) :: ires
       character(len=25) :: f_subset
       integer :: ireadmg
@@ -205,10 +204,9 @@ module bufr_c2f_interface
     !>
     !> @author Jeff Ator @date 2025-08-25
     recursive subroutine readmg_c(bufr_unit, c_subset, iddate, subset_str_len, ires) bind(C, name='readmg_f')
-      integer(c_int), value, intent(in) :: bufr_unit
+      integer(c_int), value, intent(in) :: bufr_unit, subset_str_len
       character(kind=c_char), intent(out) :: c_subset(*)
       integer(c_int), intent(out) :: iddate, ires
-      integer(c_int), value, intent(in) :: subset_str_len
       character(len=25) :: f_subset
 
       call readmg(bufr_unit, f_subset, iddate, ires)
@@ -361,6 +359,32 @@ module bufr_c2f_interface
       call c_f_pointer(c_data, f_data)
       call ufbstp(bufr_unit, f_data, dim_1, dim_2, iret, str(1:lstr))
     end subroutine ufbstp_c
+
+    !> Read one or more data values from a data subset.
+    !>
+    !> Wraps ufbevn() subroutine.
+    !>
+    !> @param bufr_unit - Fortran logical unit number to read from
+    !> @param c_data - C-style pointer to a pre-allocated buffer
+    !> @param dim_1, dim_2, dim_3 - Dimensionality of data to read
+    !> @param iret - Return value, length of data read
+    !> @param table_b_mnemonic - String of mnemonics
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine ufbevn_c(bufr_unit, c_data, dim_1, dim_2, dim_3, iret, table_b_mnemonic) bind(C, name='ufbevn_f')
+      integer(c_int), value, intent(in) :: bufr_unit, dim_1, dim_2, dim_3
+      type(c_ptr), intent(out) ::  c_data
+      integer(c_int), intent(out) :: iret
+      character(kind=c_char), intent(in) :: table_b_mnemonic(*)
+      character(len=90) :: str
+      real, pointer :: f_data
+      integer :: lstr
+
+      lstr = get_c_string_length(table_b_mnemonic)
+      str = transfer(table_b_mnemonic(1:lstr), str)
+      call c_f_pointer(c_data, f_data)
+      call ufbevn(bufr_unit, f_data, dim_1, dim_2, dim_3, iret, str(1:lstr))
+    end subroutine ufbevn_c
 
     !> Specify location of master BUFR tables on local file system.
     !>
@@ -1369,5 +1393,64 @@ module bufr_c2f_interface
       error_str_len_f = error_str_len_f + 1  ! add 1 for the null terminator
       call copy_f_c_str(error_str_f, error_str, min(error_str_len_f, error_str_len))
     end subroutine check_for_bort_c
+
+    !> Get the current location of the file pointer within a BUFR file.
+    !>
+    !> Wraps ufbcnt() subroutine.
+    !>
+    !> @param lunit - Fortran logical unit.
+    !> @param kmsg - Message number
+    !> @param ksub - Subset number
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine ufbcnt_c(lunit, kmsg, ksub) bind(C, name='ufbcnt_f')
+      integer(c_int), value, intent(in) :: lunit
+      integer(c_int), intent(out) :: kmsg, ksub
+
+      call ufbcnt(lunit, kmsg, ksub)
+    end subroutine ufbcnt_c
+
+    !> Return a prepbufr program code corresponding to a mnemonic.
+    !>
+    !> Wraps ufbqcd() subroutine.
+    !>
+    !> @param lunit - Fortran logical unit.
+    !> @param cnemo - Mnemonic
+    !> @param iqcd - Y value of descriptor associated with mnemonic
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine ufbqcd_c(lunit, cnemo, iqcd) bind(C, name='ufbqcd_f')
+      integer(c_int), value, intent(in) :: lunit
+      integer(c_int), intent(out) :: iqcd
+      character(kind=c_char), intent(in) :: cnemo(*)
+      character(len=12) :: nemo
+      integer :: lcn
+
+      lcn = get_c_string_length(cnemo)
+      nemo = transfer(cnemo(1:lcn), nemo)
+      call ufbqcd(lunit, nemo(1:lcn), iqcd)
+    end subroutine ufbqcd_c
+
+    !> Return a mnemonic corresponding to a prepbufr program code.
+    !>
+    !> Wraps ufbqcp() subroutine.
+    !>
+    !> @param lunit - Fortran logical unit.
+    !> @param iqcp - Y value of a Category 63 Table D descriptor
+    !> @param cnemo - Mnemonic associated with iqcp
+    !> @param cnemo_len - Allocated length of cnemo string
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine ufbqcp_c(lunit, iqcp, cnemo, cnemo_len) bind(C, name='ufbqcp_f')
+      integer(c_int), value, intent(in) :: lunit, iqcp, cnemo_len
+      character(kind=c_char), intent(out) :: cnemo(*)
+      character(len=8) :: nemo
+      integer :: lnm
+
+      call ufbqcp(lunit, iqcp, nemo)
+
+      lnm = len(trim(nemo)) + 1  ! add 1 for the null terminator
+      call copy_f_c_str(nemo, cnemo, min(lnm, cnemo_len))
+    end subroutine ufbqcp_c
 
 end module bufr_c2f_interface

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -1270,10 +1270,15 @@ module bufr_c2f_interface
     !> @param errstr - Error message.
     !>
     !> @author J. Ator @date 2023-04-07
-    subroutine bort_c(errstr) bind(C, name='bort_f')
+    recursive subroutine bort_c(errstr) bind(C, name='bort_f')
       character(kind=c_char), intent(in) :: errstr(*)
+      character(len=255) :: my_errstr
+      integer :: lers
 
-      call bort(c_f_string(errstr))
+      lers = get_c_string_length(errstr)
+      my_errstr = transfer(errstr(1:lers), my_errstr)
+
+      call bort(my_errstr(1:lers))
     end subroutine bort_c
 
     !> Open a new message for output in a BUFR file that was
@@ -1373,6 +1378,31 @@ module bufr_c2f_interface
       ch = cf(1)
       ires = catch_borts(ch)
     end function catch_borts_c
+
+    !> Sets a new bort target, if bort catching is enabled and such a target doesn't already exist.
+    !>
+    !> Wraps bort_target_set() function.
+    !>
+    !> @returns bort_target_set_c - Return code:
+    !>  - 0 = a new bort target was not set during this call, or bort catching is disabled
+    !>  - 1 = a new bort target was set during this call
+    !>
+    !> @author J. Ator @date 2025-11-05
+    function bort_target_set_c() result(ires) bind(C, name='bort_target_set_f')
+      integer(c_int) :: ires
+      integer :: bort_target_set
+
+      ires = bort_target_set()
+    end function bort_target_set_c
+
+    !> Clear any existing bort target.
+    !>
+    !> Wraps bort_target_unset() function.
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine bort_target_unset_c() bind(C, name='bort_target_unset_f')
+      call bort_target_unset
+    end subroutine bort_target_unset_c
 
     !> Check whether a bort error was caught during a previous call to a library
     !> function or subroutine
@@ -1474,17 +1504,14 @@ module bufr_c2f_interface
       character(kind=c_char), intent(out) :: cmeang_c(*)
       character(len=600) :: cmeang
       character(len=8) :: nemoi, nemod
-      integer :: lcni, lcnd, lcmg, mxchr_f
+      integer :: lcni, lcnd, lcmg
 
       lcni = get_c_string_length(cnemoi)
       nemoi = transfer(cnemoi(1:lcni), nemoi)
       lcnd = get_c_string_length(cnemod)
       nemod = transfer(cnemod(1:lcnd), nemod)
 
-      ! leave room for a trailing null when determining how much space to allow getcfmng to write into
-      mxchr_f = min(len(cmeang), lcmgc) - 1
-
-      call getcfmng(lunit, nemoi(1:lcni), ivali, nemod(1:lcnd), ivald, cmeang(1:mxchr_f), lcmg, iret)
+      call getcfmng(lunit, nemoi(1:lcni), ivali, nemod(1:lcnd), ivald, cmeang(1:min(len(cmeang), lcmgc)), lcmg, iret)
 
       lcmg = lcmg + 1  ! add 1 for the null terminator
       call copy_f_c_str(cmeang, cmeang_c, min(lcmg, lcmgc))

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -27,7 +27,7 @@ module bufr_c2f_interface
   public :: imrkopr_c, istdesc_c, ifxy_c, igetntbi_c, igettdi_c, stntbi_c, igetprm_c, isetprm_c, maxout_c, igetmxby_c
   public :: elemdx_c, cadn30_c, strnum_c, uptdd_c, pktdd_c, nemdefs_c, nemspecs_c, nemtab_c, nemtbb_c, numtbd_c
   public :: writsb_c, writsa_c, ufbstp_c, writlc_c, drfini_c, ufbcnt_c, ufbevn_c, ufbqcd_c, ufbqcp_c, getcfmng_c
-  public :: upftbv_c
+  public :: upftbv_c, ufbtab_c, ufbpos_c
 
   integer, allocatable, target, save :: isc_f(:), link_f(:), itp_f(:), jmpb_f(:), irf_f(:)
   character(len=10), allocatable, target, save :: tag_f(:)
@@ -1541,5 +1541,55 @@ module bufr_c2f_interface
       nemo = transfer(cnemo(1:lcn), nemo)
       call upftbv(lunit, nemo(1:lcn), val, mxib, ibit, nib)
     end subroutine upftbv_c
+
+    !> Read one or more data values from every data subset in a BUFR file.
+    !>
+    !> Wraps ufbtab() subroutine.
+    !>
+    !> @param bufr_unit - Fortran logical unit number to read from
+    !> @param c_data - C-style pointer to a pre-allocated buffer
+    !> @param dim_1, dim_2 - Dimensionality of data to read
+    !> @param iret - Return value, number of data subsets read
+    !> @param table_b_mnemonic - String of mnemonics to read from each data subset
+    !>
+    !> @author J. Ator @date 2025-11-13
+    recursive subroutine ufbtab_c(bufr_unit, c_data, dim_1, dim_2, iret, table_b_mnemonic) bind(C, name='ufbtab_f')
+      integer(c_int), value, intent(in) :: bufr_unit, dim_1, dim_2
+      type(c_ptr), intent(inout) ::  c_data
+      integer(c_int), intent(inout) :: iret
+      character(kind=c_char), intent(in) :: table_b_mnemonic(*)
+      character(len=90) :: str
+      real, pointer :: f_data
+      integer :: lstr
+
+      lstr = get_c_string_length(table_b_mnemonic)
+      str = transfer(table_b_mnemonic(1:lstr), str)
+      call c_f_pointer(c_data, f_data)
+
+      call ufbtab(bufr_unit, f_data, dim_1, dim_2, iret, str(1:lstr))
+    end subroutine ufbtab_c
+
+    !> Jump forwards or backwards to a specified data subset within a BUFR file.
+    !>
+    !> Wraps ufbpos() subroutine.
+    !>
+    !> @param bufr_unit - Fortran logical unit number to read from
+    !> @param irec - Ordinal number of message to be read
+    !> @param isub - Ordinal number of subset to be read from (irec)th message
+    !> @param c_subset - Subset string
+    !> @param iddate - Datetime of message
+    !> @param subset_str_len - Length of the subset string
+    !>
+    !> @author Jeff Ator @date 2025-11-13
+    recursive subroutine ufbpos_c(bufr_unit, irec, isub, c_subset, iddate, subset_str_len) bind(C, name='ufbpos_f')
+      integer(c_int), value, intent(in) :: bufr_unit, subset_str_len, irec, isub
+      character(kind=c_char), intent(out) :: c_subset(*)
+      integer(c_int), intent(out) :: iddate
+      character(len=25) :: f_subset
+
+      call ufbpos(bufr_unit, irec, isub, f_subset, iddate)
+
+      call copy_f_c_str(f_subset, c_subset, subset_str_len)
+    end subroutine ufbpos_c
 
 end module bufr_c2f_interface

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -26,7 +26,8 @@ module bufr_c2f_interface
   public :: get_inv_c, get_irf_c, readlc_c, delete_table_data_c, cmpmsg_c, catch_borts_c, check_for_bort_c, iupbs01_c
   public :: imrkopr_c, istdesc_c, ifxy_c, igetntbi_c, igettdi_c, stntbi_c, igetprm_c, isetprm_c, maxout_c, igetmxby_c
   public :: elemdx_c, cadn30_c, strnum_c, uptdd_c, pktdd_c, nemdefs_c, nemspecs_c, nemtab_c, nemtbb_c, numtbd_c
-  public :: writsb_c, writsa_c, ufbstp_c, writlc_c, drfini_c, ufbcnt_c, ufbevn_c, ufbqcd_c, ufbqcp_c
+  public :: writsb_c, writsa_c, ufbstp_c, writlc_c, drfini_c, ufbcnt_c, ufbevn_c, ufbqcd_c, ufbqcp_c, getcfmng_c
+  public :: upftbv_c
 
   integer, allocatable, target, save :: isc_f(:), link_f(:), itp_f(:), jmpb_f(:), irf_f(:)
   character(len=10), allocatable, target, save :: tag_f(:)
@@ -275,7 +276,7 @@ module bufr_c2f_interface
     !> @param nbufr - Number of integers returned in bufr array, or 0 if no message was returned
     !>
     !> @author Jeff Ator @date 2025-10-20
-    recursive subroutine writsa_c(bufr_unit,bufr_len,bufr,nbufr) bind(C, name='writsa_f')
+    recursive subroutine writsa_c(bufr_unit, bufr_len, bufr, nbufr) bind(C, name='writsa_f')
       integer(c_int), value, intent(in) :: bufr_unit, bufr_len
       integer(c_int), intent(out) :: bufr(*), nbufr
 
@@ -1452,5 +1453,66 @@ module bufr_c2f_interface
       lnm = len(trim(nemo)) + 1  ! add 1 for the null terminator
       call copy_f_c_str(nemo, cnemo, min(lnm, cnemo_len))
     end subroutine ufbqcp_c
+
+    !> Get the meaning of a numerical value from a code or flag table
+    !>
+    !> @param lunit - Fortran logical unit.
+    !> @param cnemoi - Mnemonic to search for
+    !> @param ivali - Value associated with cnemoi
+    !> @param cnemod - Optional second mnemonic upon which cnemoi may depend
+    !> @param ivald - Value associated with cnemod
+    !> @param cmeang_c - Meaning associated with cnemoi and ivali (and possibly cnemod and ivald as well)
+    !> @param lcmgc - Allocated length of cmeang_c
+    !> @param iret - Return code from call to getcfmng
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine getcfmng_c(lunit, cnemoi, ivali, cnemod, ivald, cmeang_c, lcmgc, iret) &
+        bind(C, name='getcfmng_f')
+      integer(c_int), value, intent(in) :: lunit, ivali, ivald, lcmgc
+      integer(c_int), intent(out) :: iret
+      character(kind=c_char), intent(in) :: cnemoi(*), cnemod(*)
+      character(kind=c_char), intent(out) :: cmeang_c(*)
+      character(len=600) :: cmeang
+      character(len=8) :: nemoi, nemod
+      integer :: lcni, lcnd, lcmg, mxchr_f
+
+      lcni = get_c_string_length(cnemoi)
+      nemoi = transfer(cnemoi(1:lcni), nemoi)
+      lcnd = get_c_string_length(cnemod)
+      nemod = transfer(cnemod(1:lcnd), nemod)
+
+      ! leave room for a trailing null when determining how much space to allow getcfmng to write into
+      mxchr_f = min(len(cmeang), lcmgc) - 1
+
+      call getcfmng(lunit, nemoi(1:lcni), ivali, nemod(1:lcnd), ivald, cmeang(1:mxchr_f), lcmg, iret)
+
+      lcmg = lcmg + 1  ! add 1 for the null terminator
+      call copy_f_c_str(cmeang, cmeang_c, min(lcmg, lcmgc))
+    end subroutine getcfmng_c
+
+    !> Get the bit settings equivalent to a given numerical value for a flag table mnemonic.
+    !>
+    !> Wraps upftbv() subroutine.
+    !>
+    !> @param lunit - Fortran logical unit.
+    !> @param cnemo - Mnemonic with flag table units
+    !> @param val - Value corresponding to cnemo
+    !> @param ibit - Bit numbers which were set to "On" in val
+    !> @param mxib - Allocated size of ibit
+    !> @param nib - Number of bit numbers returned in ibit
+    !>
+    !> @author J. Ator @date 2025-11-05
+    recursive subroutine upftbv_c(lunit, cnemo, val, ibit, mxib, nib) bind(C, name='upftbv_f')
+      integer(c_int), value, intent(in) :: lunit, mxib
+      integer(c_int), intent(out) :: ibit(*), nib
+      real(c_double), value, intent(in) :: val
+      character(kind=c_char), intent(in) :: cnemo(*)
+      character(len=12) :: nemo
+      integer :: lcn
+
+      lcn = get_c_string_length(cnemo)
+      nemo = transfer(cnemo(1:lcn), nemo)
+      call upftbv(lunit, nemo(1:lcn), val, mxib, ibit, nib)
+    end subroutine upftbv_c
 
 end module bufr_c2f_interface

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -791,6 +791,39 @@ void getcfmng_f(int lunit, char *cnemoi, int ivali, char *cnemod, int ivald, cha
 */
 void upftbv_f(int lunit, char *cnemo, double val, int *ibit, int mxib, int *nib);
 
+/**
+ * Read one or more data values from every data subset in a BUFR file.
+ *
+ * Wraps ufbtab() subroutine.
+ *
+ * @param bufr_unit - the Fortran logical unit number to read from
+ * @param c_data - pointer to a pointer to a pre-allocated buffer.
+ * @param dim_1 - dimensionality of data to read
+ * @param dim_2 - dimensionality of data to read
+ * @param iret - return value, number of data subsets read
+ * @param table_b_mnemonic - String of mnemonics to read from each data subset
+ *
+ * @author J. Ator @date 2025-11-13
+ */
+void ufbtab_f(int bufr_unit, void **c_data, int dim_1, int dim_2,
+              int *iret, const char *table_b_mnemonic);
+
+/**
+ * Jump forwards or backwards to a specified data subset within a BUFR file.
+ *
+ * Wraps ufbpos() subroutine.
+ *
+ * @param bufr_unit - the Fortran logical unit number to read from
+ * @param irec - Ordinal number of message to be read
+ * @param isub - Ordinal number of subset to be read from (irec)th message
+ * @param subset - the subset string
+ * @param iddate - datetime of message
+ * @param subset_len - length of the subset string
+ *
+ * @author Jeff Ator @date 2025-11-13
+ */
+void ufbpos_f(int bufr_unit, int irec, int isub, char *subset, int *iddate, int subset_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -171,11 +171,11 @@ void writsa_f(int bufr_unit, int bufr_len, int *bufr, int *nbufr);
  *
  * Wraps ufbint() subroutine.
  *
- * @param bufr_unit - the Fortran logical unit number to read from.
+ * @param bufr_unit - the Fortran logical unit number to read from or write to.
  * @param c_data - pointer to a pointer to a pre-allocated buffer.
  * @param dim_1 - dimensionality of data to read or write.
  * @param dim_2 - dimensionality of data to read or write.
- * @param iret - return value, length of data read.
+ * @param iret - return value, length of data read or written.
  * @param table_b_mnemonic - string of mnemonics.
  *
  * @author Ronald Mclaren @date 2020-07-29
@@ -188,11 +188,11 @@ void ufbint_f(int bufr_unit, void **c_data, int dim_1, int dim_2,
  *
  * Wraps ufbrep() subroutine.
  *
- * @param bufr_unit - the Fortran logical unit number to read from.
+ * @param bufr_unit - the Fortran logical unit number to read from or write to.
  * @param c_data - pointer to a pointer to a pre-allocated buffer.
  * @param dim_1 - dimensionality of data to read or write.
  * @param dim_2 - dimensionality of data to read or write.
- * @param iret - length of data read.
+ * @param iret - length of data read or written.
  * @param table_b_mnemonic - string of mnemonics.
  *
  * @author Ronald Mclaren @date 2020-07-29
@@ -205,16 +205,34 @@ void ufbrep_f(int bufr_unit, void **c_data, int dim_1, int dim_2,
  *
  * Wraps ufbstp() subroutine.
  *
- * @param bufr_unit - the Fortran logical unit number to read from.
+ * @param bufr_unit - the Fortran logical unit number to read from or write to.
  * @param c_data - pointer to a pointer to a pre-allocated buffer.
  * @param dim_1 - dimensionality of data to read or write.
  * @param dim_2 - dimensionality of data to read or write.
- * @param iret - length of data read.
+ * @param iret - length of data read or written.
  * @param table_b_mnemonic - string of mnemonics.
  *
  * @author Jeff Ator @date 2025-10-24
  */
 void ufbstp_f(int bufr_unit, void **c_data, int dim_1, int dim_2,
+              int *iret, const char *table_b_mnemonic);
+
+/**
+ * Read one or more data values from a data subset.
+ *
+ * Wraps ufbevn() subroutine.
+ *
+ * @param bufr_unit - the Fortran logical unit number to read from.
+ * @param c_data - pointer to a pointer to a pre-allocated buffer.
+ * @param dim_1 - dimensionality of data to read
+ * @param dim_2 - dimensionality of data to read
+ * @param dim_3 - dimensionality of data to read
+ * @param iret - return value, length of data read.
+ * @param table_b_mnemonic - string of mnemonics.
+ *
+ * @author J. Ator @date 2025-11-05
+ */
+void ufbevn_f(int bufr_unit, void **c_data, int dim_1, int dim_2, int dim_3,
               int *iret, const char *table_b_mnemonic);
 
 /**
@@ -559,11 +577,11 @@ void drfini_f(int bufr_unit, int *mdrf, int ndrf, const char *table_d_mnemonic);
  *
  * Wraps ufbseq() subroutine.
  *
- * @param bufr_unit - the Fortran logical unit number to read from.
+ * @param bufr_unit - the Fortran logical unit number to read from or write to.
  * @param c_data - pointer to a pointer to a pre-allocated buffer.
  * @param dim_1 - dimensionality of data to read or write.
  * @param dim_2 - dimensionality of data to read or write.
- * @param iret - return value, length of data read.
+ * @param iret - return value, length of data read or written.
  * @param table_d_mnemonic - Table A or Table D mnemonic.
  *
  * @author J. Ator @date 2023-04-07
@@ -698,6 +716,46 @@ int catch_borts_f(char *cf);
  * @author J. Ator @date 2025-10-15
  */
 void check_for_bort_f(char *error_str, int error_str_len);
+
+/**
+ * Get the current location of the file pointer within a BUFR file.
+ *
+ * Wraps ufbcnt() subroutine.
+ *
+ * @param lunit - Fortran logical unit
+ * @param kmsg - Message number
+ * @param ksub - Subset number
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void ufbcnt_f(int lunit, int *kmsg, int *ksub);
+
+/**
+ * Return a prepbufr program code corresponding to a mnemonic.
+ *
+ * Wraps ufbqcd() subroutine.
+ *
+ * @param lunit - Fortran logical unit
+ * @param cnemo - Mnemonic
+ * @param iqcd - Y value of descriptor associated with mnemonic
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void ufbqcd_f(int lunit, char *cnemo, int *iqcd);
+
+/**
+ * Return a mnemonic corresponding to a prepbufr program code.
+ *
+ * Wraps ufbqcp() subroutine.
+ *
+ * @param lunit - Fortran logical unit
+ * @param iqcp - Y value of a Category 63 Table D descriptor
+ * @param cnemo - Mnemonic associated with iqcp
+ * @param cnemo_len - Allocated length of cnemo string
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void ufbqcp_f(int lunit, int iqcp, char *cnemo, int cnemo_len);
 
 #ifdef __cplusplus
 }

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -757,6 +757,40 @@ void ufbqcd_f(int lunit, char *cnemo, int *iqcd);
 */
 void ufbqcp_f(int lunit, int iqcp, char *cnemo, int cnemo_len);
 
+/**
+ * Get the meaning of a numerical value from a code or flag table.
+ *
+ * Wraps getcfmng() subroutine.
+ *
+ * @param lunit - Fortran logical unit
+ * @param cnemoi - Mnemonic to search for
+ * @param ivali - Value associated with cnemoi
+ * @param cnemod - Optional second mnemonic upon which cnemoi may depend
+ * @param ivald - Value associated with cnemod
+ * @param cmeang_c - Meaning associated with cnemoi and ivali (and possibly cnemod and ivald as well)
+ * @param lcmgc - Allocated length of cmeang_c
+ * @param iret - Return code from call to getcfmng
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void getcfmng_f(int lunit, char *cnemoi, int ivali, char *cnemod, int ivald, char *cmeang_c, int lcmgc, int *iret);
+
+/**
+ * Get the bit settings equivalent to a given numerical value for a flag table mnemonic.
+ *
+ * Wraps upftbv() subroutine.
+ *
+ * @param lunit - Fortran logical unit
+ * @param cnemo - Mnemonic with flag table units
+ * @param val - Value corresponding to cnemo
+ * @param ibit - Bit numbers which were set to "On" in val
+ * @param mxib - Allocated size of ibit
+ * @param nib - Number of bit numbers returned in ibit
+ *
+ * @author J. Ator @date 2025-11-05
+*/
+void upftbv_f(int lunit, char *cnemo, double val, int *ibit, int mxib, int *nib);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/bufrlib.F90
+++ b/src/bufrlib.F90
@@ -571,6 +571,29 @@ module bufrlib
       real(c_double), intent(inout) :: usr(i1,*)
     end subroutine catch_bort_ufbstp_c
 
+    !> @fn bufrlib::catch_bort_ufbevn_c::catch_bort_ufbevn_c(lunit,usr,i1,i2,i3,iret,cstr,cstr_len)
+    !> Catch any bort error inside of subroutine ufbevn().
+    !>
+    !> Wraps catch_bort_ufbevn() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param usr - Data values
+    !> @param i1 - First dimension of usr
+    !> @param i2 - Second dimension of usr
+    !> @param i3 - Third dimension of usr
+    !> @param iret - Number of replications of cstr that were read from the data subset
+    !> @param cstr - String of mnemonics to read from the data subset
+    !> @param cstr_len - Length of cstr
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_ufbevn_c(lunit,usr,i1,i2,i3,iret,cstr,cstr_len) bind(C, name='catch_bort_ufbevn')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, i1, i2, i3, cstr_len
+      integer(c_int), intent(out) :: iret
+      character(kind=c_char), intent(inout) :: cstr(*)
+      real(c_double), intent(out) :: usr(i1,i2,*)
+    end subroutine catch_bort_ufbevn_c
+
     !> @fn bufrlib::catch_bort_drfini_c::catch_bort_drfini_c(lunit,mdrf,ndrf,drftag,drftag_len)
     !> Catch any bort error inside of subroutine drfini().
     !>
@@ -650,6 +673,59 @@ module bufrlib
       integer(c_int), value, intent(in) :: lunit, cstr_len, cchr_len
       character(kind=c_char), intent(inout) :: cstr(*), cchr(*)
     end subroutine catch_bort_writlc_c
+
+    !> @fn bufrlib::catch_bort_ufbcnt_c::catch_bort_ufbcnt_c(lunit,kmsg,ksub)
+    !> Catch any bort error inside of subroutine ufbcnt().
+    !>
+    !> Wraps catch_bort_ufbcnt() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param kmsg - Message number
+    !> @param ksub - Subset number
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_ufbcnt_c(lunit,kmsg,ksub) bind(C, name='catch_bort_ufbcnt')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit
+      integer(c_int), intent(out) :: kmsg, ksub
+    end subroutine catch_bort_ufbcnt_c
+
+    !> @fn bufrlib::catch_bort_ufbqcd_c::catch_bort_ufbqcd_c(lunit,cnemo,iqcd,cnemo_len)
+    !> Catch any bort error inside of subroutine ufbqcd().
+    !>
+    !> Wraps catch_bort_ufbqcd() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param cnemo - Mnemonic associated with a Category 63 Table D descriptor
+    !> @param iqcd - Y value of descriptor associated with mnemonic
+    !> @param cnemo_len - Length of cnemo
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_ufbqcd_c(lunit,cnemo,iqcd,cnemo_len) bind(C, name='catch_bort_ufbqcd')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, cnemo_len
+      integer(c_int), intent(out) :: iqcd
+      character(kind=c_char), intent(inout) :: cnemo(*)
+    end subroutine catch_bort_ufbqcd_c
+
+    !> @fn bufrlib::catch_bort_ufbqcp_c::catch_bort_ufbqcp_c(lunit,iqcp,cnemo,cnemo_len,ncn)
+    !> Catch any bort error inside of subroutine ufbqcp().
+    !>
+    !> Wraps catch_bort_ufbqcp() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param iqcp - Y value of a Category 63 Table D descriptor
+    !> @param cnemo - Mnemonic associated with iqcp
+    !> @param cnemo_len - Allocated length of cnemo string
+    !> @param ncn - Number of characters returned in cnemo
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_ufbqcp_c(lunit,iqcp,cnemo,cnemo_len,ncn) bind(C, name='catch_bort_ufbqcp')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, iqcp, cnemo_len
+      integer(c_int), intent(out) :: ncn
+      character(kind=c_char), intent(out) :: cnemo(*)
+    end subroutine catch_bort_ufbqcp_c
 
   end interface
 

--- a/src/bufrlib.F90
+++ b/src/bufrlib.F90
@@ -776,6 +776,48 @@ module bufrlib
       character(kind=c_char), intent(inout) :: cnemo(*)
     end subroutine catch_bort_upftbv_c
 
+    !> @fn bufrlib::catch_bort_ufbtab_c::catch_bort_ufbtab_c(lunin,tab,i1,i2,iret,cstr,cstr_len)
+    !> Catch any bort error inside of subroutine ufbtab().
+    !>
+    !> Wraps catch_bort_ufbtab() function.
+    !>
+    !> @param lunin - Absolute value is Fortran logical unit number for BUFR file
+    !> @param tab - Data values
+    !> @param i1 - First dimension of tab
+    !> @param i2 - Second dimension of tab
+    !> @param iret - Number of data subsets returned
+    !> @param cstr - String of mnemonics to read from each data subset
+    !> @param cstr_len - Length of cstr
+    !>
+    !> @author J. Ator @date 2025-11-13
+    subroutine catch_bort_ufbtab_c(lunin,tab,i1,i2,iret,cstr,cstr_len) bind(C, name='catch_bort_ufbtab')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunin, i1, i2, cstr_len
+      integer(c_int), intent(inout) :: iret
+      character(kind=c_char), intent(inout) :: cstr(*)
+      real(c_double), intent(inout) :: tab(i1,*)
+    end subroutine catch_bort_ufbtab_c
+
+    !> @fn bufrlib::catch_bort_ufbpos_c::catch_bort_ufbpos_c(lunit,irec,isub,subset,jdate,subset_str_len)
+    !> Catch any bort error inside of subroutine ufbpos().
+    !>
+    !> Wraps catch_bort_ufbpos() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param irec - Ordinal number of message to be read
+    !> @param isub - Ordinal number of subset to be read from (irec)th message
+    !> @param subset - Table A mnemonic for type of BUFR message that was read
+    !> @param jdate - Date-time stored within Section 1 of BUFR message that was read
+    !> @param subset_str_len - Allocated length of subset string
+    !>
+    !> @author J. Ator @date 2025-11-13
+    subroutine catch_bort_ufbpos_c(lunit,irec,isub,subset,jdate,subset_str_len) bind(C, name='catch_bort_ufbpos')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, subset_str_len, irec, isub
+      character(kind=c_char), intent(out) :: subset(*)
+      integer(c_int), intent(out) :: jdate
+    end subroutine catch_bort_ufbpos_c
+
   end interface
 
 end module bufrlib

--- a/src/bufrlib.F90
+++ b/src/bufrlib.F90
@@ -727,6 +727,55 @@ module bufrlib
       character(kind=c_char), intent(out) :: cnemo(*)
     end subroutine catch_bort_ufbqcp_c
 
+    !> @fn bufrlib::catch_bort_getcfmng_c::catch_bort_getcfmng_c(lunit,cnemoi,lcni,ivali,cnemod,lcnd,ivald,cmeang_c,lcmgc,lnmng,iret)
+    !> Catch any bort error inside of subroutine getcfmng().
+    !>
+    !> Wraps catch_bort_getcfmng() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param cnemoi - Mnemonic to search for
+    !> @param lcni - Length of cnemoi
+    !> @param ivali - Value associated with cnemoi
+    !> @param cnemod - Optional second mnemonic upon which cnemoi may depend
+    !> @param lcnd - Length of cnemod
+    !> @param ivald - Value associated with cnemod
+    !> @param cmeang_c - Meaning associated with cnemoi and ivali (and possibly cnemod and ivald as well)
+    !> @param lcmgc - Allocated length of cmeang_c
+    !> @param lnmng - Number of characters returned in cmeang_c
+    !> @param iret - Return code from call to getcfmng_f
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_getcfmng_c(lunit,cnemoi,lcni,ivali,cnemod,lcnd,ivald,cmeang_c,lcmgc,lnmng,iret) &
+        bind(C, name='catch_bort_getcfmng')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, lcni, ivali, lcnd, ivald, lcmgc
+      integer(c_int), intent(out) :: lnmng, iret
+      character(kind=c_char), intent(inout) :: cnemoi(*), cnemod(*)
+      character(kind=c_char), intent(out) :: cmeang_c(*)
+    end subroutine catch_bort_getcfmng_c
+
+    !> @fn bufrlib::catch_bort_upftbv_c::catch_bort_upftbv_c(lunit,cnemo,lcn,val,ibit,mxib,nib)
+    !> Catch any bort error inside of subroutine upftbv().
+    !>
+    !> Wraps catch_bort_upftbv() function.
+    !>
+    !> @param lunit - Fortran logical unit number for BUFR file
+    !> @param cnemo - Mnemonic with flag table units
+    !> @param lcn - Length of cnemo
+    !> @param val - Value corresponding to cnemo
+    !> @param ibit - Bit numbers which were set to "On" in val
+    !> @param mxib - Allocated size of ibit
+    !> @param nib - Number of bit numbers returned in ibit
+    !>
+    !> @author J. Ator @date 2025-11-05
+    subroutine catch_bort_upftbv_c(lunit,cnemo,lcn,val,ibit,mxib,nib) bind(C, name='catch_bort_upftbv')
+      use iso_c_binding
+      integer(c_int), value, intent(in) :: lunit, lcn, mxib
+      integer(c_int), intent(out) :: ibit(*), nib
+      real(c_double), value, intent(in) :: val
+      character(kind=c_char), intent(inout) :: cnemo(*)
+    end subroutine catch_bort_upftbv_c
+
   end interface
 
 end module bufrlib

--- a/src/bufrlib.h.in
+++ b/src/bufrlib.h.in
@@ -29,6 +29,9 @@ void cwrbufr(int nfile, int *bufr, int nwrd);
 int icvidx(int ii, int jj, int numjj);
 void restd(int lunb, int tddesc, int *nctddesc, int *ctddesc);
 void stseq(int lun, int *irepct, int idn, char *nemo, char *cseq, int *cdesc, int ncdesc);
+void catch_bort_cobfl(char *bfl, char io);
+void catch_bort_crbmg(char *bmg, int mxmb, int *nmb, int *iret);
+void catch_bort_cwbmg(char *bmg, int nmb, int *iret);
 
 /** Size of a character string needed to store an FXY value. */
 #define FXY_STR_LEN 6
@@ -261,3 +264,23 @@ void pktdd_f(int id, int lun, int idn, int *iret);
  * @author J. Ator @date 2023-04-07
  */
 void bort_f(char *errstr);
+
+/**
+ * Sets a new bort target, if bort catching is enabled and such a target doesn't already exist.
+ *
+ * Wraps bort_target_set() function.
+ *
+ * @return - 1 if a new bort target was set during this call, otherwise 0
+ *
+ * @author J. Ator @date 2025-11-05
+ */
+int bort_target_set_f(void);
+
+/**
+ * Clear any existing bort target.
+ *
+ * Wraps bort_target_unset() subroutine.
+ *
+ * @author J. Ator @date 2025-11-05
+ */
+void bort_target_unset_f(void);

--- a/src/cftbvs.F90
+++ b/src/cftbvs.F90
@@ -31,11 +31,9 @@ recursive real*8 function pkftbv(nbits,ibit) result(r8val)
 
   if(im8b) then
     im8b=.false.
-
     call x84(nbits,my_nbits,1)
     call x84(ibit,my_ibit,1)
     r8val=pkftbv(my_nbits,my_ibit)
-
     im8b=.true.
     return
   endif
@@ -89,13 +87,11 @@ recursive subroutine upftbv(lunit,nemo,val,mxib,ibit,nib)
 
   if(im8b) then
     im8b=.false.
-
     call x84(lunit,my_lunit,1)
     call x84(mxib,my_mxib,1)
     call upftbv( my_lunit, nemo, val, my_mxib*2, ibit, nib )
     call x48(ibit(1),ibit(1),nib)
     call x48(nib,nib,1)
-
     im8b=.true.
     return
   endif
@@ -394,16 +390,21 @@ end subroutine getcfmng
 !> @author J. Woollen @date 1994-01-06
 recursive subroutine ufbqcd(lunit,nemo,iqcd)
 
+  use bufrlib
+
   use modv_vars, only: im8b
+
+  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: iqcd
-  integer my_lunit, lun, il, im, idn, iret
+  integer my_lunit, lun, il, im, idn, iret, lcn
 
   character*(*), intent(in) :: nemo
   character*128 bort_str
+  character*12 cnemo
   character*6 fxy, adn30
   character tab
 
@@ -415,6 +416,17 @@ recursive subroutine ufbqcd(lunit,nemo,iqcd)
     call ufbqcd(my_lunit,nemo,iqcd)
     call x48(iqcd,iqcd,1)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call strsuc(nemo,cnemo,lcn)
+    call catch_bort_ufbqcd_c(lunit,cnemo,iqcd,lcn)
+    bort_target_is_unset = .true.
     return
   endif
 
@@ -454,14 +466,19 @@ end subroutine ufbqcd
 !> @author J. Woollen @date 1994-01-06
 recursive subroutine ufbqcp(lunit,iqcp,nemo)
 
+  use bufrlib
+
   use modv_vars, only: im8b
+
+  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, iqcp
-  integer my_lunit, my_iqcp, lun, il, im, idn, iret, ifxy
+  integer my_lunit, my_iqcp, lun, il, im, idn, iret, ifxy, lnm, ncn
 
   character*(*), intent(out) :: nemo
+  character*9 cnemo
   character tab
 
   ! Check for I8 integers
@@ -472,6 +489,19 @@ recursive subroutine ufbqcp(lunit,iqcp,nemo)
     call x84(iqcp,my_iqcp,1)
     call ufbqcp(my_lunit,my_iqcp,nemo)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call catch_bort_ufbqcp_c(lunit,iqcp,cnemo,len(cnemo),ncn)
+    nemo = ' '
+    lnm = min(len(nemo),ncn)
+    nemo(1:lnm) = cnemo(1:lnm)
+    bort_target_is_unset = .true.
     return
   endif
 

--- a/src/cftbvs.F90
+++ b/src/cftbvs.F90
@@ -71,13 +71,12 @@ recursive subroutine upftbv(lunit,nemo,val,mxib,ibit,nib)
   use modv_vars, only: im8b
 
   use moda_tababd
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, mxib
   integer, intent(out) :: ibit(*), nib
-  integer my_lunit, my_mxib, lun, il, im, idn, i, n, nbits, iersn, lcn
+  integer my_lunit, my_mxib, lun, il, im, idn, i, n, nbits, iersn, lcn, bort_target_set
 
   character*(*), intent(in) :: nemo
   character*128 bort_str
@@ -102,12 +101,10 @@ recursive subroutine upftbv(lunit,nemo,val,mxib,ibit,nib)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(nemo,cnemo,lcn)
     call catch_bort_upftbv_c(lunit,cnemo,lcn,val,ibit,mxib,nib)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -235,14 +232,13 @@ recursive subroutine getcfmng ( lunit, nemoi, ivali, nemod, ivald, cmeang, lnmng
 
   use moda_tababd
   use moda_tablef
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, ivali, ivald
   integer, intent(out) :: lnmng, iret
   integer ifxyd(10), my_lunit, my_ivali, my_ivald, lun, il, im, itmp, ii, ifxyi, lcmg, n, ntg, iret2, ierbd, ifxy, ireadmt, &
-    lcni, lcnd, lcmgc
+    lcni, lcnd, lcmgc, bort_target_set
 
   character*(*), intent(in) :: nemoi, nemod
   character*(*), intent(out) :: cmeang
@@ -271,9 +267,7 @@ recursive subroutine getcfmng ( lunit, nemoi, ivali, nemod, ivald, cmeang, lnmng
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(nemoi,cnemoi,lcni)
     call strsuc(nemod,cnemod,lcnd)
     lcmgc = lcmg + 1  ! Allow extra byte in cmeang_c for the trailing null in C
@@ -281,7 +275,7 @@ recursive subroutine getcfmng ( lunit, nemoi, ivali, nemod, ivald, cmeang, lnmng
     call catch_bort_getcfmng_c(lunit,cnemoi,lcni,ivali,cnemod,lcnd,ivald,cmeang_c,lcmgc,lnmng,iret)
     cmeang(1:lnmng) = cmeang_c(1:lnmng)
     deallocate(cmeang_c)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -428,13 +422,11 @@ recursive subroutine ufbqcd(lunit,nemo,iqcd)
 
   use modv_vars, only: im8b
 
-  use moda_borts
-
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: iqcd
-  integer my_lunit, lun, il, im, idn, iret, lcn
+  integer my_lunit, lun, il, im, idn, iret, lcn, bort_target_set
 
   character*(*), intent(in) :: nemo
   character*128 bort_str
@@ -455,12 +447,10 @@ recursive subroutine ufbqcd(lunit,nemo,iqcd)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(nemo,cnemo,lcn)
     call catch_bort_ufbqcd_c(lunit,cnemo,iqcd,lcn)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -504,12 +494,10 @@ recursive subroutine ufbqcp(lunit,iqcp,nemo)
 
   use modv_vars, only: im8b
 
-  use moda_borts
-
   implicit none
 
   integer, intent(in) :: lunit, iqcp
-  integer my_lunit, my_iqcp, lun, il, im, idn, iret, ifxy, lnm, ncn
+  integer my_lunit, my_iqcp, lun, il, im, idn, iret, ifxy, lnm, ncn, bort_target_set
 
   character*(*), intent(out) :: nemo
   character*9 cnemo
@@ -528,14 +516,12 @@ recursive subroutine ufbqcp(lunit,iqcp,nemo)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_ufbqcp_c(lunit,iqcp,cnemo,len(cnemo),ncn)
     nemo = ' '
     lnm = min(len(nemo),ncn)
     nemo(1:lnm) = cnemo(1:lnm)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/cftbvs.F90
+++ b/src/cftbvs.F90
@@ -66,18 +66,22 @@ end function pkftbv
 !> @author J. Ator @date 2005-11-29
 recursive subroutine upftbv(lunit,nemo,val,mxib,ibit,nib)
 
+  use bufrlib
+
   use modv_vars, only: im8b
 
   use moda_tababd
+  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, mxib
   integer, intent(out) :: ibit(*), nib
-  integer my_lunit, my_mxib, lun, il, im, idn, i, n, nbits, iersn
+  integer my_lunit, my_mxib, lun, il, im, idn, i, n, nbits, iersn, lcn
 
   character*(*), intent(in) :: nemo
   character*128 bort_str
+  character*12 cnemo
   character tab
 
   real*8, intent(in) :: val
@@ -89,10 +93,21 @@ recursive subroutine upftbv(lunit,nemo,val,mxib,ibit,nib)
     im8b=.false.
     call x84(lunit,my_lunit,1)
     call x84(mxib,my_mxib,1)
-    call upftbv( my_lunit, nemo, val, my_mxib*2, ibit, nib )
+    call upftbv(my_lunit,nemo,val,my_mxib*2,ibit,nib)
     call x48(ibit(1),ibit(1),nib)
     call x48(nib,nib,1)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call strsuc(nemo,cnemo,lcn)
+    call catch_bort_upftbv_c(lunit,cnemo,lcn,val,ibit,mxib,nib)
+    bort_target_is_unset = .true.
     return
   endif
 
@@ -220,32 +235,53 @@ recursive subroutine getcfmng ( lunit, nemoi, ivali, nemod, ivald, cmeang, lnmng
 
   use moda_tababd
   use moda_tablef
+  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, ivali, ivald
   integer, intent(out) :: lnmng, iret
-  integer ifxyd(10), my_lunit, my_ivali, my_ivald, lun, il, im, itmp, ii, ifxyi, lcmg, n, ntg, iret2, ierbd, ifxy, ireadmt
+  integer ifxyd(10), my_lunit, my_ivali, my_ivald, lun, il, im, itmp, ii, ifxyi, lcmg, n, ntg, iret2, ierbd, ifxy, ireadmt, &
+    lcni, lcnd, lcmgc
 
   character*(*), intent(in) :: nemoi, nemod
   character*(*), intent(out) :: cmeang
   character*128 bort_str
+  character*9 cnemoi, cnemod
   character*8 nemo, my_nemoi, my_nemod
   character tab
+  character*(:), allocatable :: cmeang_c
 
   ! Check for I8 integers
 
   if(im8b) then
     im8b=.false.
-
     call x84(lunit,my_lunit,1)
     call x84(ivali,my_ivali,1)
     call x84(ivald,my_ivald,1)
     call getcfmng(my_lunit,nemoi,my_ivali,nemod,my_ivald,cmeang,lnmng,iret)
     call x48(lnmng,lnmng,1)
     call x48(iret,iret,1)
-
     im8b=.true.
+    return
+  endif
+
+  cmeang = ' '
+  lcmg = len ( cmeang )
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call strsuc(nemoi,cnemoi,lcni)
+    call strsuc(nemod,cnemod,lcnd)
+    lcmgc = lcmg + 1  ! Allow extra byte in cmeang_c for the trailing null in C
+    allocate(character*(lcmgc) :: cmeang_c)
+    call catch_bort_getcfmng_c(lunit,cnemoi,lcni,ivali,cnemod,lcnd,ivald,cmeang_c,lcmgc,lnmng,iret)
+    cmeang(1:lnmng) = cmeang_c(1:lnmng)
+    deallocate(cmeang_c)
+    bort_target_is_unset = .true.
     return
   endif
 
@@ -264,8 +300,6 @@ recursive subroutine getcfmng ( lunit, nemoi, ivali, nemod, ivald, cmeang, lnmng
   ! Check the validity of the input mnemonic(s).  Include special handling for originating centers, originating subcenters, data
   ! types and data subtypes, since those can be reported in Section 1 of a BUFR message as well as in Section 3, so if a user
   ! requests those mnemonics we can't necessarily assume they came from within Section 3.
-
-  lcmg = len ( cmeang )
 
   my_nemoi = '        '
   do ii = 1, min ( 8, len( nemoi ) )

--- a/src/crwbmg.c
+++ b/src/crwbmg.c
@@ -127,6 +127,15 @@ cobfl(char *bfl, char io)
     unsigned short i, j;
 
     /*
+    ** If we're catching bort errors, set a target return location if one doesn't already exist.
+    */
+    if (bort_target_set_f() == 1) {
+        catch_bort_cobfl(bfl, io);
+        bort_target_unset_f();
+        return;
+    }
+
+    /*
     ** Copy the input arguments into local variables and check them for validity. This is especially
     ** important in case either of the arguments was passed in as a string literal by the calling
     ** program or else doesn't have a trailing NULL character.
@@ -199,6 +208,15 @@ crbmg(char *bmg, int mxmb, int *nmb, int *iret)
     char blanks[5] = "    ";
 
     /*
+    ** If we're catching bort errors, set a target return location if one doesn't already exist.
+    */
+    if (bort_target_set_f() == 1) {
+        catch_bort_crbmg(bmg, mxmb, nmb, iret);
+        bort_target_unset_f();
+        return;
+    }
+
+    /*
     ** Make sure that a file is open for reading.
     */
     if (pbf[0] == NULL) {
@@ -262,6 +280,15 @@ void
 cwbmg(char *bmg, int nmb, int *iret)
 {
     char errstr[129];
+
+    /*
+    ** If we're catching bort errors, set a target return location if one doesn't already exist.
+    */
+    if (bort_target_set_f() == 1) {
+        catch_bort_cwbmg(bmg, nmb, iret);
+        bort_target_unset_f();
+        return;
+    }
 
     /*
     ** Make sure that a file is open for writing.

--- a/src/modules_arrs.F90
+++ b/src/modules_arrs.F90
@@ -44,8 +44,8 @@ module moda_bitmaps
   integer :: lstnod
   !> Current count of consecutive occurrences of lstnod.
   integer :: lstnodct
-  !> true if a bitmap is in the process of being read for the current
-  !> data subset; false otherwise.
+  !> Set to .true. ff a bitmap is in the process of being read for the current
+  !> data subset.  Otherwise set to .false.
   logical :: linbtm
   !> Entries within jump/link table which contain Table A mnemonics.
   integer, allocatable :: inodtamc(:)
@@ -843,8 +843,8 @@ end module moda_usrtmp
 module moda_xtab
   !> Tracking index for each file ID. Set to
   !> .true. if the DX BUFR table for the corresponding logical unit has
-  !> changed since the previous call to subroutine makestab(); set to
-  !> .false. otherwise.
+  !> changed since the previous call to subroutine makestab().
+  !> Otherwise set to .false.
   logical, allocatable :: xtab(:)
 end module moda_xtab
 
@@ -914,7 +914,8 @@ module moda_borts
   !> - 'N' = No (default)
   !> - 'Y' = Yes
   character :: bort_catch = 'N'
-  !> .true. iff bort_catch is 'Y' <b>and</b> a target location to which to return any caught error is not currently set.
+  !> Set to .true. if bort_catch is 'Y' <b>and</b> a target location to which to return any caught error is not currently set.
+  !> Otherwise set to .false.
   logical :: bort_target_is_unset = .false.
   !> Bort error string.
   character*300 :: caught_str

--- a/src/openclosebf.F90
+++ b/src/openclosebf.F90
@@ -899,6 +899,8 @@ end subroutine rewnbf
 
 recursive subroutine ufbtab(lunin,tab,i1,i2,iret,str)
 
+  use bufrlib
+
   use modv_vars, only: part, im8b, bmiss, iac, iprt
 
   use moda_usrint
@@ -915,10 +917,11 @@ recursive subroutine ufbtab(lunin,tab,i1,i2,iret,str)
   integer, parameter :: maxtg = 100
   integer nnod, ncon, nods, nodc, ivls, kons, my_lunin, my_i1, my_i2, lunit, lun, il, im, irec, isub, i, n, ntg, &
     jdate, jbit, kbit, lbit, mbit, nbit, nibit, nbyt, nsb, node, nbmp, nrep, lret, linc, iac_prev, ityp, &
-    ireadmg, ireadsb, nmsub
+    ireadmg, ireadsb, nmsub, lcstr, bort_target_set
 
   character*(*), intent(in) :: str
   character*128 errstr
+  character*90 cstr
   character*40 cref
   character*10 tgs(maxtg)
   character*8 subset, cval
@@ -947,6 +950,14 @@ recursive subroutine ufbtab(lunin,tab,i1,i2,iret,str)
     call ufbtab(my_lunin,tab,my_i1,my_i2,iret,str)
     call x48(iret,iret,1)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+  if (bort_target_set() == 1) then
+    call strsuc(str,cstr,lcstr)
+    call catch_bort_ufbtab_c(lunin,tab,i1,i2,iret,cstr,lcstr)
+    call bort_target_unset
     return
   endif
 

--- a/src/openclosebf.F90
+++ b/src/openclosebf.F90
@@ -608,9 +608,12 @@ end subroutine wtstat
 !> @author J. Woollen @date 1994-01-06
 recursive subroutine ufbcnt(lunit,kmsg,ksub)
 
+  use bufrlib
+
   use modv_vars, only: im8b
 
   use moda_msgcwd
+  use moda_borts
 
   implicit none
 
@@ -627,6 +630,15 @@ recursive subroutine ufbcnt(lunit,kmsg,ksub)
     call x48(kmsg,kmsg,1)
     call x48(ksub,ksub,1)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call catch_bort_ufbcnt_c(lunit, kmsg, ksub)
+    bort_target_is_unset = .true.
     return
   endif
 

--- a/src/openclosebf.F90
+++ b/src/openclosebf.F90
@@ -176,12 +176,11 @@ recursive subroutine openbf(lunit,io,lundx)
   use moda_lushr
   use moda_nulbfr
   use moda_stcode
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, lundx
-  integer my_lunit, my_lundx, iprtprv, lun, il, im, lcio
+  integer my_lunit, my_lundx, iprtprv, lun, il, im, lcio, bort_target_set
 
   character*(*), intent(in) :: io
   character*255 filename, fileacc
@@ -209,12 +208,10 @@ recursive subroutine openbf(lunit,io,lundx)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(io,cio,lcio)
     call catch_bort_openbf_c(lunit,cio,lundx,lcio)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -345,14 +342,13 @@ recursive subroutine closbf(lunit)
   use modv_vars, only: im8b
 
   use moda_nulbfr
-  use moda_borts
 
   implicit none
 
   character*128 errstr
 
   integer, intent(in) :: lunit
-  integer my_lunit, lun, il, im
+  integer my_lunit, lun, il, im, bort_target_set
 
   ! Check for i8 integers
 
@@ -366,11 +362,9 @@ recursive subroutine closbf(lunit)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_closbf_c(lunit)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -422,13 +416,12 @@ recursive subroutine status(lunit,lun,il,im)
   use modv_vars, only: im8b, nfiles
 
   use moda_stbfr
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: lun, il, im
-  integer my_lunit, i
+  integer my_lunit, i, bort_target_set
 
   character*128 bort_str, errstr
 
@@ -447,11 +440,9 @@ recursive subroutine status(lunit,lun,il,im)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_status_c(lunit,lun,il,im)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -613,13 +604,12 @@ recursive subroutine ufbcnt(lunit,kmsg,ksub)
   use modv_vars, only: im8b
 
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: kmsg, ksub
-  integer my_lunit, lun, il, im
+  integer my_lunit, lun, il, im, bort_target_set
 
   ! Check for I8 integers
 
@@ -634,11 +624,10 @@ recursive subroutine ufbcnt(lunit,kmsg,ksub)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+
+  if (bort_target_set() == 1) then
     call catch_bort_ufbcnt_c(lunit, kmsg, ksub)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/readwritemg.F90
+++ b/src/readwritemg.F90
@@ -49,13 +49,12 @@ recursive subroutine readmg(lunxx,subset,jdate,iret)
   use moda_msgcwd
   use moda_sc3bfr
   use moda_bitbuf
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunxx
   integer, intent(out) :: jdate, iret
-  integer my_lunxx, lunit, lun, il, im, ier, idxmsg
+  integer my_lunxx, lunit, lun, il, im, ier, idxmsg, bort_target_set
 
   character*8, intent(out) :: subset
   character*9 csubset
@@ -75,12 +74,10 @@ recursive subroutine readmg(lunxx,subset,jdate,iret)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_readmg_c(lunxx,csubset,jdate,len(csubset),iret)
     subset(1:8) = csubset(1:8)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -405,12 +402,11 @@ recursive subroutine openmb(lunit,subset,jdate)
   use modv_vars, only: im8b
 
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, jdate
-  integer my_lunit, my_jdate, lun, il, im, mtyp, mstb, inod, i4dy, lcsb
+  integer my_lunit, my_jdate, lun, il, im, mtyp, mstb, inod, i4dy, lcsb, bort_target_set
 
   character*(*), intent(in) :: subset
   character*9 csubset
@@ -430,12 +426,10 @@ recursive subroutine openmb(lunit,subset,jdate)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(subset,csubset,lcsb)
     call catch_bort_openmb_c(lunit,csubset,lcsb,jdate)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -490,12 +484,11 @@ recursive subroutine openmg(lunit,subset,jdate)
   use modv_vars, only: im8b
 
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit, jdate
-  integer my_lunit, my_jdate, lun, il, im, mtyp, mstb, inod, i4dy, lcsb
+  integer my_lunit, my_jdate, lun, il, im, mtyp, mstb, inod, i4dy, lcsb, bort_target_set
 
   character*(*), intent(in) :: subset
   character*9 csubset
@@ -513,12 +506,10 @@ recursive subroutine openmg(lunit,subset,jdate)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(subset,csubset,lcsb)
     call catch_bort_openmg_c(lunit,csubset,lcsb,jdate)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/readwritesb.F90
+++ b/src/readwritesb.F90
@@ -39,13 +39,12 @@ recursive subroutine readsb(lunit,iret)
   use moda_bitbuf
   use moda_bitmaps
   use moda_stcode
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: iret
-  integer my_lunit, lun, il, im, ier, nbyt
+  integer my_lunit, lun, il, im, ier, nbyt, bort_target_set
 
   ! Check for I8 integers
 
@@ -60,11 +59,9 @@ recursive subroutine readsb(lunit,iret)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_readsb_c(lunit,iret)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -181,13 +178,12 @@ recursive subroutine readns(lunit,subset,jdate,iret)
 
   use moda_msgcwd
   use moda_tables
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer, intent(out) :: jdate, iret
-  integer my_lunit, lun, il, im
+  integer my_lunit, lun, il, im, bort_target_set
 
   character*8, intent(out) :: subset
   character*9 csubset
@@ -206,12 +202,10 @@ recursive subroutine readns(lunit,subset,jdate,iret)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_readns_c(lunit,csubset,jdate,len(csubset),iret)
     subset(1:8) = csubset(1:8)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -327,12 +321,11 @@ recursive subroutine writsb(lunit)
   use modv_vars, only: im8b
 
   use moda_msgcmp
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
-  integer my_lunit, lun, il, im
+  integer my_lunit, lun, il, im, bort_target_set
 
   ! Check for I8 integers
 
@@ -346,11 +339,9 @@ recursive subroutine writsb(lunit)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_writsb_c(lunit)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -459,13 +450,12 @@ recursive subroutine writsa(lunxx,lmsgt,msgt,msgl)
 
   use moda_bufrmg
   use moda_msgcmp
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunxx, lmsgt
   integer, intent(out) :: msgt(*), msgl
-  integer my_lunxx, my_lmsgt, lunit, lun, il, im, n
+  integer my_lunxx, my_lmsgt, lunit, lun, il, im, n, bort_target_set
 
   ! Check for I8 integers
 
@@ -482,11 +472,9 @@ recursive subroutine writsa(lunxx,lmsgt,msgt,msgl)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
 
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call catch_bort_writsa_c(lunxx,lmsgt,msgt,msgl)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/readwritesb.F90
+++ b/src/readwritesb.F90
@@ -919,9 +919,10 @@ recursive subroutine ufbpos(lunit,irec,isub,subset,jdate)
 
   integer, intent(in) :: lunit, irec, isub
   integer, intent(out) :: jdate
-  integer my_lunit, my_irec, my_isub, lun, il, im, jrec, jsub, iret
+  integer my_lunit, my_irec, my_isub, lun, il, im, jrec, jsub, iret, bort_target_set
 
   character*128 bort_str
+  character*9 csubset
   character*8, intent(out) :: subset
 
   ! Check for I8 integers
@@ -937,7 +938,16 @@ recursive subroutine ufbpos(lunit,irec,isub,subset,jdate)
     return
   endif
 
-  !  Make sure a file is open for input
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+
+  if (bort_target_set() == 1) then
+    call catch_bort_ufbpos_c(lunit,irec,isub,csubset,jdate,len(csubset))
+    subset(1:8) = csubset(1:8)
+    call bort_target_unset
+    return
+  endif
+
+  ! Make sure a file is open for input
 
   call status(lunit,lun,il,im)
   if(il==0) call bort('BUFRLIB: UFBPOS - INPUT BUFR FILE IS CLOSED, IT MUST BE OPEN FOR INPUT')
@@ -952,11 +962,11 @@ recursive subroutine ufbpos(lunit,irec,isub,subset,jdate)
     call bort(bort_str)
   endif
 
-  !  See where pointers are currently located
+  ! See where pointers are currently located
 
   call ufbcnt(lunit,jrec,jsub)
 
-  !  Rewind file if requested pointers are behind current pointers
+  ! Rewind file if requested pointers are behind current pointers
 
   if(irec<jrec .or. (irec==jrec.and.isub<jsub)) then
     call cewind_c(lun)

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -213,13 +213,12 @@ recursive subroutine writlc(lunit,chr,str)
   use moda_bitbuf
   use moda_tables
   use moda_comprs
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
   integer my_lunit, maxtg, lun, il, im, ntg, nnod, kon, ii, n, node, ioid, ival, mbit, nbit, nbmp, nchr, nbyt, nsubs, &
-    itagct, len0, len1, len2, len3, l4, l5, mbyte, iupbs3, lcstr, lcchr
+    itagct, len0, len1, len2, len3, l4, l5, mbyte, iupbs3, lcstr, lcchr, bort_target_set
 
   character*(*), intent(in) :: chr, str
   character*128 bort_str, errstr
@@ -242,13 +241,11 @@ recursive subroutine writlc(lunit,chr,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call strsuc(chr,cchr,lcchr)
     call catch_bort_writlc_c(lunit,cstr,lcstr,cchr,lcchr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -685,7 +682,6 @@ recursive subroutine ufbint(lunin,usr,i1,i2,iret,str)
 
   use moda_usrint
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
@@ -695,7 +691,8 @@ recursive subroutine ufbint(lunin,usr,i1,i2,iret,str)
 
   integer, intent(in) :: lunin, i1, i2
   integer, intent(out) :: iret
-  integer nnod, ncon, nods, nodc, ivls, kons, ifirst1, ifirst2, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, lcstr
+  integer nnod, ncon, nods, nodc, ivls, kons, ifirst1, ifirst2, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, lcstr, &
+    bort_target_set
 
   real*8, intent(inout) :: usr(i1,i2)
 
@@ -718,12 +715,10 @@ recursive subroutine ufbint(lunin,usr,i1,i2,iret,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call catch_bort_ufbint_c(lunin,usr,i1,i2,iret,cstr,lcstr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -947,7 +942,6 @@ recursive subroutine ufbrep(lunin,usr,i1,i2,iret,str)
 
   use moda_usrint
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
@@ -957,7 +951,7 @@ recursive subroutine ufbrep(lunin,usr,i1,i2,iret,str)
 
   integer, intent(in) :: lunin, i1, i2
   integer, intent(out) :: iret
-  integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, iac_prev, lcstr
+  integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, iac_prev, lcstr, bort_target_set
 
   real*8, intent(inout) :: usr(i1,i2)
 
@@ -978,12 +972,10 @@ recursive subroutine ufbrep(lunin,usr,i1,i2,iret,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call catch_bort_ufbrep_c(lunin,usr,i1,i2,iret,cstr,lcstr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -1181,7 +1173,6 @@ recursive subroutine ufbstp(lunin,usr,i1,i2,iret,str)
 
   use moda_usrint
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
@@ -1191,7 +1182,7 @@ recursive subroutine ufbstp(lunin,usr,i1,i2,iret,str)
 
   integer, intent(in) :: lunin, i1, i2
   integer, intent(out) :: iret
-  integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, lcstr
+  integer ifirst1, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, lcstr, bort_target_set
 
   real*8, intent(inout) :: usr(i1,i2)
 
@@ -1212,12 +1203,10 @@ recursive subroutine ufbstp(lunin,usr,i1,i2,iret,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call catch_bort_ufbstp_c(lunin,usr,i1,i2,iret,cstr,lcstr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -1424,7 +1413,6 @@ recursive subroutine ufbseq(lunin,usr,i1,i2,iret,str)
   use moda_usrint
   use moda_msgcwd
   use moda_tables
-  use moda_borts
 
   implicit none
 
@@ -1432,7 +1420,7 @@ recursive subroutine ufbseq(lunin,usr,i1,i2,iret,str)
   integer, intent(out) :: iret
   integer, parameter :: mtag = 10
   integer ifirst1, ifirst2, my_lunin, my_i1, my_i2, lunit, lun, il, im, io, i, j, ntag, node, nods, ins1, ins2, insx, &
-    nseq, isq, ityp, invwin, invtag, lcstr
+    nseq, isq, ityp, invwin, invtag, lcstr, bort_target_set
 
   real*8, intent(inout) :: usr(i1,i2)
 
@@ -1459,12 +1447,10 @@ recursive subroutine ufbseq(lunin,usr,i1,i2,iret,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call catch_bort_ufbseq_c(lunin,usr,i1,i2,iret,cstr,lcstr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -1697,7 +1683,6 @@ recursive subroutine drfini(lunit,mdrf,ndrf,drftag)
 
   use moda_usrint
   use moda_tables
-  use moda_borts
 
   implicit none
 
@@ -1706,7 +1691,7 @@ recursive subroutine drfini(lunit,mdrf,ndrf,drftag)
 
   integer, intent(in) :: mdrf(*), lunit, ndrf
   integer, parameter :: mxdrf = 2000
-  integer my_mdrf(mxdrf), my_lunit, my_ndrf, lun, il, im, m, n, node, lcdrftag
+  integer my_mdrf(mxdrf), my_lunit, my_ndrf, lun, il, im, m, n, node, lcdrftag, bort_target_set
 
   ! Check for I8 integers
   if(im8b) then
@@ -1720,12 +1705,10 @@ recursive subroutine drfini(lunit,mdrf,ndrf,drftag)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(drftag,cdrftag,lcdrftag)
     call catch_bort_drfini_c(lunit,mdrf,ndrf,cdrftag,lcdrftag)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 
@@ -2379,7 +2362,6 @@ recursive subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str)
 
   use moda_usrint
   use moda_msgcwd
-  use moda_borts
 
   implicit none
 
@@ -2390,7 +2372,7 @@ recursive subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str)
   integer, intent(in) :: lunit, i1, i2, i3
   integer, intent(out) :: iret
   integer invn(255), nnod, ncon, nods, nodc, ivls, kons, maxevn, my_lunit, my_i1, my_i2, my_i3, i, j, k, lun, il, im, &
-    ins1, ins2, inc1, inc2, nnvn, nvnwin, lcstr
+    ins1, ins2, inc1, inc2, nnvn, nvnwin, lcstr, bort_target_set
 
   real*8, intent(out) :: usr(i1,i2,i3)
 
@@ -2413,12 +2395,11 @@ recursive subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str)
   endif
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     call catch_bort_ufbevn_c(lunit,usr,i1,i2,i3,iret,cstr,lcstr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -435,12 +435,12 @@ recursive subroutine readlc(lunit,chr,str)
   use moda_bitbuf
   use moda_tables
   use moda_rlccmn
-  use moda_borts
 
   implicit none
 
   integer, intent(in) :: lunit
-  integer my_lunit, maxtg, lchr, lun, il, im, ntg, nnod, kon, ii, n, nod, ioid, itagct, nchr, kbit, lcstr, lcchr, ncchr
+  integer my_lunit, maxtg, lchr, lun, il, im, ntg, nnod, kon, ii, n, nod, ioid, itagct, nchr, kbit, lcstr, lcchr, ncchr, &
+    bort_target_set
 
   character*(*), intent(in) :: str
   character*(*), intent(out) :: chr
@@ -468,16 +468,14 @@ recursive subroutine readlc(lunit,chr,str)
   lchr=len(chr)
 
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
-  if (bort_target_is_unset) then
-    bort_target_is_unset = .false.
-    caught_str_len = 0
+  if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
     lcchr = lchr + 1  ! Allow extra byte in cchr for the trailing null in C
     allocate(character*(lcchr) :: cchr)
     call catch_bort_readlc_c(lunit,cstr,lcstr,cchr,lcchr,ncchr)
     chr(1:ncchr) = cchr(1:ncchr)
     deallocate(cchr)
-    bort_target_is_unset = .true.
+    call bort_target_unset
     return
   endif
 

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -2375,20 +2375,24 @@ end subroutine ufbovr
 !> @author J. Woollen @date 1994-01-06
 recursive subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str)
 
+  use bufrlib
+
   use modv_vars, only: im8b, bmiss, iprt
 
   use moda_usrint
   use moda_msgcwd
+  use moda_borts
 
   implicit none
 
   character*(*), intent(in) :: str
   character*128 errstr
+  character*90 cstr
 
   integer, intent(in) :: lunit, i1, i2, i3
   integer, intent(out) :: iret
   integer invn(255), nnod, ncon, nods, nodc, ivls, kons, maxevn, my_lunit, my_i1, my_i2, my_i3, i, j, k, lun, il, im, &
-    ins1, ins2, inc1, inc2, nnvn, nvnwin
+    ins1, ins2, inc1, inc2, nnvn, nvnwin, lcstr
 
   real*8, intent(out) :: usr(i1,i2,i3)
 
@@ -2407,6 +2411,16 @@ recursive subroutine ufbevn(lunit,usr,i1,i2,i3,iret,str)
     call ufbevn(my_lunit,usr,my_i1,my_i2,my_i3,iret,str)
     call x48(iret,iret,1)
     im8b=.true.
+    return
+  endif
+
+  ! If we're catching bort errors, set a target return location if one doesn't already exist.
+  if (bort_target_is_unset) then
+    bort_target_is_unset = .false.
+    caught_str_len = 0
+    call strsuc(str,cstr,lcstr)
+    call catch_bort_ufbevn_c(lunit,usr,i1,i2,i3,iret,cstr,lcstr)
+    bort_target_is_unset = .true.
     return
   endif
 

--- a/test/intest14.F90
+++ b/test/intest14.F90
@@ -4,12 +4,17 @@
 !
 ! J. Ator, 8/25/2025
 program intest14
+  use bufr_interface
+
   implicit none
 
   integer errstr_len, lunit, idate, iret
-  integer*4 isetprm, ireadmg, catch_borts
+  integer*4 isetprm, ireadmg, catch_borts, mxmb, nmb, ierr
+  parameter (mxmb = 1000)
 
   character errstr*400, subset*8
+  character bmg*1000
+  character*20 filnam / 'testfiles/IN_1' /
 
   real*8 r8arr(18, 2)
 
@@ -64,6 +69,17 @@ program intest14
   call check_for_bort(errstr, errstr_len)
   if ( errstr_len <= 0 .or. index( errstr(1:errstr_len), 'STRING - INPUT STRING (') == 0 .or. &
     index( errstr(1:errstr_len), '> LIMIT OF 80 CHAR.') == 0 ) stop 9
+
+  ! Test the catching of an illegal second input value to subroutine cobfl_c.
+  call cobfl_c(filnam, 'j')
+  call check_for_bort(errstr, errstr_len)
+  if ( errstr_len <= 0 .or. index( errstr(1:errstr_len), 'COBFL - SECOND ARGUMENT WAS (') == 0 .or. &
+    index( errstr(1:errstr_len), 'WHICH IS AN ILLEGAL VALUE') == 0 ) stop 10
+
+  ! Test the catching of an erroneous call to subroutine crbmg_c.
+  call crbmg_c(bmg, mxmb, nmb, ierr)
+  call check_for_bort(errstr, errstr_len)
+  if ( errstr_len <= 0 .or. index( errstr(1:errstr_len), 'CRBMG - NO FILE IS OPEN FOR READING') == 0 ) stop 11
 
   call closbf(lunit)
 

--- a/test/intest5.F90
+++ b/test/intest5.F90
@@ -4,7 +4,6 @@
 !
 ! J. Ator, 2/24/2023
 program intest5
-  use bufr_interface
 
   implicit none
 


### PR DESCRIPTION
Part of #340

Note that I also modified how bort targets are internally set and unset, because this was previously being done using a Fortran boolean (.true. vs .false.), which is fine when you're trying to set targets within user-callable Fortran routines, but not so much when you're trying to do the same thing within user-callable C routines such as cobfl, crbmg, etc.  So I've now encapsulated those set/unset switches inside of new internal `bort_target_set/unset()` routines using more C-friendly (1 vs. 0, instead of .true. vs .false.) return values.  I've also gone ahead and modified all of the prior Fortran bort catchers to use this same new methodology, for consistency but also because it ends up reducing the overall number of lines of code throughout the library :-)