### PR TITLE
remove hard declarations of temporary character strings

### DIFF
--- a/.github/workflows/developer.yaml
+++ b/.github/workflows/developer.yaml
@@ -17,8 +17,8 @@ jobs:
   developer:
     runs-on: ubuntu-22.04
     env:
-      FC: gfortran-11
-      CC: gcc-11
+      FC: gfortran-12
+      CC: gcc-12
 
     steps:
     - name: install-deps

--- a/.github/workflows/developer.yaml
+++ b/.github/workflows/developer.yaml
@@ -60,7 +60,7 @@ jobs:
       run: |
         cd bufr/build
         ctest --verbose --output-on-failure --rerun-failed
-        gcovr --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary --exclude-unreachable-branches --exclude-throw-branches --decisions --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file -o test-coverage.html
+        gcovr --gcov-executable gcov-12 --root .. -v  --html-details --exclude ../test --exclude CMakeFiles --print-summary --exclude-unreachable-branches --exclude-throw-branches --decisions --gcov-ignore-parse-errors=suspicious_hits.warn_once_per_file -o test-coverage.html
 
     - name: cache-data
       if: steps.cache-data.outputs.cache-hit != 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CMAKE_Fortran_COMPILER_ID STREQUAL "IntelLLVM")
 endif()
 
 # Handle user options.
-option(ENABLE_DOCS "Enable generation of doxygen-based documentation." OFF)
+option(ENABLE_DOCS "Enable generation of doxygen-based documentation" OFF)
 option(ENABLE_PYTHON "Enable building python module 'ncepbufr'" OFF)
 option(BUILD_SHARED_LIBS "Enable building shared libraries" OFF)
 option(BUILD_UTILS "Enable building utilities" ON)
@@ -27,11 +27,11 @@ option(BUILD_TESTING "Enable automated testing" ON)
 # Developers can use this option to specify a local directory which
 # holds the test files. They will be copied instead of fetching the
 # files via FTP.
-set(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP.")
-message(STATUS "Finding test data files in directory ${TEST_FILE_DIR}.")
+set(TEST_FILE_DIR "." CACHE STRING "Check this directory for test files before using FTP")
+message(STATUS "Finding test data files in directory ${TEST_FILE_DIR}")
 
 set(MASTER_TABLE_DIR "${CMAKE_INSTALL_PREFIX}/tables" CACHE STRING "Installation location of Master BUFR Tables")
-message(STATUS "Storing master tables into directory ${MASTER_TABLE_DIR}.")
+message(STATUS "Storing master tables into directory ${MASTER_TABLE_DIR}")
 string(LENGTH "${MASTER_TABLE_DIR}" _lenmtd)
 set(_lenslmax 60)  # max number of chars of ${MASTER_TABLE_DIR} to store on a single line of a Fortran90 or C source code file
 if(${_lenmtd} LESS_EQUAL ${_lenslmax})
@@ -57,7 +57,7 @@ else() # generate source code lines in chunks of ${_lenslmax} chars each
 endif()
 
 if(NOT CMAKE_BUILD_TYPE MATCHES "^(Debug|Release|RelWithDebInfo|MinSizeRel)$")
-  message(STATUS "Setting build type to 'Release' as none was specified.")
+  message(STATUS "Setting build type to 'Release' as none was specified")
   set(CMAKE_BUILD_TYPE
       "Release"
       CACHE STRING "Choose the type of build." FORCE)

--- a/src/borts.F90
+++ b/src/borts.F90
@@ -193,7 +193,7 @@ end subroutine bort_target_unset
 !> This subroutine should only be called if a prior call was made to function
 !> catch_borts() from an application program with cbc set to 'Y'
 !>
-!> @param bort_str - Error string, if such a bort error occurred; otherwise empty.
+!> @param bort_str - Error string, if a bort error occurred
 !> @param bort_str_len - Length of bort_str:
 !>  - -1 = Subroutine catch_borts() was not previously called
 !>  -  0 = No bort error occurred
@@ -228,12 +228,9 @@ recursive subroutine check_for_bort(bort_str, bort_str_len)
       call errwrt('+++++++++++++++++++++WARNING+++++++++++++++++++++++')
     endif
     bort_str_len = -1
-  else if (caught_str_len == 0) then
-    bort_str_len = 0
-    bort_str = ' '
   else
     bort_str_len = min(len(bort_str),caught_str_len)
-    bort_str = caught_str(1:bort_str_len)
+    if (bort_str_len > 0) bort_str = caught_str(1:bort_str_len)
   endif
 
   return

--- a/src/borts.c
+++ b/src/borts.c
@@ -450,7 +450,10 @@ void
 catch_bort_writlc(int lunit, char *cstr, int cstr_len, char *cchr, int cchr_len)
 {
     /* Set the target location to which to return if a bort error is caught. */
-    if ( setjmp(context) == 1 ) return;
+    if ( setjmp(context) == 1 ) {
+        dealloc_vars_f("writlc_f");
+        return;
+    }
 
     /* Add a trailing null to cstr, for use with get_c_string_length inside of writlc_f. */
     cstr[cstr_len] = '\0';

--- a/src/borts.c
+++ b/src/borts.c
@@ -1655,7 +1655,10 @@ void
 catch_bort_getabdb(int lunit, int itab, char (*ctabdb)[128], int *jtab)
 {
     /* Set the target location to which to return if a bort error is caught. */
-    if ( setjmp(context) == 1 ) return;
+    if ( setjmp(context) == 1 ) {
+        dealloc_vars_f("getabdb_f");
+        return;
+    }
 
     /* Recursively call the subroutine. */
     getabdb_f(lunit, itab, ctabdb, jtab);

--- a/src/borts.c
+++ b/src/borts.c
@@ -859,7 +859,10 @@ void
 catch_bort_upds3(int *mbay, int lcds3, char (*ccds3)[6], int *nds3)
 {
     /* Set the target location to which to return if a bort error is caught. */
-    if ( setjmp(context) == 1 ) return;
+    if ( setjmp(context) == 1 ) {
+        dealloc_vars_f("upds3_f");
+        return;
+    }
 
     /* Recursively call the subroutine. */
     upds3_f(mbay, lcds3, ccds3, nds3);

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -1604,13 +1604,19 @@ module bufr_c2f_interface
     subroutine check_for_bort_c(error_str, error_str_len) bind(C, name='check_for_bort_f')
       integer(c_int), value, intent(in) :: error_str_len
       character(kind=c_char), intent(out) :: error_str(*)
-      character(len=310) :: error_str_f
-      integer :: error_str_len_f
+      character(len=:), allocatable :: error_str_f
+      integer :: error_str_len_f, lallc
 
+      ! Strings allocated within this subroutine will be for use in Fortran, so we won't need
+      ! space for a trailing null and can therefore subtract 1 from error_str_len.
+      lallc = max(1,error_str_len-1)
+
+      allocate(character(len=lallc) :: error_str_f)
       call check_for_bort(error_str_f, error_str_len_f)
-
+      if (error_str_len_f == -1) error_str_len_f = 0  ! return empty string if catch_borts() wasn't previously called
       error_str_len_f = error_str_len_f + 1  ! add 1 for the null terminator
-      call copy_f_c_str(error_str_f, error_str, min(error_str_len_f, error_str_len))
+      call copy_f_c_str(error_str_f, error_str, error_str_len_f)
+      deallocate(error_str_f)
     end subroutine check_for_bort_c
 
     !> Get the current location of the file pointer within a BUFR file.

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -42,6 +42,7 @@ module bufr_c2f_interface
   character*(:), allocatable, save :: readlc_fchr_outer, readlc_fchr_inner
   character*(:), allocatable, save :: getcfmng_cmng_outer, getcfmng_cmng_inner
   character*128, allocatable, save :: getabdb_tabdb_outer(:), getabdb_tabdb_inner(:)
+  character*(:), allocatable, save :: writlc_fchr_outer, writlc_fchr_inner
 
   contains
 
@@ -150,6 +151,12 @@ module bufr_c2f_interface
             deallocate(getabdb_tabdb_inner)
           else
             deallocate(getabdb_tabdb_outer)
+          end if
+        case ('writlc_f')
+          if (allocated(writlc_fchr_inner)) then
+            deallocate(writlc_fchr_inner)
+          else
+            deallocate(writlc_fchr_outer)
           end if
       end select
     end subroutine dealloc_vars_c
@@ -903,7 +910,6 @@ module bufr_c2f_interface
       integer(c_int), value, intent(in) :: lunit
       character(kind=c_char), intent(in) :: str(*), chr(*)
       character(len=14) :: my_str
-      character(len=255) :: my_chr
       integer :: lstr, lchr
 
       lstr = get_c_string_length(str)
@@ -916,13 +922,21 @@ module bufr_c2f_interface
 
       lchr = get_c_string_length(chr)
       if (lchr == 0) then
-        my_chr(1:1) = ' '
-        lchr = 1
+        call writlc(lunit, ' ', my_str(1:lstr))
+      else if (allocated(writlc_fchr_outer)) then
+        ! A previous call was directly made to this subroutine from within a C application
+        ! program with bort catching enabled.  So we now need to allocate a separate "inner"
+        ! string and recursively call writlc() again with that string.
+        allocate(character(len=lchr) :: writlc_fchr_inner)
+        writlc_fchr_inner = transfer(chr(1:lchr), writlc_fchr_inner)
+        call writlc(lunit, writlc_fchr_inner(1:lchr), my_str(1:lstr))
+        deallocate(writlc_fchr_inner)
       else
-        my_chr = transfer(chr(1:lchr), my_chr)
+        allocate(character(len=lchr) :: writlc_fchr_outer)
+        writlc_fchr_outer = transfer(chr(1:lchr), writlc_fchr_outer)
+        call writlc(lunit, writlc_fchr_outer(1:lchr), my_str(1:lstr))
+        deallocate(writlc_fchr_outer)
       endif
-
-      call writlc(lunit, my_chr(1:lchr), my_str(1:lstr))
     end subroutine writlc_c
 
     !> Deletes the copies of the moda_tables arrays.

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -41,6 +41,7 @@ module bufr_c2f_interface
   character*(:), allocatable, save :: bvers_fstr_outer, bvers_fstr_inner
   character*(:), allocatable, save :: readlc_fchr_outer, readlc_fchr_inner
   character*(:), allocatable, save :: getcfmng_cmng_outer, getcfmng_cmng_inner
+  character*128, allocatable, save :: getabdb_tabdb_outer(:), getabdb_tabdb_inner(:)
 
   contains
 
@@ -143,6 +144,12 @@ module bufr_c2f_interface
             deallocate(getcfmng_cmng_inner)
           else
             deallocate(getcfmng_cmng_outer)
+          end if
+        case ('getabdb_f')
+          if (allocated(getabdb_tabdb_inner)) then
+            deallocate(getabdb_tabdb_inner)
+          else
+            deallocate(getabdb_tabdb_outer)
           end if
       end select
     end subroutine dealloc_vars_c
@@ -2659,15 +2666,30 @@ module bufr_c2f_interface
       integer(c_int), value, intent(in) :: lunit, itab
       integer(c_int), intent(out) :: jtab
       character(kind=c_char), intent(out) :: ctabdb(128,*)
-      character(len=128) :: tabdb(1000)
       integer :: ii, jj
 
-      call getabdb(lunit, tabdb, itab, jtab)
-      do ii = 1, jtab
-        do jj = 1, 128
-          ctabdb(jj,ii) = tabdb(ii)(jj:jj)
+      if (allocated(getabdb_tabdb_outer)) then
+        ! A previous call was directly made to this subroutine from within a C application
+        ! program with bort catching enabled.  So we now need to allocate a separate "inner"
+        ! array and recursively call getabdb() again with that array.
+        allocate(getabdb_tabdb_inner(itab))
+        call getabdb(lunit, getabdb_tabdb_inner, itab, jtab)
+        do ii = 1, jtab
+          do jj = 1, 128
+            ctabdb(jj,ii) = getabdb_tabdb_inner(ii)(jj:jj)
+          enddo
         enddo
-      enddo
+        deallocate(getabdb_tabdb_inner)
+      else
+        allocate(getabdb_tabdb_outer(itab))
+        call getabdb(lunit, getabdb_tabdb_outer, itab, jtab)
+        do ii = 1, jtab
+          do jj = 1, 128
+            ctabdb(jj,ii) = getabdb_tabdb_outer(ii)(jj:jj)
+          enddo
+        enddo
+        deallocate(getabdb_tabdb_outer)
+      end if
     end subroutine getabdb_c
 
     !> Read one or more data values from a data subset without advancing the subset pointer

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -1628,18 +1628,22 @@ module bufr_c2f_interface
       integer(c_int), value, intent(in) :: error_str_len
       character(kind=c_char), intent(out) :: error_str(*)
       character(len=:), allocatable :: error_str_f
-      integer :: error_str_len_f, lallc
+      integer :: error_str_len_f
 
-      ! Strings allocated within this subroutine will be for use in Fortran, so we won't need
-      ! space for a trailing null and can therefore subtract 1 from error_str_len.
-      lallc = max(1,error_str_len-1)
-
-      allocate(character(len=lallc) :: error_str_f)
-      call check_for_bort(error_str_f, error_str_len_f)
-      if (error_str_len_f == -1) error_str_len_f = 0  ! return empty string if catch_borts() wasn't previously called
-      error_str_len_f = error_str_len_f + 1  ! add 1 for the null terminator
-      call copy_f_c_str(error_str_f, error_str, error_str_len_f)
-      deallocate(error_str_f)
+      if (error_str_len <= 1) then
+        ! Any writeable string passed in from a C routine will always contain at least one byte for a trailing null,
+        ! even if it's an empty string!
+        error_str(1) = c_null_char
+      else
+        ! The following allocated string will be for use in Fortran, so we won't need space for a trailing null and can
+        ! therefore subtract 1 from error_str_len.
+        allocate(character(len=error_str_len-1) :: error_str_f)
+        call check_for_bort(error_str_f, error_str_len_f)
+        if (error_str_len_f == -1) error_str_len_f = 0  ! return empty string if catch_borts() wasn't previously called
+        error_str_len_f = error_str_len_f + 1  ! add 1 for the null terminator
+        call copy_f_c_str(error_str_f, error_str, error_str_len_f)
+        deallocate(error_str_f)
+      endif
     end subroutine check_for_bort_c
 
     !> Get the current location of the file pointer within a BUFR file.
@@ -2712,7 +2716,9 @@ module bufr_c2f_interface
       character(kind=c_char), intent(out) :: ctabdb(128,*)
       integer :: ii, jj
 
-      if (allocated(getabdb_tabdb_outer)) then
+      if (itab <= 0) then
+        jtab = 0
+      else if (allocated(getabdb_tabdb_outer)) then
         ! A previous call was directly made to this subroutine from within a C application
         ! program with bort catching enabled.  So we now need to allocate a separate "inner"
         ! array and recursively call getabdb() again with that array.

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -43,6 +43,7 @@ module bufr_c2f_interface
   character*(:), allocatable, save :: getcfmng_cmng_outer, getcfmng_cmng_inner
   character*128, allocatable, save :: getabdb_tabdb_outer(:), getabdb_tabdb_inner(:)
   character*(:), allocatable, save :: writlc_fchr_outer, writlc_fchr_inner
+  character*6, allocatable, save :: upds3_cds3_outer(:), upds3_cds3_inner(:)
 
   contains
 
@@ -157,6 +158,12 @@ module bufr_c2f_interface
             deallocate(writlc_fchr_inner)
           else
             deallocate(writlc_fchr_outer)
+          end if
+        case ('upds3_f')
+          if (allocated(upds3_cds3_inner)) then
+            deallocate(upds3_cds3_inner)
+          else
+            deallocate(upds3_cds3_outer)
           end if
       end select
     end subroutine dealloc_vars_c
@@ -1989,15 +1996,30 @@ module bufr_c2f_interface
       integer(c_int), intent(in) :: mbay(*)
       integer(c_int), intent(out) :: nds3
       character(kind=c_char), intent(out) :: ccds3(6,*)
-      character(len=6) :: cds3(600)
       integer :: ii, jj
 
-      call upds3(mbay, lcds3, cds3, nds3)
-      do ii = 1, nds3
-        do jj = 1, 6
-          ccds3(jj,ii) = cds3(ii)(jj:jj)
+      if (allocated(upds3_cds3_outer)) then
+        ! A previous call was directly made to this subroutine from within a C application
+        ! program with bort catching enabled.  So we now need to allocate a separate "inner"
+        ! array and recursively call upds3() again with that array.
+        allocate(upds3_cds3_inner(lcds3))
+        call upds3(mbay, lcds3, upds3_cds3_inner, nds3)
+        do ii = 1, nds3
+          do jj = 1, 6
+            ccds3(jj,ii) = upds3_cds3_inner(ii)(jj:jj)
+          enddo
         enddo
-      enddo
+        deallocate(upds3_cds3_inner)
+      else
+        allocate(upds3_cds3_outer(lcds3))
+        call upds3(mbay, lcds3, upds3_cds3_outer, nds3)
+        do ii = 1, nds3
+          do jj = 1, 6
+            ccds3(jj,ii) = upds3_cds3_outer(ii)(jj:jj)
+          enddo
+        enddo
+        deallocate(upds3_cds3_outer)
+      end if
     end subroutine upds3_c
 
     !> Specify a value to be written into Section 1 of a BUFR message

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -154,9 +154,11 @@ module bufr_c2f_interface
             deallocate(getabdb_tabdb_outer)
           end if
         case ('writlc_f')
+          ! It is possible for writlc_f to have previously called writlc without
+          ! allocating any memory, so we need to explicitly check for that.
           if (allocated(writlc_fchr_inner)) then
             deallocate(writlc_fchr_inner)
-          else
+          else if (allocated(writlc_fchr_outer)) then
             deallocate(writlc_fchr_outer)
           end if
         case ('upds3_f')

--- a/src/bufr_c2f_interface.F90
+++ b/src/bufr_c2f_interface.F90
@@ -483,17 +483,19 @@ module bufr_c2f_interface
     subroutine mtinfo_c(path, file_unit_1, file_unit_2) bind(C, name='mtinfo_f')
       character(kind=c_char), intent(in) :: path(*)
       integer(c_int), value, intent(in) :: file_unit_1, file_unit_2
-      character(len=240) :: mtdir
+      character(len=:), allocatable :: mtdir
       integer :: lmtdir
 
       lmtdir = get_c_string_length(path)
       if (lmtdir == 0) then
-        mtdir(1:1) = ' '
-        lmtdir = 1
+        call mtinfo(' ', file_unit_1, file_unit_2)
       else
+        allocate(character(len=lmtdir) :: mtdir)
         mtdir = transfer(path(1:lmtdir), mtdir)
+        call mtinfo(mtdir(1:lmtdir), file_unit_1, file_unit_2)
+        deallocate(mtdir)
       endif
-      call mtinfo(mtdir(1:lmtdir), file_unit_1, file_unit_2)
+
     end subroutine mtinfo_c
 
     !> Check whether a file is connected to the library.
@@ -877,13 +879,13 @@ module bufr_c2f_interface
         ! string and recursively call readlc() again with that string.
         allocate(character*(lallc) :: readlc_fchr_inner)
         call readlc(lunit, readlc_fchr_inner, str(1:lstr))
-        lchr = len(trim(readlc_fchr_inner)) + 1  ! add 1 for the null terminator
+        lchr = len_trim(readlc_fchr_inner) + 1  ! add 1 for the null terminator
         call copy_f_c_str(readlc_fchr_inner, cchr, lchr)
         deallocate(readlc_fchr_inner)
       else
         allocate(character*(lallc) :: readlc_fchr_outer)
         call readlc(lunit, readlc_fchr_outer, str(1:lstr))
-        lchr = len(trim(readlc_fchr_outer)) + 1  ! add 1 for the null terminator
+        lchr = len_trim(readlc_fchr_outer) + 1  ! add 1 for the null terminator
         call copy_f_c_str(readlc_fchr_outer, cchr, lchr)
         deallocate(readlc_fchr_outer)
       end if
@@ -1679,7 +1681,7 @@ module bufr_c2f_interface
 
       call ufbqcp(lunit, iqcp, nemo)
 
-      lnm = len(trim(nemo)) + 1  ! add 1 for the null terminator
+      lnm = len_trim(nemo) + 1  ! add 1 for the null terminator
       call copy_f_c_str(nemo, cnemo, min(lnm, cnemo_len))
     end subroutine ufbqcp_c
 
@@ -2496,7 +2498,7 @@ module bufr_c2f_interface
 
       call gettagpr(bufr_unit, f_tagch(1:lfc), ntagch, f_tagpr, ires)
 
-      lfp = len(trim(f_tagpr)) + 1  ! add 1 for the null terminator
+      lfp = len_trim(f_tagpr) + 1  ! add 1 for the null terminator
       call copy_f_c_str(f_tagpr, c_tagpr, min(lfp, tagpr_len))
     end subroutine gettagpr_c
 
@@ -2531,7 +2533,7 @@ module bufr_c2f_interface
 
       call gettagre(bufr_unit, f_tagi(1:lfi), ntagi, f_tagre, ntagre, ires)
 
-      lfr = len(trim(f_tagre)) + 1  ! add 1 for the null terminator
+      lfr = len_trim(f_tagre) + 1  ! add 1 for the null terminator
       call copy_f_c_str(f_tagre, c_tagre, min(lfr, tagre_len))
     end subroutine gettagre_c
 
@@ -2933,5 +2935,21 @@ module bufr_c2f_interface
       nbytp1 = nbyt + 1  ! add 1 for the null terminator
       call copy_f_c_str(f_cbay, cbay, min(nbytp1, cbay_len))
     end subroutine ipkm_c
+
+    !> Rewind a file to the beginning, or restore the previous status.
+    !>
+    !> Wraps rewnbf() subroutine.
+    !>
+    !> @param file_unit - Fortran logical unit number of file.
+    !> @param isr - Switch:
+    !>   - 0 = Save current file status, then rewind file to beginning with read status
+    !>   - 1 = Restore file to previous saved status
+    !>
+    !> @author Jeff Ator @date 2026-02-13
+    recursive subroutine rewnbf_c(file_unit, isr) bind(C, name='rewnbf_f')
+      integer(c_int), value, intent(in) :: file_unit, isr
+
+      call rewnbf(file_unit, isr)
+    end subroutine rewnbf_c
 
 end module bufr_c2f_interface

--- a/src/bufr_interface.h
+++ b/src/bufr_interface.h
@@ -1567,6 +1567,20 @@ int iupm_f(const char *cbay, int nbits, int lcbay);
  */
 void ipkm_f(char *cbay, int nbyt, int ival, int cbay_len);
 
+/**
+ * Rewind a file to the beginning, or restore the previous status.
+ *
+ * Wraps rewnbf() subroutine.
+ *
+ * @param file_unit - Fortran logical unit number of file.
+ * @param isr - Switch:
+ *   - 0 = Save current file status, then rewind file to beginning with read status
+ *   - 1 = Restore file to previous saved status
+ *
+ * @author Jeff Ator @date 2026-02-13
+ */
+void rewnbf_f(int file_unit, int isr);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/dumpdata.F90
+++ b/src/dumpdata.F90
@@ -912,8 +912,8 @@ recursive subroutine getabdb(lunit,tabdb,itab,jtab)
     nemo = tabd(i,lun)(7:14)
     call nemtbd(lun,i,nseq,nem(1,1),irp(1,1),krp(1,1))
     do j=1,nseq,10
-      jtab = jtab+1
-      if(jtab<=itab) then
+      if(jtab<itab) then
+        jtab = jtab+1
         write(tabdb(jtab),fmt='(A,A8,10(1X,A10))') 'D ', nemo, (nem(k,1),k=j,min(j+9,nseq))
       endif
     enddo
@@ -922,8 +922,8 @@ recursive subroutine getabdb(lunit,tabdb,itab,jtab)
   ! Add the Table B entries
 
   do i=1,ntbb(lun)
-    jtab = jtab+1
-    if(jtab<=itab) then
+    if(jtab<itab) then
+      jtab = jtab+1
       write(tabdb(jtab),fmt='(A,A8,1X,A42)') 'B ', tabb(i,lun)(7:14), tabb(i,lun)(71:112)
     endif
   enddo

--- a/src/mastertable.F90
+++ b/src/mastertable.F90
@@ -33,7 +33,7 @@
 !> @author J. Ator @date 2009-03-23
 recursive subroutine mtinfo ( cmtdir, lunmt1, lunmt2 )
 
-  use modv_vars, only: im8b, lun1, lun2, mtdir, lmtd
+  use modv_vars, only: im8b, lun1, lun2, mtdir, lmtd, lmt
 
   implicit none
 
@@ -53,9 +53,18 @@ recursive subroutine mtinfo ( cmtdir, lunmt1, lunmt2 )
   endif
 
   call strsuc ( cmtdir, mtdir, lmtd )
+  if (lmtd == 0) then
+    lmtd = 1
+    mtdir(1:lmtd) = ' '
+  endif
 
   lun1 = lunmt1
   lun2 = lunmt2
+
+  !> We've now reset the internal values of mtdir, lmtd, lun1 and lun2. But we also need to reset the internal
+  !> value of lmt to an artificially low number, in order to ensure that new master tables will be read in using
+  !> these new mtdir, lmtd, lun1 and lun2 values during the next internal call to subroutine ireadmt().
+  lmt = -99
 
   return
 end subroutine mtinfo

--- a/src/readwriteval.F90
+++ b/src/readwriteval.F90
@@ -242,14 +242,14 @@ recursive subroutine writlc(lunit,chr,str)
 
   integer, intent(in) :: lunit
   integer my_lunit, maxtg, lun, il, im, ntg, nnod, kon, ii, n, node, ioid, ival, mbit, nbit, nbmp, nchr, nbyt, nsubs, &
-    itagct, len0, len1, len2, len3, l4, l5, mbyte, iupbs3, lcstr, lcchr, bort_target_set
+    itagct, len0, len1, len2, len3, l4, l5, mbyte, iupbs3, lchr, lcstr, bort_target_set
 
   character*(*), intent(in) :: chr, str
   character*128 bort_str, errstr
   character*10 ctag
   character*14 tgs(10)
   character*15 cstr
-  character*256 cchr
+  character*(:), allocatable :: cchr
 
   real roid
 
@@ -264,11 +264,15 @@ recursive subroutine writlc(lunit,chr,str)
     return
   endif
 
+  lchr=len(chr)
+
   ! If we're catching bort errors, set a target return location if one doesn't already exist.
   if (bort_target_set() == 1) then
     call strsuc(str,cstr,lcstr)
-    call strsuc(chr,cchr,lcchr)
-    call catch_bort_writlc_c(lunit,cstr,lcstr,cchr,lcchr)
+    allocate(character*(lchr+1) :: cchr)  ! Allow extra byte in cchr for the trailing null in C
+    cchr(1:lchr) = chr(1:lchr)
+    call catch_bort_writlc_c(lunit,cstr,lcstr,cchr,lchr)
+    deallocate(cchr)
     call bort_target_unset
     return
   endif
@@ -325,7 +329,7 @@ recursive subroutine writlc(lunit,chr,str)
           catx(n,ncol)=' '
           ! The following statement enforces a limit of mxlcc characters per long character string when writing
           ! compressed messages. This limit keeps the array catx to a reasonable dimensioned size.
-          nchr=min(mxlcc,len(chr),ibt(node)/8)
+          nchr=min(mxlcc,lchr,ibt(node)/8)
           catx(n,ncol)=chr(1:nchr)
           call usrtpl(lun,1,1)
           return

--- a/src/s013vals.F90
+++ b/src/s013vals.F90
@@ -898,8 +898,8 @@ recursive subroutine upds3(mbay,lcds3,cds3,nds3)
 
   nds3 = 0
   do jj = 8,(len3-1),2
+   if(nds3+1>lcds3) call bort('BUFRLIB: UPDS3 - OVERFLOW OF OUTPUT DESCRIPTOR ARRAY; TRY A LARGER DIMENSION FOR THIS ARRAY')
    nds3 = nds3 + 1
-   if(nds3>lcds3) call bort('BUFRLIB: UPDS3 - OVERFLOW OF OUTPUT DESCRIPTOR ARRAY; TRY A LARGER DIMENSION FOR THIS ARRAY')
    cds3(nds3) = adn30(iupb(mbay,ipt+jj,16),6)
   enddo
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 # their machines, and save the time of downloading them every time.
 if(NOT ${TEST_FILE_DIR} STREQUAL ".")
   if (EXISTS ${TEST_FILE_DIR}/${BUFR_TAR})
-    message(STATUS "Copying file ${TEST_FILE_DIR}/${BUFR_TAR} to test data directory.")
+    message(STATUS "Copying file ${TEST_FILE_DIR}/${BUFR_TAR} to test data directory")
     FILE(COPY ${TEST_FILE_DIR}/${BUFR_TAR}
       DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
   endif()
@@ -100,24 +100,6 @@ function(create_test name kind num)
   endif()
 endfunction()
 
-# This is for testing bort().
-foreach(kind ${test_kinds})
-  add_executable(test_bort_${kind} test_bort.F90)
-  # Need to include -Wno-character-truncation flag for test_bort, so it can do stupid things needed to fail.
-  set_target_properties(test_bort_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags} -Wno-character-truncation")
-  target_compile_definitions(test_bort_${kind} PUBLIC -DKIND_${kind})
-  target_link_libraries(test_bort_${kind} PRIVATE bufr_4)
-  add_dependencies(test_bort_${kind} bufr_4)
-endforeach()
-
-# Test the borts. This runs test script run_test_bort.sh, which
-# repeatedly calls program test_bort, and expects each time for the
-# program to be aborted.
-file(COPY "${CMAKE_SOURCE_DIR}/test/run_test_bort.sh"
-    DESTINATION ${CMAKE_BINARY_DIR}/test
-    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
-add_test(NAME run_test_bort COMMAND ${CMAKE_BINARY_DIR}/test/run_test_bort.sh)
-
 # These are the C API tests.
 list(APPEND test_c_interface_srcs
   test_c_interface.c
@@ -166,13 +148,6 @@ foreach(kind ${test_kinds})
   endforeach()
 endforeach()
 
-# The C bort test is not run as a regular test, because it fails.
-set(test_name test_c_bort)
-add_executable(${test_name} ${test_name}.c)
-add_dependencies(${test_name} bufr_4)
-target_link_libraries(${test_name} PRIVATE bufr::bufr_4)
-target_include_directories(${test_name} PRIVATE "${CMAKE_BINARY_DIR}/src")
-
 # c_interface tests
 foreach(test_src ${test_c_interface_srcs})
   string(REPLACE ".c" "" testPref ${test_src})
@@ -203,3 +178,28 @@ if(BUILD_UTILS)
     add_test(NAME ${test} COMMAND ${CMAKE_BINARY_DIR}/bin/${test}.sh)
   endforeach()
 endif()
+
+# This is for testing bort().
+foreach(kind ${test_kinds})
+  add_executable(test_bort_${kind} test_bort.F90)
+  # Need to include -Wno-character-truncation flag for test_bort, so it can do stupid things needed to fail.
+  set_target_properties(test_bort_${kind} PROPERTIES COMPILE_FLAGS "${fortran_${kind}_flags} -Wno-character-truncation")
+  target_compile_definitions(test_bort_${kind} PUBLIC -DKIND_${kind})
+  target_link_libraries(test_bort_${kind} PRIVATE bufr_4)
+  add_dependencies(test_bort_${kind} bufr_4)
+endforeach()
+
+# Test the borts. This runs test script run_test_bort.sh, which
+# repeatedly calls program test_bort, and expects each time for the
+# program to be aborted.
+file(COPY "${CMAKE_SOURCE_DIR}/test/run_test_bort.sh"
+    DESTINATION ${CMAKE_BINARY_DIR}/test
+    FILE_PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
+add_test(NAME run_test_bort COMMAND ${CMAKE_BINARY_DIR}/test/run_test_bort.sh)
+
+# The C bort test is not run as a regular test, because it fails.
+set(test_name test_c_bort)
+add_executable(${test_name} ${test_name}.c)
+add_dependencies(${test_name} bufr_4)
+target_link_libraries(${test_name} PRIVATE bufr::bufr_4)
+target_include_directories(${test_name} PRIVATE "${CMAKE_BINARY_DIR}/src")

--- a/test/intest14.F90
+++ b/test/intest14.F90
@@ -15,6 +15,7 @@ program intest14
   character errstr*400, subset*8
   character bmg*1000
   character*20 filnam / 'testfiles/IN_1' /
+  character(len=:), allocatable :: empty_string
 
   real*8 r8arr(18, 2)
 
@@ -80,6 +81,12 @@ program intest14
   call crbmg_c(bmg, mxmb, nmb, ierr)
   call check_for_bort(errstr, errstr_len)
   if ( errstr_len <= 0 .or. index( errstr(1:errstr_len), 'CRBMG - NO FILE IS OPEN FOR READING') == 0 ) stop 11
+
+  ! Test passing in an empty string to check_for_bort.
+  empty_string = ''
+  call check_for_bort(empty_string, errstr_len)
+  if (errstr_len /= 0) stop 12
+  deallocate(empty_string)
 
   call closbf(lunit)
 

--- a/test/outtest5.F90
+++ b/test/outtest5.F90
@@ -8,9 +8,9 @@ program outtest5
 
   integer*4 ireadns, catch_borts
 
-  integer jdate(5), jdump(5), ii, jtab, nsub, imgdt
+  integer jdate(5), jdump(5), ii, jtab, nsub, imgdt, errstr_len
 
-  character cmgtag*8, tabdb(1000)*128
+  character cmgtag*8, tabdb(1000)*128, errstr*400
 
   print *, 'Testing writing OUT_5 using DUMPBF, GETABDB, UFDUMP, UFBDMP, and DXDUMP'
 
@@ -49,9 +49,13 @@ program outtest5
   call openbf ( 11, 'IN', 11 )
 
   write ( 13, fmt = '(///,A)' ) '------------ GETABDB -----------'
-  ! First do a quick sanity check to confirm that getabdb properly handles a bad input parameter.
+  ! First do some quick sanity checks to confirm that getabdb properly handles bad input parameters.
   call getabdb ( 11, tabdb, 0, jtab )
   if (jtab /= 0) stop 1
+  call getabdb ( 111, tabdb, 1000, jtab )
+  call check_for_bort(errstr, errstr_len)
+  if ( errstr_len <= 0 .or. &
+    index( errstr(1:errstr_len), 'STATUS - INPUT UNIT NUMBER (111) OUTSIDE LEGAL RANGE OF 1-99') == 0 ) stop 2
   ! Now go ahead and call getabdb to get the expected output.
   call getabdb ( 11, tabdb, 1000, jtab )
   do ii = 1, jtab

--- a/test/outtest5.F90
+++ b/test/outtest5.F90
@@ -49,6 +49,10 @@ program outtest5
   call openbf ( 11, 'IN', 11 )
 
   write ( 13, fmt = '(///,A)' ) '------------ GETABDB -----------'
+  ! First do a quick sanity check to confirm that getabdb properly handles a bad input parameter.
+  call getabdb ( 11, tabdb, 0, jtab )
+  if (jtab /= 0) stop 1
+  ! Now go ahead and call getabdb to get the expected output.
   call getabdb ( 11, tabdb, 1000, jtab )
   do ii = 1, jtab
     write ( 13, fmt = '(A,I4,2A)' ) 'tabdb entry #', ii, ":", tabdb(ii)

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -125,6 +125,7 @@ void test_longStrings()
     char msg_subset[SUBSET_STRING_LEN];
     char bort_string[BORT_STRING_LEN];
     char tabdb[700][128];
+    char empty_string[] = "";
 
     open_f(BUFR_FILE_UNIT, INPUT_FILE_LONG_STR);
     openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);
@@ -132,6 +133,12 @@ void test_longStrings()
     check_for_bort_f( bort_string, BORT_STRING_LEN );
     if ( strlen( bort_string ) != 0 ) {
         printf("%s", "openbf check_for_bort check FAILED!");
+        exit(1);
+    }
+    /* Test passing in an empty string to check_for_bort_f. */
+    check_for_bort_f( empty_string, sizeof(empty_string) );
+    if ( strlen( empty_string ) != 0 ) {
+        printf("%s", "check_for_bort empty_string sanity check FAILED!");
         exit(1);
     }
 
@@ -204,6 +211,12 @@ void test_longStrings()
     check_for_bort_f( bort_string, BORT_STRING_LEN );
     if ( ( strlen( bort_string ) != 0 ) || ( il != 266 ) ) {
         printf( "%s\n", "getabdb check_for_bort check #2 FAILED!" );
+        exit(1);
+    }
+    getabdb_f(BUFR_FILE_UNIT, 0, tabdb, &il);
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) != 0 ) || ( il != 0 ) ) {
+        printf( "%s\n", "getabdb sanity check with bad input parameter FAILED!" );
         exit(1);
     }
 

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -124,6 +124,7 @@ void test_longStrings()
     int iddate, iret;
     char msg_subset[SUBSET_STRING_LEN];
     char bort_string[BORT_STRING_LEN];
+    char tabdb[700][128];
 
     open_f(BUFR_FILE_UNIT, INPUT_FILE_LONG_STR);
     openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);
@@ -168,11 +169,35 @@ void test_longStrings()
         exit(1);
     }
 
+    /* Run some checks on getcfmng_f */
     getcfmng_f(BUFR_FILE_UNIT, "GCLONG", 254, " ", -1, long_str, LONG_STR_LEN, &il);
     check_for_bort_f( bort_string, BORT_STRING_LEN );
     if ( ( strlen( bort_string ) == 0 ) ||
          ( strncmp( bort_string, "BUFRLIB: GETCFMNG - TO USE THIS SUBROUTINE, MUST FIRST CALL SUBROUTINE CODFLG", 77 ) != 0 ) ) {
-        printf( "%s\n", "getcfmng check_for_bort check FAILED!" );
+        printf( "%s\n", "getcfmng check_for_bort check #1 FAILED!" );
+        exit(1);
+    }
+    codflg_f("Y");
+    getcfmng_f(BUFR_FILE_UNIT, "GCLONG", 254, " ", -1, long_str, LONG_STR_LEN, &il);
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) != 0 ) || ( strcmp( long_str, "EUMETSAT Operation Centre" ) != 0 ) ) {
+        printf( "%s\n", "getcfmng check_for_bort check #2 FAILED!" );
+        exit(1);
+    }
+    codflg_f("N");
+
+    /* Run some checks on getabdb_f */
+    getabdb_f(112, 700, tabdb, &il);
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) == 0 ) ||
+         ( strcmp( bort_string, "BUFRLIB: STATUS - INPUT UNIT NUMBER (112) OUTSIDE LEGAL RANGE OF 1-99" ) != 0 ) ) {
+        printf( "%s\n", "getabdb check_for_bort check #1 FAILED!" );
+        exit(1);
+    }
+    getabdb_f(BUFR_FILE_UNIT, 700, tabdb, &il);
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) != 0 ) || ( il != 266 ) ) {
+        printf( "%s\n", "getabdb check_for_bort check #2 FAILED!" );
         exit(1);
     }
 

--- a/test/test_c_interface.c
+++ b/test/test_c_interface.c
@@ -128,6 +128,12 @@ void test_longStrings()
 
     open_f(BUFR_FILE_UNIT, INPUT_FILE_LONG_STR);
     openbf_f(BUFR_FILE_UNIT, "IN", BUFR_FILE_UNIT);
+    /* The following call should return an empty string since we haven't turned on bort catching yet. */
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf("%s", "openbf check_for_bort check FAILED!");
+        exit(1);
+    }
 
     int bufrLoc;
     int il, im;

--- a/test/test_c_interface_2.c
+++ b/test/test_c_interface_2.c
@@ -28,9 +28,12 @@ int main() {
     int jj, lun, il, im;
     int iret;
     int iddate;
+    int ibufrmg[1250];
+    char bufrmg[5000];
     char msg_subset[SUBSET_STRING_LEN];
     char bort_string[BORT_STRING_LEN];
     char bv_short[3], bv_normal[9];
+    char cds3_toosmall[20][6], cds3[60][6];
 
     double r8arr[180][15];
     double* r8arr_ptr = &r8arr[0][0];
@@ -198,6 +201,39 @@ int main() {
     check_for_bort_f( bort_string, BORT_STRING_LEN );
     if ( strlen( bort_string ) != 0 ) {
         printf( "%s\n", "writlc check_for_bort single mnemonic check FAILED!" );
+        exit(1);
+    }
+
+    /* Reopen the same input file as before, but now using cobfl. */
+    cobfl( INPUT_FILE, 'r' );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf( "%s\n", "cobfl check_for_bort check FAILED!" );
+        exit(1);
+    }
+
+    /* Read the first message of the file into a character array in memory. */
+    crbmg( bufrmg, 5000, &il, &im );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) != 0 ) || ( il != 3588 ) || ( im != 0 ) ) {
+        printf( "%s\n", "crbmg check_for_bort check FAILED!" );
+        exit(1);
+    }
+    /* Copy the message into an integer array for use in upds3. */
+    memmove( ibufrmg, bufrmg, il );
+    /* Test catching a bort from upds3 by passing in an output array that's too small. */
+    upds3_f( ibufrmg, 20, cds3_toosmall, &im );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) == 0 ) ||
+         ( strncmp( bort_string, "BUFRLIB: UPDS3 - OVERFLOW OF OUTPUT DESCRIPTOR ARRAY", 52 ) != 0 ) ) {
+        printf( "%s\n", "upds3 check_for_bort toosmall check FAILED!" );
+        exit(1);
+    }
+    /* Now pass in an output array that's large enough to hold the descriptor list. */
+    upds3_f( ibufrmg, 60, cds3, &im );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) != 0 ) || ( im != 51 ) ) {
+        printf( "%s\n", "upds3 check_for_bort check FAILED!" );
         exit(1);
     }
 

--- a/test/test_c_interface_2.c
+++ b/test/test_c_interface_2.c
@@ -13,6 +13,7 @@
 
 static const int BUFR_INPUT_FILE_UNIT = 11;
 static const int BUFR_OUTPUT_FILE_UNIT = 51;
+static const int BUFR_DXTABLE_FILE_UNIT = 12;
 static const int TABLE_1_FILE_UNIT = 90;
 static const int TABLE_2_FILE_UNIT = 91;
 static const int SUBSET_STRING_LEN = 12;
@@ -20,6 +21,7 @@ static const int BORT_STRING_LEN = 200;
 
 static const char* INPUT_FILE = "testfiles/IN_4";
 static const char* OUTPUT_FILE = "testfiles/test_c_interface_2.out";
+static const char* DXTABLE_FILE = "testfiles/OUT_6_bufrtab";
 
 int main() {
 
@@ -33,9 +35,10 @@ int main() {
     double r8arr[180][15];
     double* r8arr_ptr = &r8arr[0][0];
 
-    /* Assign Fortran logical unit numbers to the input and output files. */
+    /* Assign Fortran logical unit numbers to the input, output and DX table files. */
     open_f( BUFR_INPUT_FILE_UNIT, INPUT_FILE );
     open_f( BUFR_OUTPUT_FILE_UNIT, OUTPUT_FILE );
+    open_f( BUFR_DXTABLE_FILE_UNIT, DXTABLE_FILE );
 
     /* Set and confirm a global library parameter. */
     if ( ( iret = isetprm_f( "NFILES" ,5 ) ) != 0 ) exit(1);
@@ -62,10 +65,11 @@ int main() {
 
     /* Open the input file to the library. */
     openbf_f( BUFR_INPUT_FILE_UNIT, "SEC3", BUFR_INPUT_FILE_UNIT );
-
-    /* Set and confirm the maximum output message size. */
-    maxout_f( 25000 );
-    if ( ( iret = igetmxby_f() ) != 25000 ) exit(1);
+    status_f( BUFR_INPUT_FILE_UNIT, &lun, &il, &im );
+    if ( il != -1 || im != 0 ) {
+        printf( "%s\n", "status check #1 FAILED!" );
+        exit(1);
+    }
 
     /* Define the location of the master BUFR tables. */
     mtinfo_f( "../tables", TABLE_1_FILE_UNIT, TABLE_2_FILE_UNIT );
@@ -133,18 +137,45 @@ int main() {
         }
     }
 
-    /* Open the output file to the library, using the same DX table information in the input file. */
-    openbf_f( BUFR_OUTPUT_FILE_UNIT, "NODX", BUFR_INPUT_FILE_UNIT );
+    /* Rewind the input file and then re-read the same BUFR message from the file. */
+    rewnbf_f( BUFR_INPUT_FILE_UNIT, 0 );
 
-    /* Open a new compressed BUFR message for output, and check that it was successful. */
-    cmpmsg_f( "Y" );
-    openmb_f( BUFR_OUTPUT_FILE_UNIT, "MSTTB001", 2023051015 );
-    status_f( BUFR_OUTPUT_FILE_UNIT, &lun, &il, &im );
-    if ( il != 1 || im != 1 ) {
-        printf( "%s\n", "status check FAILED!" );
+    /* Test catching a bort from ireadmg by passing an empty pathname to mtinfo. */
+    mtinfo_f( "", TABLE_1_FILE_UNIT, TABLE_2_FILE_UNIT );
+    iret = ireadmg_f( BUFR_INPUT_FILE_UNIT, msg_subset, &iddate, SUBSET_STRING_LEN );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) == 0 ) ||
+         ( strncmp( bort_string, "BUFRLIB: MTFNAM - COULD NOT FIND STANDARD FILE:", 47 ) != 0 ) ) {
+        printf( "%s\n", "ireadmg check_for_bort check FAILED!" );
         exit(1);
     }
 
-    /* Disconnect the library, deallocate memory, and close all open logical units. */
+    /* The preceding bort error was caught several levels down within the internal call stack, which
+     * means there's a good possibility that the library is no longer in a useable state.  So if we
+     * want to proceed with any further use of the library, then we should fully reset it just to be safe. */
     exitbufr_f();
+
+    /* Open an output file to the library. */
+    openbf_f( BUFR_OUTPUT_FILE_UNIT, "NODX", BUFR_DXTABLE_FILE_UNIT );
+
+    /* Turn on bort catching again. */
+    if ( ( iret = catch_borts_f("Y") ) != 0 ) exit(1);
+
+    /* Set and confirm the maximum output message size. */
+    maxout_f( 25000 );
+    if ( ( iret = igetmxby_f() ) != 25000 ) exit(1);
+
+    /* Open a new compressed BUFR message for output, and check that it was successful. */
+    cmpmsg_f( "Y" );
+    openmb_f( BUFR_OUTPUT_FILE_UNIT, "F5FCMESG", 2023051015 );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf( "%s\n", "openmb check_for_bort check FAILED!" );
+        exit(1);
+    }
+    status_f( BUFR_OUTPUT_FILE_UNIT, &lun, &il, &im );
+    if ( il != 1 || im != 1 ) {
+        printf( "%s\n", "status check #2 FAILED!" );
+        exit(1);
+    }
 }

--- a/test/test_c_interface_2.c
+++ b/test/test_c_interface_2.c
@@ -178,4 +178,27 @@ int main() {
         printf( "%s\n", "status check #2 FAILED!" );
         exit(1);
     }
+    writsb_f( BUFR_OUTPUT_FILE_UNIT );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf( "%s\n", "writsb check_for_bort check FAILED!" );
+        exit(1);
+    }
+
+    /* Test catching a bort from writlc by incorrectly passing in two mnemonics. */
+    writlc_f( BUFR_OUTPUT_FILE_UNIT, "HOUR PTIDC", "300534061608630" );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( ( strlen( bort_string ) == 0 ) ||
+         ( strncmp( bort_string, "BUFRLIB: WRITLC - THERE CANNOT BE MORE THAN  ONE MNEMONIC IN THE INPUT STRING", 77 ) != 0 ) ) {
+        printf( "%s\n", "writlc check_for_bort two mnemonic check FAILED!" );
+        exit(1);
+    }
+    /* Now correctly pass in a single mnemonic. */
+    writlc_f( BUFR_OUTPUT_FILE_UNIT, "PTIDC", "300534061608630" );
+    check_for_bort_f( bort_string, BORT_STRING_LEN );
+    if ( strlen( bort_string ) != 0 ) {
+        printf( "%s\n", "writlc check_for_bort single mnemonic check FAILED!" );
+        exit(1);
+    }
+
 }

--- a/utils/readbp.F90
+++ b/utils/readbp.F90
@@ -85,7 +85,7 @@ program readbp
       call get_command_argument(iarg,file)
       if(file(1:1)=='-') then
          if(file(2:2)=='s') then
-           iarg=iarg+1; call get_command_argument(iarg,sta); nsta=len(trim(sta))
+           iarg=iarg+1; call get_command_argument(iarg,sta); nsta=len_trim(sta)
          elseif(file(2:2)=='w') then
            iarg=iarg+1; call get_command_argument(iarg,val); read(val,*)x1
            iarg=iarg+1; call get_command_argument(iarg,val); read(val,*)x2
@@ -220,7 +220,7 @@ program readbp
          stop
       elseif(optarg(1:1)=='s') then
          read(optarg(2:50),*) sta
-         nsta=len(trim(sta))
+         nsta=len_trim(sta)
       elseif(optarg(1:1)=='w') then
          read(optarg(2:50),*) x1,x2,y1,y2
          window=.true.


### PR DESCRIPTION
Fixes #689

Also adds a wrapper to subroutine rewnbf, to enable it to be called directly from C applications 